### PR TITLE
Flutter 3.27 compatibility; TrinaGridChangeLazyPageEvent added.

### DIFF
--- a/demo/lib/screen/feature/grid_export_screen.dart
+++ b/demo/lib/screen/feature/grid_export_screen.dart
@@ -2,14 +2,14 @@ import 'dart:typed_data';
 
 import 'package:file_saver/file_saver.dart';
 import 'package:flutter/material.dart';
-import 'package:trina_grid/trina_grid.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
+import 'package:trina_grid/trina_grid.dart';
 
+import '../../dummy_data/dummy_data.dart';
 import '../../widget/trina_example_button.dart';
 import '../../widget/trina_example_screen.dart';
-import '../../dummy_data/dummy_data.dart';
 
 class GridExportScreen extends StatefulWidget {
   static const routeName = 'feature/grid-export';
@@ -587,7 +587,8 @@ class _GridExportScreenState extends State<GridExportScreen> {
 
         // Function to convert Flutter Color to PdfColor
         PdfColor flutterToPdfColor(Color color) {
-          return PdfColor.fromInt(color.toARGB32());
+          return PdfColor.fromInt(
+              color.value); // compatibility with Flutter 3.27
         }
 
         // Create theme data

--- a/lib/src/manager/event/trina_grid_change_lazy_page_event.dart
+++ b/lib/src/manager/event/trina_grid_change_lazy_page_event.dart
@@ -1,0 +1,12 @@
+import 'package:trina_grid/trina_grid.dart';
+
+/// Allows changing the current page when using lazy pagination.
+class TrinaGridChangeLazyPageEvent extends TrinaGridEvent {
+  /// In case of null the current lazy page will be used.
+  final int? page;
+
+  TrinaGridChangeLazyPageEvent({required this.page});
+
+  @override
+  void handler(TrinaGridStateManager stateManager) {}
+}

--- a/lib/src/plugin/trina_lazy_pagination.dart
+++ b/lib/src/plugin/trina_lazy_pagination.dart
@@ -252,6 +252,8 @@ class TrinaLazyPaginationState extends State<TrinaLazyPagination> {
     if (event is TrinaGridChangeColumnSortEvent ||
         event is TrinaGridSetColumnFilterEvent) {
       setPage(1);
+    } else if (event is TrinaGridChangeLazyPageEvent) {
+      setPage((event.page == null || event.page! < 1) ? _page : event.page!);
     }
   }
 

--- a/lib/trina_grid.dart
+++ b/lib/trina_grid.dart
@@ -22,6 +22,7 @@ export './src/manager/event/trina_grid_drag_rows_event.dart';
 export './src/manager/event/trina_grid_event.dart';
 export './src/manager/event/trina_grid_scroll_update_event.dart';
 export './src/manager/event/trina_grid_set_column_filter_event.dart';
+export './src/manager/event/trina_grid_change_lazy_page_event.dart';
 export './src/manager/trina_change_notifier.dart';
 export './src/manager/trina_change_notifier_filter.dart';
 export './src/manager/trina_grid_event_manager.dart';


### PR DESCRIPTION
It is possible to refresh lazy grid easily by sending event.
```dart
void refreshGridData(TrinaGridStateManager? manager) =>
    manager?.eventManager?.addEvent(TrinaGridChangeLazyPageEvent(page: null));
```