### PR TITLE
Smooth scrolling animation and configuration

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -866,6 +866,7 @@ class TrinaGridScrollbarConfig {
     this.thumbHoverColor,
     this.trackHoverColor,
     this.columnShowScrollWidth = true,
+    this.smoothScrolling = false,
   });
 
   /// Whether the scrollbar is always visible
@@ -913,6 +914,10 @@ class TrinaGridScrollbarConfig {
   /// Whether to show the scrollbar width in the column header
   final bool columnShowScrollWidth;
 
+  /// Whether the scrollbar should animate when scrolling instead of
+  /// snapping to the next position
+  final bool smoothScrolling;
+
   /// Get effective thumb color
   Color get effectiveThumbColor =>
       thumbColor ?? Colors.grey.withAlpha((153).toInt());
@@ -950,7 +955,8 @@ class TrinaGridScrollbarConfig {
             trackColor == other.trackColor &&
             thumbHoverColor == other.thumbHoverColor &&
             trackHoverColor == other.trackHoverColor &&
-            columnShowScrollWidth == other.columnShowScrollWidth;
+            columnShowScrollWidth == other.columnShowScrollWidth &&
+            smoothScrolling == other.smoothScrolling;
   }
 
   @override
@@ -970,6 +976,7 @@ class TrinaGridScrollbarConfig {
         thumbHoverColor,
         trackHoverColor,
         columnShowScrollWidth,
+        smoothScrolling,
       ]);
 }
 

--- a/lib/src/ui/scrolls/trina_single_child_smooth_scroll_view.dart
+++ b/lib/src/ui/scrolls/trina_single_child_smooth_scroll_view.dart
@@ -1,0 +1,741 @@
+// A modified version of Flutter's SingleChildScrollView widget.
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart' show DragStartBehavior;
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import 'trina_smooth_scrollable.dart' show TrinaSmoothScrollable;
+
+/// A box in which a single widget can be scrolled.
+///
+/// This widget is useful when you have a single box that will normally be
+/// entirely visible, for example a clock face in a time picker, but you need to
+/// make sure it can be scrolled if the container gets too small in one axis
+/// (the scroll direction).
+///
+/// It is also useful if you need to shrink-wrap in both axes (the main
+/// scrolling direction as well as the cross axis), as one might see in a dialog
+/// or pop-up menu. In that case, you might pair the [TestSingleChildScrollView]
+/// with a [ListBody] child.
+///
+/// When you have a list of children and do not require cross-axis
+/// shrink-wrapping behavior, for example a scrolling list that is always the
+/// width of the screen, consider [ListView], which is vastly more efficient
+/// than a [TestSingleChildScrollView] containing a [ListBody] or [Column] with
+/// many children.
+///
+/// ## Sample code: Using [TestSingleChildScrollView] with a [Column]
+///
+/// Sometimes a layout is designed around the flexible properties of a
+/// [Column], but there is the concern that in some cases, there might not
+/// be enough room to see the entire contents. This could be because some
+/// devices have unusually small screens, or because the application can
+/// be used in landscape mode where the aspect ratio isn't what was
+/// originally envisioned, or because the application is being shown in a
+/// small window in split-screen mode. In any case, as a result, it might
+/// make sense to wrap the layout in a [TestSingleChildScrollView].
+///
+/// Doing so, however, usually results in a conflict between the [Column],
+/// which typically tries to grow as big as it can, and the [TestSingleChildScrollView],
+/// which provides its children with an infinite amount of space.
+///
+/// To resolve this apparent conflict, there are a couple of techniques, as
+/// discussed below. These techniques should only be used when the content is
+/// normally expected to fit on the screen, so that the lazy instantiation of a
+/// sliver-based [ListView] or [CustomScrollView] is not expected to provide any
+/// performance benefit. If the viewport is expected to usually contain content
+/// beyond the dimensions of the screen, then [TestSingleChildScrollView] would be
+/// very expensive (in which case [ListView] may be a better choice than
+/// [Column]).
+///
+/// ### Centering, spacing, or aligning fixed-height content
+///
+/// If the content has fixed (or intrinsic) dimensions but needs to be spaced out,
+/// centered, or otherwise positioned using the [Flex] layout model of a [Column],
+/// the following technique can be used to provide the [Column] with a minimum
+/// dimension while allowing it to shrink-wrap the contents when there isn't enough
+/// room to apply these spacing or alignment needs.
+///
+/// A [LayoutBuilder] is used to obtain the size of the viewport (implicitly via
+/// the constraints that the [TestSingleChildScrollView] sees, since viewports
+/// typically grow to fit their maximum height constraint). Then, inside the
+/// scroll view, a [ConstrainedBox] is used to set the minimum height of the
+/// [Column].
+///
+/// The [Column] has no [Expanded] children, so rather than take on the infinite
+/// height from its [BoxConstraints.maxHeight], (the viewport provides no maximum height
+/// constraint), it automatically tries to shrink to fit its children. It cannot
+/// be smaller than its [BoxConstraints.minHeight], though, and It therefore
+/// becomes the bigger of the minimum height provided by the
+/// [ConstrainedBox] and the sum of the heights of the children.
+///
+/// If the children aren't enough to fit that minimum size, the [Column] ends up
+/// with some remaining space to allocate as specified by its
+/// [Column.mainAxisAlignment] argument.
+///
+/// {@tool dartpad}
+/// In this example, the children are spaced out equally, unless there's no more
+/// room, in which case they stack vertically and scroll.
+///
+/// When using this technique, [Expanded] and [Flexible] are not useful, because
+/// in both cases the "available space" is infinite (since this is in a viewport).
+/// The next section describes a technique for providing a maximum height constraint.
+///
+/// ** See code in examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.0.dart **
+/// {@end-tool}
+///
+/// ### Expanding content to fit the viewport
+///
+/// The following example builds on the previous one. In addition to providing a
+/// minimum dimension for the child [Column], an [IntrinsicHeight] widget is used
+/// to force the column to be exactly as big as its contents. This constraint
+/// combines with the [ConstrainedBox] constraints discussed previously to ensure
+/// that the column becomes either as big as viewport, or as big as the contents,
+/// whichever is biggest.
+///
+/// Both constraints must be used to get the desired effect. If only the
+/// [IntrinsicHeight] was specified, then the column would not grow to fit the
+/// entire viewport when its children were smaller than the whole screen. If only
+/// the size of the viewport was used, then the [Column] would overflow if the
+/// children were bigger than the viewport.
+///
+/// The widget that is to grow to fit the remaining space so provided is wrapped
+/// in an [Expanded] widget.
+///
+/// This technique is quite expensive, as it more or less requires that the contents
+/// of the viewport be laid out twice (once to find their intrinsic dimensions, and
+/// once to actually lay them out). The number of widgets within the column should
+/// therefore be kept small. Alternatively, subsets of the children that have known
+/// dimensions can be wrapped in a [SizedBox] that has tight vertical constraints,
+/// so that the intrinsic sizing algorithm can short-circuit the computation when it
+/// reaches those parts of the subtree.
+///
+/// {@tool dartpad}
+/// In this example, the column becomes either as big as viewport, or as big as
+/// the contents, whichever is biggest.
+///
+/// ** See code in examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.1.dart **
+/// {@end-tool}
+///
+/// {@macro flutter.widgets.ScrollView.PageStorage}
+///
+/// See also:
+///
+///  * [ListView], which handles multiple children in a scrolling list.
+///  * [GridView], which handles multiple children in a scrolling grid.
+///  * [PageView], for a scrollable that works page by page.
+///  * [Scrollable], which handles arbitrary scrolling effects.
+class TrinaSingleChildSmoothScrollView extends StatelessWidget {
+  /// Creates a box in which a single widget can be scrolled.
+  const TrinaSingleChildSmoothScrollView({
+    super.key,
+    this.thumbVisibility,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.padding,
+    this.primary,
+    this.physics,
+    this.controller,
+    this.child,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.clipBehavior = Clip.hardEdge,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+    this.restorationId,
+    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
+  }) : assert(
+          !(controller != null && (primary ?? false)),
+          'Primary ScrollViews obtain their ScrollController via inheritance '
+          'from a PrimaryScrollController widget. You cannot both set primary to '
+          'true and pass an explicit controller.',
+        );
+
+  final bool? thumbVisibility;
+
+  /// {@macro flutter.widgets.scroll_view.scrollDirection}
+  final Axis scrollDirection;
+
+  /// Whether the scroll view scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// [scrollDirection] is [Axis.horizontal], then the scroll view scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if [scrollDirection] is [Axis.vertical], then the scroll view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  final bool reverse;
+
+  /// The amount of space by which to inset the child.
+  final EdgeInsetsGeometry? padding;
+
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  ///
+  /// Must be null if [primary] is true.
+  ///
+  /// A [ScrollController] serves several purposes. It can be used to control
+  /// the initial scroll position (see [ScrollController.initialScrollOffset]).
+  /// It can be used to control whether the scroll view should automatically
+  /// save and restore its scroll position in the [PageStorage] (see
+  /// [ScrollController.keepScrollOffset]). It can be used to read the current
+  /// scroll position (see [ScrollController.offset]), or change it (see
+  /// [ScrollController.animateTo]).
+  final ScrollController? controller;
+
+  /// {@macro flutter.widgets.scroll_view.primary}
+  final bool? primary;
+
+  /// How the scroll view should respond to user input.
+  ///
+  /// For example, determines how the scroll view continues to animate after the
+  /// user stops dragging the scroll view.
+  ///
+  /// Defaults to matching platform conventions.
+  final ScrollPhysics? physics;
+
+  /// The widget that scrolls.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget? child;
+
+  /// {@macro flutter.widgets.scrollable.dragStartBehavior}
+  final DragStartBehavior dragStartBehavior;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
+  /// {@macro flutter.widgets.scrollable.hitTestBehavior}
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior hitTestBehavior;
+
+  /// {@macro flutter.widgets.scrollable.restorationId}
+  final String? restorationId;
+
+  /// {@macro flutter.widgets.scroll_view.keyboardDismissBehavior}
+  final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
+
+  AxisDirection _getDirection(BuildContext context) {
+    return getAxisDirectionFromAxisReverseAndDirectionality(
+        context, scrollDirection, reverse);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AxisDirection axisDirection = _getDirection(context);
+    Widget? contents = child;
+    if (padding != null) {
+      contents = Padding(padding: padding!, child: contents);
+    }
+    final bool effectivePrimary = primary ??
+        controller == null &&
+            PrimaryScrollController.shouldInherit(context, scrollDirection);
+
+    final ScrollController? scrollController = effectivePrimary
+        ? PrimaryScrollController.maybeOf(context)
+        : controller;
+
+    Widget scrollable = TrinaSmoothScrollable(
+      dragStartBehavior: dragStartBehavior,
+      axisDirection: axisDirection,
+      controller: scrollController,
+      physics: physics,
+      restorationId: restorationId,
+      clipBehavior: clipBehavior,
+      hitTestBehavior: hitTestBehavior,
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        return _SingleChildViewport(
+          axisDirection: axisDirection,
+          offset: offset,
+          clipBehavior: clipBehavior,
+          child: contents,
+        );
+      },
+    );
+
+    if (keyboardDismissBehavior == ScrollViewKeyboardDismissBehavior.onDrag) {
+      scrollable = NotificationListener<ScrollUpdateNotification>(
+        child: scrollable,
+        onNotification: (ScrollUpdateNotification notification) {
+          final FocusScopeNode currentScope = FocusScope.of(context);
+          if (notification.dragDetails != null &&
+              !currentScope.hasPrimaryFocus &&
+              currentScope.hasFocus) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          }
+          return false;
+        },
+      );
+    }
+
+    return effectivePrimary && scrollController != null
+        // Further descendant ScrollViews will not inherit the same
+        // PrimaryScrollController
+        ? PrimaryScrollController.none(child: scrollable)
+        : scrollable;
+  }
+}
+
+class _SingleChildViewport extends SingleChildRenderObjectWidget {
+  const _SingleChildViewport({
+    this.axisDirection = AxisDirection.down,
+    required this.offset,
+    super.child,
+    required this.clipBehavior,
+  });
+
+  final AxisDirection axisDirection;
+  final ViewportOffset offset;
+  final Clip clipBehavior;
+
+  @override
+  _RenderSingleChildViewport createRenderObject(BuildContext context) {
+    return _RenderSingleChildViewport(
+      axisDirection: axisDirection,
+      offset: offset,
+      clipBehavior: clipBehavior,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, _RenderSingleChildViewport renderObject) {
+    // Order dependency: The offset setter reads the axis direction.
+    renderObject
+      ..axisDirection = axisDirection
+      ..offset = offset
+      ..clipBehavior = clipBehavior;
+  }
+
+  @override
+  SingleChildRenderObjectElement createElement() {
+    return _SingleChildViewportElement(this);
+  }
+}
+
+class _SingleChildViewportElement extends SingleChildRenderObjectElement
+    with NotifiableElementMixin, ViewportElementMixin {
+  _SingleChildViewportElement(_SingleChildViewport super.widget);
+}
+
+class _RenderSingleChildViewport extends RenderBox
+    with RenderObjectWithChildMixin<RenderBox>
+    implements RenderAbstractViewport {
+  _RenderSingleChildViewport({
+    AxisDirection axisDirection = AxisDirection.down,
+    required ViewportOffset offset,
+    RenderBox? child,
+    required Clip clipBehavior,
+  })  : _axisDirection = axisDirection,
+        _offset = offset,
+        _clipBehavior = clipBehavior {
+    this.child = child;
+  }
+
+  AxisDirection get axisDirection => _axisDirection;
+  AxisDirection _axisDirection;
+  set axisDirection(AxisDirection value) {
+    if (value == _axisDirection) {
+      return;
+    }
+    _axisDirection = value;
+    markNeedsLayout();
+  }
+
+  Axis get axis => axisDirectionToAxis(axisDirection);
+
+  ViewportOffset get offset => _offset;
+  ViewportOffset _offset;
+  set offset(ViewportOffset value) {
+    if (value == _offset) {
+      return;
+    }
+    if (attached) {
+      _offset.removeListener(_hasScrolled);
+    }
+    _offset = value;
+    if (attached) {
+      _offset.addListener(_hasScrolled);
+    }
+    markNeedsLayout();
+  }
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.none].
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
+
+  void _hasScrolled() {
+    markNeedsPaint();
+    markNeedsSemanticsUpdate();
+  }
+
+  @override
+  void setupParentData(RenderObject child) {
+    // We don't actually use the offset argument in BoxParentData, so let's
+    // avoid allocating it at all.
+    if (child.parentData is! ParentData) {
+      child.parentData = ParentData();
+    }
+  }
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _offset.addListener(_hasScrolled);
+  }
+
+  @override
+  void detach() {
+    _offset.removeListener(_hasScrolled);
+    super.detach();
+  }
+
+  @override
+  bool get isRepaintBoundary => true;
+
+  double get _viewportExtent {
+    assert(hasSize);
+    return switch (axis) {
+      Axis.horizontal => size.width,
+      Axis.vertical => size.height,
+    };
+  }
+
+  double get _minScrollExtent {
+    assert(hasSize);
+    return 0.0;
+  }
+
+  double get _maxScrollExtent {
+    assert(hasSize);
+    if (child == null) {
+      return 0.0;
+    }
+    return math.max(
+        0.0,
+        switch (axis) {
+          Axis.horizontal => child!.size.width - size.width,
+          Axis.vertical => child!.size.height - size.height,
+        });
+  }
+
+  BoxConstraints _getInnerConstraints(BoxConstraints constraints) {
+    return switch (axis) {
+      Axis.horizontal => constraints.heightConstraints(),
+      Axis.vertical => constraints.widthConstraints(),
+    };
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    return child?.getMinIntrinsicWidth(height) ?? 0.0;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    return child?.getMaxIntrinsicWidth(height) ?? 0.0;
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    return child?.getMinIntrinsicHeight(width) ?? 0.0;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    return child?.getMaxIntrinsicHeight(width) ?? 0.0;
+  }
+
+  // We don't override computeDistanceToActualBaseline(), because we
+  // want the default behavior (returning null). Otherwise, as you
+  // scroll, it would shift in its parent if the parent was baseline-aligned,
+  // which makes no sense.
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    if (child == null) {
+      return constraints.smallest;
+    }
+    final Size childSize =
+        child!.getDryLayout(_getInnerConstraints(constraints));
+    return constraints.constrain(childSize);
+  }
+
+  @override
+  void performLayout() {
+    final BoxConstraints constraints = this.constraints;
+    if (child == null) {
+      size = constraints.smallest;
+    } else {
+      child!.layout(_getInnerConstraints(constraints), parentUsesSize: true);
+      size = constraints.constrain(child!.size);
+    }
+
+    if (offset.hasPixels) {
+      if (offset.pixels > _maxScrollExtent) {
+        offset.correctBy(_maxScrollExtent - offset.pixels);
+      } else if (offset.pixels < _minScrollExtent) {
+        offset.correctBy(_minScrollExtent - offset.pixels);
+      }
+    }
+
+    offset.applyViewportDimension(_viewportExtent);
+    offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent);
+  }
+
+  Offset get _paintOffset => _paintOffsetForPosition(offset.pixels);
+
+  Offset _paintOffsetForPosition(double position) {
+    return switch (axisDirection) {
+      AxisDirection.up =>
+        Offset(0.0, position - child!.size.height + size.height),
+      AxisDirection.left =>
+        Offset(position - child!.size.width + size.width, 0.0),
+      AxisDirection.right => Offset(-position, 0.0),
+      AxisDirection.down => Offset(0.0, -position),
+    };
+  }
+
+  bool _shouldClipAtPaintOffset(Offset paintOffset) {
+    assert(child != null);
+    switch (clipBehavior) {
+      case Clip.none:
+        return false;
+      case Clip.hardEdge:
+      case Clip.antiAlias:
+      case Clip.antiAliasWithSaveLayer:
+        return paintOffset.dx < 0 ||
+            paintOffset.dy < 0 ||
+            paintOffset.dx + child!.size.width > size.width ||
+            paintOffset.dy + child!.size.height > size.height;
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child != null) {
+      final Offset paintOffset = _paintOffset;
+
+      void paintContents(PaintingContext context, Offset offset) {
+        context.paintChild(child!, offset + paintOffset);
+      }
+
+      if (_shouldClipAtPaintOffset(paintOffset)) {
+        _clipRectLayer.layer = context.pushClipRect(
+          needsCompositing,
+          offset,
+          Offset.zero & size,
+          paintContents,
+          clipBehavior: clipBehavior,
+          oldLayer: _clipRectLayer.layer,
+        );
+      } else {
+        _clipRectLayer.layer = null;
+        paintContents(context, offset);
+      }
+    }
+  }
+
+  final LayerHandle<ClipRectLayer> _clipRectLayer =
+      LayerHandle<ClipRectLayer>();
+
+  @override
+  void dispose() {
+    _clipRectLayer.layer = null;
+    super.dispose();
+  }
+
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    final Offset paintOffset = _paintOffset;
+    transform.translate(paintOffset.dx, paintOffset.dy);
+  }
+
+  @override
+  Rect? describeApproximatePaintClip(RenderObject? child) {
+    if (child != null && _shouldClipAtPaintOffset(_paintOffset)) {
+      return Offset.zero & size;
+    }
+    return null;
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    if (child != null) {
+      return result.addWithPaintOffset(
+        offset: _paintOffset,
+        position: position,
+        hitTest: (BoxHitTestResult result, Offset transformed) {
+          assert(transformed == position + -_paintOffset);
+          return child!.hitTest(result, position: transformed);
+        },
+      );
+    }
+    return false;
+  }
+
+  @override
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    Axis? axis,
+  }) {
+    // One dimensional viewport has only one axis, override if it was
+    // provided/may be mismatched.
+    axis = this.axis;
+
+    rect ??= target.paintBounds;
+    if (target is! RenderBox) {
+      return RevealedOffset(offset: offset.pixels, rect: rect);
+    }
+
+    final RenderBox targetBox = target;
+    final Matrix4 transform = targetBox.getTransformTo(child);
+    final Rect bounds = MatrixUtils.transformRect(transform, rect);
+    final Size contentSize = child!.size;
+
+    final (
+      double mainAxisExtent,
+      double leadingScrollOffset,
+      double targetMainAxisExtent
+    ) = switch (axisDirection) {
+      AxisDirection.up => (
+          size.height,
+          contentSize.height - bounds.bottom,
+          bounds.height
+        ),
+      AxisDirection.left => (
+          size.width,
+          contentSize.width - bounds.right,
+          bounds.width
+        ),
+      AxisDirection.right => (size.width, bounds.left, bounds.width),
+      AxisDirection.down => (size.height, bounds.top, bounds.height),
+    };
+
+    final double targetOffset = leadingScrollOffset -
+        (mainAxisExtent - targetMainAxisExtent) * alignment;
+    final Rect targetRect = bounds.shift(_paintOffsetForPosition(targetOffset));
+    return RevealedOffset(offset: targetOffset, rect: targetRect);
+  }
+
+  @override
+  void showOnScreen({
+    RenderObject? descendant,
+    Rect? rect,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+  }) {
+    if (!offset.allowImplicitScrolling) {
+      return super.showOnScreen(
+        descendant: descendant,
+        rect: rect,
+        duration: duration,
+        curve: curve,
+      );
+    }
+
+    final Rect? newRect = RenderViewportBase.showInViewport(
+      descendant: descendant,
+      viewport: this,
+      offset: offset,
+      rect: rect,
+      duration: duration,
+      curve: curve,
+    );
+    super.showOnScreen(
+      rect: newRect,
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Offset>('offset', _paintOffset));
+  }
+
+  @override
+  Rect describeSemanticsClip(RenderObject child) {
+    final double remainingOffset = _maxScrollExtent - offset.pixels;
+    switch (axisDirection) {
+      case AxisDirection.up:
+        return Rect.fromLTRB(
+          semanticBounds.left,
+          semanticBounds.top - remainingOffset,
+          semanticBounds.right,
+          semanticBounds.bottom + offset.pixels,
+        );
+      case AxisDirection.right:
+        return Rect.fromLTRB(
+          semanticBounds.left - offset.pixels,
+          semanticBounds.top,
+          semanticBounds.right + remainingOffset,
+          semanticBounds.bottom,
+        );
+      case AxisDirection.down:
+        return Rect.fromLTRB(
+          semanticBounds.left,
+          semanticBounds.top - offset.pixels,
+          semanticBounds.right,
+          semanticBounds.bottom + remainingOffset,
+        );
+      case AxisDirection.left:
+        return Rect.fromLTRB(
+          semanticBounds.left - remainingOffset,
+          semanticBounds.top,
+          semanticBounds.right + offset.pixels,
+          semanticBounds.bottom,
+        );
+    }
+  }
+}
+
+// Not using a RestorableDouble because we want to allow null values and override
+// [enabled].
+// ignore: unused_element
+class _RestorableScrollOffset extends RestorableValue<double?> {
+  @override
+  double? createDefaultValue() => null;
+
+  @override
+  void didUpdateValue(double? oldValue) {
+    notifyListeners();
+  }
+
+  @override
+  double fromPrimitives(Object? data) {
+    return data! as double;
+  }
+
+  @override
+  Object? toPrimitives() {
+    return value;
+  }
+
+  @override
+  bool get enabled => value != null;
+}

--- a/lib/src/ui/scrolls/trina_smooth_list_view.dart
+++ b/lib/src/ui/scrolls/trina_smooth_list_view.dart
@@ -1,0 +1,1446 @@
+// A modified version of Flutter's ListView widget.
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:flutter/cupertino.dart';
+/// @docImport 'package:flutter/material.dart';
+/// @docImport 'package:flutter/widgets.dart';
+/// @docImport 'package:flutter_test/flutter_test.dart';
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart'
+    show DiagnosticPropertiesBuilder, DragStartBehavior;
+import 'package:flutter/material.dart'
+    show
+        AlwaysScrollableScrollPhysics,
+        AppBar,
+        AutomaticKeepAlive,
+        Axis,
+        AxisDirection,
+        BuildContext,
+        ChildIndexGetter,
+        Clip,
+        Container,
+        Directionality,
+        Divider,
+        EdgeInsets,
+        EdgeInsetsGeometry,
+        FocusManager,
+        FocusScope,
+        FocusScopeNode,
+        GridView,
+        GrowthDirection,
+        HitTestBehavior,
+        IndexedWidgetBuilder,
+        KeepAlive,
+        Key,
+        ListBody,
+        ListTile,
+        MaterialApp,
+        MediaQuery,
+        MediaQueryData,
+        ModalRoute,
+        NotificationListener,
+        NullableIndexedWidgetBuilder,
+        PageStorage,
+        PageStorageKey,
+        PageView,
+        PrimaryScrollController,
+        Radio,
+        ScrollAction,
+        ScrollBehavior,
+        ScrollConfiguration,
+        ScrollController,
+        ScrollMetrics,
+        ScrollNotification,
+        ScrollPhysics,
+        ScrollPosition,
+        ScrollUpdateNotification,
+        ScrollViewKeyboardDismissBehavior,
+        Scrollable,
+        Scrollbar,
+        Shortcuts,
+        ShrinkWrappingViewport,
+        SingleChildScrollView,
+        SliverAppBar,
+        SliverChildBuilderDelegate,
+        SliverChildDelegate,
+        SliverChildListDelegate,
+        SliverFixedExtentList,
+        SliverGrid,
+        SliverList,
+        SliverPadding,
+        SliverPrototypeExtentList,
+        SliverSafeArea,
+        SliverVariedExtentList,
+        StatefulWidget,
+        StatelessWidget,
+        Text,
+        TextDirection,
+        TwoDimensionalScrollView,
+        Viewport,
+        Widget,
+        debugCheckHasDirectionality,
+        getAxisDirectionFromAxisReverseAndDirectionality,
+        protected;
+import 'package:flutter/rendering.dart'
+    show
+        Axis,
+        AxisDirection,
+        Clip,
+        DiagnosticPropertiesBuilder,
+        DiagnosticsProperty,
+        DoubleProperty,
+        EdgeInsets,
+        EdgeInsetsGeometry,
+        EnumProperty,
+        FlagProperty,
+        GrowthDirection,
+        HitTestBehavior,
+        ItemExtentBuilder,
+        Key,
+        ScrollDirection,
+        SemanticsConfiguration,
+        TextDirection,
+        ViewportOffset;
+
+import 'trina_smooth_scrollable.dart' show TrinaSmoothScrollable;
+
+/// A widget that combines a [Scrollable] and a [Viewport] to create an
+/// interactive scrolling pane of content in one dimension.
+///
+/// Scrollable widgets consist of three pieces:
+///
+///  1. A [Scrollable] widget, which listens for various user gestures and
+///     implements the interaction design for scrolling.
+///  2. A viewport widget, such as [Viewport] or [ShrinkWrappingViewport], which
+///     implements the visual design for scrolling by displaying only a portion
+///     of the widgets inside the scroll view.
+///  3. One or more slivers, which are widgets that can be composed to created
+///     various scrolling effects, such as lists, grids, and expanding headers.
+///
+/// [ScrollView] helps orchestrate these pieces by creating the [Scrollable] and
+/// the viewport and deferring to its subclass to create the slivers.
+///
+/// To learn more about slivers, see [CustomScrollView.slivers].
+///
+/// To control the initial scroll offset of the scroll view, provide a
+/// [controller] with its [ScrollController.initialScrollOffset] property set.
+///
+/// {@template flutter.widgets.ScrollView.PageStorage}
+/// ## Persisting the scroll position during a session
+///
+/// Scroll views attempt to persist their scroll position using [PageStorage].
+/// This can be disabled by setting [ScrollController.keepScrollOffset] to false
+/// on the [controller]. If it is enabled, using a [PageStorageKey] for the
+/// [key] of this widget is recommended to help disambiguate different scroll
+/// views from each other.
+/// {@endtemplate}
+///
+/// See also:
+///
+///  * [ListView], which is a commonly used [ScrollView] that displays a
+///    scrolling, linear list of child widgets.
+///  * [PageView], which is a scrolling list of child widgets that are each the
+///    size of the viewport.
+///  * [GridView], which is a [ScrollView] that displays a scrolling, 2D array
+///    of child widgets.
+///  * [CustomScrollView], which is a [ScrollView] that creates custom scroll
+///    effects using slivers.
+///  * [ScrollNotification] and [NotificationListener], which can be used to watch
+///    the scroll position without using a [ScrollController].
+///  * [TwoDimensionalScrollView], which is a similar widget [ScrollView] that
+///    scrolls in two dimensions.
+abstract class _ScrollView extends StatelessWidget {
+  /// Creates a widget that scrolls.
+  ///
+  /// The [ScrollView.primary] argument defaults to true for vertical
+  /// scroll views if no [controller] has been provided. The [controller] argument
+  /// must be null if [primary] is explicitly set to true. If [primary] is true,
+  /// the nearest [PrimaryScrollController] surrounding the widget is attached
+  /// to this scroll view.
+  ///
+  /// If the [shrinkWrap] argument is true, the [center] argument must be null.
+  ///
+  /// The [anchor] argument must be in the range zero to one, inclusive.
+  const _ScrollView({
+    super.key,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.controller,
+    this.primary,
+    ScrollPhysics? physics,
+    // ignore: unused_element_parameter
+    this.scrollBehavior,
+    this.shrinkWrap = false,
+    this.center,
+    this.anchor = 0.0,
+    this.cacheExtent,
+    this.semanticChildCount,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.keyboardDismissBehavior,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+  })  : assert(
+          !(controller != null && (primary ?? false)),
+          'Primary ScrollViews obtain their ScrollController via inheritance '
+          'from a PrimaryScrollController widget. You cannot both set primary to '
+          'true and pass an explicit controller.',
+        ),
+        assert(!shrinkWrap || center == null),
+        assert(anchor >= 0.0 && anchor <= 1.0),
+        assert(semanticChildCount == null || semanticChildCount >= 0),
+        physics = physics ??
+            ((primary ?? false) ||
+                    (primary == null &&
+                        controller == null &&
+                        identical(scrollDirection, Axis.vertical))
+                ? const AlwaysScrollableScrollPhysics()
+                : null);
+
+  /// {@template flutter.widgets.scroll_view.scrollDirection}
+  /// The [Axis] along which the scroll view's offset increases.
+  ///
+  /// For the direction in which active scrolling may be occurring, see
+  /// [ScrollDirection].
+  ///
+  /// Defaults to [Axis.vertical].
+  /// {@endtemplate}
+  final Axis scrollDirection;
+
+  /// {@template flutter.widgets.scroll_view.reverse}
+  /// Whether the scroll view scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// [scrollDirection] is [Axis.horizontal], then the scroll view scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if [scrollDirection] is [Axis.vertical], then the scroll view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  /// {@endtemplate}
+  final bool reverse;
+
+  /// {@template flutter.widgets.scroll_view.controller}
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  ///
+  /// Must be null if [primary] is true.
+  ///
+  /// A [ScrollController] serves several purposes. It can be used to control
+  /// the initial scroll position (see [ScrollController.initialScrollOffset]).
+  /// It can be used to control whether the scroll view should automatically
+  /// save and restore its scroll position in the [PageStorage] (see
+  /// [ScrollController.keepScrollOffset]). It can be used to read the current
+  /// scroll position (see [ScrollController.offset]), or change it (see
+  /// [ScrollController.animateTo]).
+  /// {@endtemplate}
+  final ScrollController? controller;
+
+  /// {@template flutter.widgets.scroll_view.primary}
+  /// Whether this is the primary scroll view associated with the parent
+  /// [PrimaryScrollController].
+  ///
+  /// When this is true, the scroll view is scrollable even if it does not have
+  /// sufficient content to actually scroll. Otherwise, by default the user can
+  /// only scroll the view if it has sufficient content. See [physics].
+  ///
+  /// Also when true, the scroll view is used for default [ScrollAction]s. If a
+  /// ScrollAction is not handled by an otherwise focused part of the application,
+  /// the ScrollAction will be evaluated using this scroll view, for example,
+  /// when executing [Shortcuts] key events like page up and down.
+  ///
+  /// On iOS, this also identifies the scroll view that will scroll to top in
+  /// response to a tap in the status bar.
+  ///
+  /// Cannot be true while a [ScrollController] is provided to `controller`,
+  /// only one ScrollController can be associated with a ScrollView.
+  ///
+  /// Setting to false will explicitly prevent inheriting any
+  /// [PrimaryScrollController].
+  ///
+  /// Defaults to null. When null, and a controller is not provided,
+  /// [PrimaryScrollController.shouldInherit] is used to decide automatic
+  /// inheritance.
+  ///
+  /// By default, the [PrimaryScrollController] that is injected by each
+  /// [ModalRoute] is configured to automatically be inherited on
+  /// [TargetPlatformVariant.mobile] for ScrollViews in the [Axis.vertical]
+  /// scroll direction. Adding another to your app will override the
+  /// PrimaryScrollController above it.
+  ///
+  /// The following video contains more information about scroll controllers,
+  /// the PrimaryScrollController widget, and their impact on your apps:
+  ///
+  /// {@youtube 560 315 https://www.youtube.com/watch?v=33_0ABjFJUU}
+  ///
+  /// {@endtemplate}
+  final bool? primary;
+
+  /// {@template flutter.widgets.scroll_view.physics}
+  /// How the scroll view should respond to user input.
+  ///
+  /// For example, determines how the scroll view continues to animate after the
+  /// user stops dragging the scroll view.
+  ///
+  /// Defaults to matching platform conventions. Furthermore, if [primary] is
+  /// false, then the user cannot scroll if there is insufficient content to
+  /// scroll, while if [primary] is true, they can always attempt to scroll.
+  ///
+  /// To force the scroll view to always be scrollable even if there is
+  /// insufficient content, as if [primary] was true but without necessarily
+  /// setting it to true, provide an [AlwaysScrollableScrollPhysics] physics
+  /// object, as in:
+  ///
+  /// ```dart
+  ///   physics: const AlwaysScrollableScrollPhysics(),
+  /// ```
+  ///
+  /// To force the scroll view to use the default platform conventions and not
+  /// be scrollable if there is insufficient content, regardless of the value of
+  /// [primary], provide an explicit [ScrollPhysics] object, as in:
+  ///
+  /// ```dart
+  ///   physics: const ScrollPhysics(),
+  /// ```
+  ///
+  /// The physics can be changed dynamically (by providing a new object in a
+  /// subsequent build), but new physics will only take effect if the _class_ of
+  /// the provided object changes. Merely constructing a new instance with a
+  /// different configuration is insufficient to cause the physics to be
+  /// reapplied. (This is because the final object used is generated
+  /// dynamically, which can be relatively expensive, and it would be
+  /// inefficient to speculatively create this object each frame to see if the
+  /// physics should be updated.)
+  /// {@endtemplate}
+  ///
+  /// If an explicit [ScrollBehavior] is provided to [scrollBehavior], the
+  /// [ScrollPhysics] provided by that behavior will take precedence after
+  /// [physics].
+  final ScrollPhysics? physics;
+
+  /// {@macro flutter.widgets.scrollable.scrollBehavior}
+  final ScrollBehavior? scrollBehavior;
+
+  /// {@template flutter.widgets.scroll_view.shrinkWrap}
+  /// Whether the extent of the scroll view in the [scrollDirection] should be
+  /// determined by the contents being viewed.
+  ///
+  /// If the scroll view does not shrink wrap, then the scroll view will expand
+  /// to the maximum allowed size in the [scrollDirection]. If the scroll view
+  /// has unbounded constraints in the [scrollDirection], then [shrinkWrap] must
+  /// be true.
+  ///
+  /// Shrink wrapping the content of the scroll view is significantly more
+  /// expensive than expanding to the maximum allowed size because the content
+  /// can expand and contract during scrolling, which means the size of the
+  /// scroll view needs to be recomputed whenever the scroll position changes.
+  ///
+  /// Defaults to false.
+  ///
+  /// {@youtube 560 315 https://www.youtube.com/watch?v=LUqDNnv_dh0}
+  /// {@endtemplate}
+  final bool shrinkWrap;
+
+  /// The first child in the [GrowthDirection.forward] growth direction.
+  ///
+  /// Children after [center] will be placed in the [AxisDirection] determined
+  /// by [scrollDirection] and [reverse] relative to the [center]. Children
+  /// before [center] will be placed in the opposite of the axis direction
+  /// relative to the [center]. This makes the [center] the inflection point of
+  /// the growth direction.
+  ///
+  /// The [center] must be the key of one of the slivers built by [buildSlivers].
+  ///
+  /// Of the built-in subclasses of [ScrollView], only [CustomScrollView]
+  /// supports [center]; for that class, the given key must be the key of one of
+  /// the slivers in the [CustomScrollView.slivers] list.
+  ///
+  /// Most scroll views by default are ordered [GrowthDirection.forward].
+  /// Changing the default values of [ScrollView.anchor],
+  /// [ScrollView.center], or both, can configure a scroll view for
+  /// [GrowthDirection.reverse].
+  ///
+  /// {@tool dartpad}
+  /// This sample shows a [CustomScrollView], with [Radio] buttons in the
+  /// [AppBar.bottom] that change the [AxisDirection] to illustrate different
+  /// configurations. The [CustomScrollView.anchor] and [CustomScrollView.center]
+  /// properties are also set to have the 0 scroll offset positioned in the middle
+  /// of the viewport, with [GrowthDirection.forward] and [GrowthDirection.reverse]
+  /// illustrated on either side. The sliver that shares the
+  /// [CustomScrollView.center] key is positioned at the [CustomScrollView.anchor].
+  ///
+  /// ** See code in examples/api/lib/rendering/growth_direction/growth_direction.0.dart **
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  ///  * [anchor], which controls where the [center] as aligned in the viewport.
+  final Key? center;
+
+  /// {@template flutter.widgets.scroll_view.anchor}
+  /// The relative position of the zero scroll offset.
+  ///
+  /// For example, if [anchor] is 0.5 and the [AxisDirection] determined by
+  /// [scrollDirection] and [reverse] is [AxisDirection.down] or
+  /// [AxisDirection.up], then the zero scroll offset is vertically centered
+  /// within the viewport. If the [anchor] is 1.0, and the axis direction is
+  /// [AxisDirection.right], then the zero scroll offset is on the left edge of
+  /// the viewport.
+  ///
+  /// Most scroll views by default are ordered [GrowthDirection.forward].
+  /// Changing the default values of [ScrollView.anchor],
+  /// [ScrollView.center], or both, can configure a scroll view for
+  /// [GrowthDirection.reverse].
+  ///
+  /// {@tool dartpad}
+  /// This sample shows a [CustomScrollView], with [Radio] buttons in the
+  /// [AppBar.bottom] that change the [AxisDirection] to illustrate different
+  /// configurations. The [CustomScrollView.anchor] and [CustomScrollView.center]
+  /// properties are also set to have the 0 scroll offset positioned in the middle
+  /// of the viewport, with [GrowthDirection.forward] and [GrowthDirection.reverse]
+  /// illustrated on either side. The sliver that shares the
+  /// [CustomScrollView.center] key is positioned at the [CustomScrollView.anchor].
+  ///
+  /// ** See code in examples/api/lib/rendering/growth_direction/growth_direction.0.dart **
+  /// {@end-tool}
+  /// {@endtemplate}
+  final double anchor;
+
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
+  final double? cacheExtent;
+
+  /// The number of children that will contribute semantic information.
+  ///
+  /// Some subtypes of [ScrollView] can infer this value automatically. For
+  /// example [ListView] will use the number of widgets in the child list,
+  /// while the [ListView.separated] constructor will use half that amount.
+  ///
+  /// For [CustomScrollView] and other types which do not receive a builder
+  /// or list of widgets, the child count must be explicitly provided. If the
+  /// number is unknown or unbounded this should be left unset or set to null.
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsConfiguration.scrollChildCount], the corresponding semantics property.
+  final int? semanticChildCount;
+
+  /// {@macro flutter.widgets.scrollable.dragStartBehavior}
+  final DragStartBehavior dragStartBehavior;
+
+  /// {@template flutter.widgets.scroll_view.keyboardDismissBehavior}
+  /// The [ScrollViewKeyboardDismissBehavior] defines how this [ScrollView] will
+  /// dismiss the keyboard automatically.
+  /// {@endtemplate}
+  ///
+  /// If [keyboardDismissBehavior] is null then it will fallback to
+  /// [scrollBehavior]. If that is also null, the inherited
+  /// [ScrollBehavior.getKeyboardDismissBehavior] will be used.
+  final ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior;
+
+  /// {@macro flutter.widgets.scrollable.restorationId}
+  final String? restorationId;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
+  /// {@macro flutter.widgets.scrollable.hitTestBehavior}
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior hitTestBehavior;
+
+  /// Returns the [AxisDirection] in which the scroll view scrolls.
+  ///
+  /// Combines the [scrollDirection] with the [reverse] boolean to obtain the
+  /// concrete [AxisDirection].
+  ///
+  /// If the [scrollDirection] is [Axis.horizontal], the ambient
+  /// [Directionality] is also considered when selecting the concrete
+  /// [AxisDirection]. For example, if the ambient [Directionality] is
+  /// [TextDirection.rtl], then the non-reversed [AxisDirection] is
+  /// [AxisDirection.left] and the reversed [AxisDirection] is
+  /// [AxisDirection.right].
+  @protected
+  AxisDirection getDirection(BuildContext context) {
+    return getAxisDirectionFromAxisReverseAndDirectionality(
+        context, scrollDirection, reverse);
+  }
+
+  /// Build the list of widgets to place inside the viewport.
+  ///
+  /// Subclasses should override this method to build the slivers for the inside
+  /// of the viewport.
+  ///
+  /// To learn more about slivers, see [CustomScrollView.slivers].
+  @protected
+  List<Widget> buildSlivers(BuildContext context);
+
+  /// Build the viewport.
+  ///
+  /// Subclasses may override this method to change how the viewport is built.
+  /// The default implementation uses a [ShrinkWrappingViewport] if [shrinkWrap]
+  /// is true, and a regular [Viewport] otherwise.
+  ///
+  /// The `offset` argument is the value obtained from
+  /// [Scrollable.viewportBuilder].
+  ///
+  /// The `axisDirection` argument is the value obtained from [getDirection],
+  /// which by default uses [scrollDirection] and [reverse].
+  ///
+  /// The `slivers` argument is the value obtained from [buildSlivers].
+  @protected
+  Widget buildViewport(
+    BuildContext context,
+    ViewportOffset offset,
+    AxisDirection axisDirection,
+    List<Widget> slivers,
+  ) {
+    assert(() {
+      switch (axisDirection) {
+        case AxisDirection.up:
+        case AxisDirection.down:
+          return debugCheckHasDirectionality(
+            context,
+            why: 'to determine the cross-axis direction of the scroll view',
+            hint:
+                'Vertical scroll views create Viewport widgets that try to determine their cross axis direction '
+                'from the ambient Directionality.',
+          );
+        case AxisDirection.left:
+        case AxisDirection.right:
+          return true;
+      }
+    }());
+    if (shrinkWrap) {
+      return ShrinkWrappingViewport(
+        axisDirection: axisDirection,
+        offset: offset,
+        slivers: slivers,
+        clipBehavior: clipBehavior,
+      );
+    }
+    return Viewport(
+      axisDirection: axisDirection,
+      offset: offset,
+      slivers: slivers,
+      cacheExtent: cacheExtent,
+      center: center,
+      anchor: anchor,
+      clipBehavior: clipBehavior,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> slivers = buildSlivers(context);
+    final AxisDirection axisDirection = getDirection(context);
+
+    final bool effectivePrimary = primary ??
+        controller == null &&
+            PrimaryScrollController.shouldInherit(context, scrollDirection);
+
+    final ScrollController? scrollController = effectivePrimary
+        ? PrimaryScrollController.maybeOf(context)
+        : controller;
+
+    final Scrollable scrollable = TrinaSmoothScrollable(
+      dragStartBehavior: dragStartBehavior,
+      axisDirection: axisDirection,
+      controller: scrollController,
+      physics: physics,
+      scrollBehavior: scrollBehavior,
+      semanticChildCount: semanticChildCount,
+      restorationId: restorationId,
+      hitTestBehavior: hitTestBehavior,
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        return buildViewport(context, offset, axisDirection, slivers);
+      },
+      clipBehavior: clipBehavior,
+    );
+
+    final Widget scrollableResult = effectivePrimary && scrollController != null
+        // Further descendant ScrollViews will not inherit the same PrimaryScrollController
+        ? PrimaryScrollController.none(child: scrollable)
+        : scrollable;
+
+    final ScrollViewKeyboardDismissBehavior effectiveKeyboardDismissBehavior =
+        keyboardDismissBehavior ??
+            scrollBehavior?.getKeyboardDismissBehavior(context) ??
+            ScrollConfiguration.of(context).getKeyboardDismissBehavior(context);
+
+    if (effectiveKeyboardDismissBehavior ==
+        ScrollViewKeyboardDismissBehavior.onDrag) {
+      return NotificationListener<ScrollUpdateNotification>(
+        child: scrollableResult,
+        onNotification: (ScrollUpdateNotification notification) {
+          final FocusScopeNode currentScope = FocusScope.of(context);
+          if (notification.dragDetails != null &&
+              !currentScope.hasPrimaryFocus &&
+              currentScope.hasFocus) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          }
+          return false;
+        },
+      );
+    } else {
+      return scrollableResult;
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(EnumProperty<Axis>('scrollDirection', scrollDirection));
+    properties.add(FlagProperty('reverse',
+        value: reverse, ifTrue: 'reversed', showName: true));
+    properties.add(
+      DiagnosticsProperty<ScrollController>(
+        'controller',
+        controller,
+        showName: false,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      FlagProperty('primary',
+          value: primary, ifTrue: 'using primary controller', showName: true),
+    );
+    properties.add(
+      DiagnosticsProperty<ScrollPhysics>('physics', physics,
+          showName: false, defaultValue: null),
+    );
+    properties.add(
+      FlagProperty('shrinkWrap',
+          value: shrinkWrap, ifTrue: 'shrink-wrapping', showName: true),
+    );
+  }
+}
+
+/// A [ScrollView] that uses a single child layout model.
+///
+/// {@template flutter.widgets.BoxScroll.scrollBehaviour}
+/// [ScrollView]s are often decorated with [Scrollbar]s and overscroll indicators,
+/// which are managed by the inherited [ScrollBehavior]. Placing a
+/// [ScrollConfiguration] above a ScrollView can modify these behaviors for that
+/// ScrollView, or can be managed app-wide by providing a ScrollBehavior to
+/// [MaterialApp.scrollBehavior] or [CupertinoApp.scrollBehavior].
+/// {@endtemplate}
+///
+/// See also:
+///
+///  * [ListView], which is a [BoxScrollView] that uses a linear layout model.
+///  * [GridView], which is a [BoxScrollView] that uses a 2D layout model.
+///  * [CustomScrollView], which can combine multiple child layout models into a
+///    single scroll view.
+abstract class _BoxScrollView extends _ScrollView {
+  /// Creates a [ScrollView] uses a single child layout model.
+  ///
+  /// If the [primary] argument is true, the [controller] must be null.
+  const _BoxScrollView({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap,
+    this.padding,
+    super.cacheExtent,
+    super.semanticChildCount,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+  });
+
+  /// The amount of space by which to inset the children.
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  List<Widget> buildSlivers(BuildContext context) {
+    Widget sliver = buildChildLayout(context);
+    EdgeInsetsGeometry? effectivePadding = padding;
+    if (padding == null) {
+      final MediaQueryData? mediaQuery = MediaQuery.maybeOf(context);
+      if (mediaQuery != null) {
+        // Automatically pad sliver with padding from MediaQuery.
+        final EdgeInsets mediaQueryHorizontalPadding =
+            mediaQuery.padding.copyWith(
+          top: 0.0,
+          bottom: 0.0,
+        );
+        final EdgeInsets mediaQueryVerticalPadding =
+            mediaQuery.padding.copyWith(
+          left: 0.0,
+          right: 0.0,
+        );
+        // Consume the main axis padding with SliverPadding.
+        effectivePadding = scrollDirection == Axis.vertical
+            ? mediaQueryVerticalPadding
+            : mediaQueryHorizontalPadding;
+        // Leave behind the cross axis padding.
+        sliver = MediaQuery(
+          data: mediaQuery.copyWith(
+            padding: scrollDirection == Axis.vertical
+                ? mediaQueryHorizontalPadding
+                : mediaQueryVerticalPadding,
+          ),
+          child: sliver,
+        );
+      }
+    }
+
+    if (effectivePadding != null) {
+      sliver = SliverPadding(padding: effectivePadding, sliver: sliver);
+    }
+    return <Widget>[sliver];
+  }
+
+  /// Subclasses should override this method to build the layout model.
+  @protected
+  Widget buildChildLayout(BuildContext context);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
+        defaultValue: null));
+  }
+}
+
+/// A scrollable list of widgets arranged linearly.
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=KJpkjHGiI5A}
+///
+/// [ListView] is the most commonly used scrolling widget. It displays its
+/// children one after another in the scroll direction. In the cross axis, the
+/// children are required to fill the [ListView].
+///
+/// If non-null, the [itemExtent] forces the children to have the given extent
+/// in the scroll direction.
+///
+/// If non-null, the [prototypeItem] forces the children to have the same extent
+/// as the given widget in the scroll direction.
+///
+/// Specifying an [itemExtent] or an [prototypeItem] is more efficient than
+/// letting the children determine their own extent because the scrolling
+/// machinery can make use of the foreknowledge of the children's extent to save
+/// work, for example when the scroll position changes drastically.
+///
+/// You can't specify both [itemExtent] and [prototypeItem], only one or none of
+/// them.
+///
+/// There are four options for constructing a [ListView]:
+///
+///  1. The default constructor takes an explicit [List<Widget>] of children. This
+///     constructor is appropriate for list views with a small number of
+///     children because constructing the [List] requires doing work for every
+///     child that could possibly be displayed in the list view instead of just
+///     those children that are actually visible.
+///
+///  2. The [ListView.builder] constructor takes an [IndexedWidgetBuilder], which
+///     builds the children on demand. This constructor is appropriate for list views
+///     with a large (or infinite) number of children because the builder is called
+///     only for those children that are actually visible.
+///
+///  3. The [ListView.separated] constructor takes two [IndexedWidgetBuilder]s:
+///     `itemBuilder` builds child items on demand, and `separatorBuilder`
+///     similarly builds separator children which appear in between the child items.
+///     This constructor is appropriate for list views with a fixed number of children.
+///
+///  4. The [ListView.custom] constructor takes a [SliverChildDelegate], which provides
+///     the ability to customize additional aspects of the child model. For example,
+///     a [SliverChildDelegate] can control the algorithm used to estimate the
+///     size of children that are not actually visible.
+///
+/// To control the initial scroll offset of the scroll view, provide a
+/// [controller] with its [ScrollController.initialScrollOffset] property set.
+///
+/// By default, [ListView] will automatically pad the list's scrollable
+/// extremities to avoid partial obstructions indicated by [MediaQuery]'s
+/// padding. To avoid this behavior, override with a zero [padding] property.
+///
+/// {@tool snippet}
+/// This example uses the default constructor for [ListView] which takes an
+/// explicit [List<Widget>] of children. This [ListView]'s children are made up
+/// of [Container]s with [Text].
+///
+/// ![A ListView of 3 amber colored containers with sample text.](https://flutter.github.io/assets-for-api-docs/assets/widgets/list_view.png)
+///
+/// ```dart
+/// ListView(
+///   padding: const EdgeInsets.all(8),
+///   children: <Widget>[
+///     Container(
+///       height: 50,
+///       color: Colors.amber[600],
+///       child: const Center(child: Text('Entry A')),
+///     ),
+///     Container(
+///       height: 50,
+///       color: Colors.amber[500],
+///       child: const Center(child: Text('Entry B')),
+///     ),
+///     Container(
+///       height: 50,
+///       color: Colors.amber[100],
+///       child: const Center(child: Text('Entry C')),
+///     ),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// This example mirrors the previous one, creating the same list using the
+/// [ListView.builder] constructor. Using the [IndexedWidgetBuilder], children
+/// are built lazily and can be infinite in number.
+///
+/// ![A ListView of 3 amber colored containers with sample text.](https://flutter.github.io/assets-for-api-docs/assets/widgets/list_view_builder.png)
+///
+/// ```dart
+/// final List<String> entries = <String>['A', 'B', 'C'];
+/// final List<int> colorCodes = <int>[600, 500, 100];
+///
+/// Widget build(BuildContext context) {
+///   return ListView.builder(
+///     padding: const EdgeInsets.all(8),
+///     itemCount: entries.length,
+///     itemBuilder: (BuildContext context, int index) {
+///       return Container(
+///         height: 50,
+///         color: Colors.amber[colorCodes[index]],
+///         child: Center(child: Text('Entry ${entries[index]}')),
+///       );
+///     }
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// This example continues to build from our the previous ones, creating a
+/// similar list using [ListView.separated]. Here, a [Divider] is used as a
+/// separator.
+///
+/// ![A ListView of 3 amber colored containers with sample text and a Divider
+/// between each of them.](https://flutter.github.io/assets-for-api-docs/assets/widgets/list_view_separated.png)
+///
+/// ```dart
+/// final List<String> entries = <String>['A', 'B', 'C'];
+/// final List<int> colorCodes = <int>[600, 500, 100];
+///
+/// Widget build(BuildContext context) {
+///   return ListView.separated(
+///     padding: const EdgeInsets.all(8),
+///     itemCount: entries.length,
+///     itemBuilder: (BuildContext context, int index) {
+///       return Container(
+///         height: 50,
+///         color: Colors.amber[colorCodes[index]],
+///         child: Center(child: Text('Entry ${entries[index]}')),
+///       );
+///     },
+///     separatorBuilder: (BuildContext context, int index) => const Divider(),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// ## Child elements' lifecycle
+///
+/// ### Creation
+///
+/// While laying out the list, visible children's elements, states and render
+/// objects will be created lazily based on existing widgets (such as when using
+/// the default constructor) or lazily provided ones (such as when using the
+/// [ListView.builder] constructor).
+///
+/// ### Destruction
+///
+/// When a child is scrolled out of view, the associated element subtree,
+/// states and render objects are destroyed. A new child at the same position
+/// in the list will be lazily recreated along with new elements, states and
+/// render objects when it is scrolled back.
+///
+/// ### Destruction mitigation
+///
+/// In order to preserve state as child elements are scrolled in and out of
+/// view, the following options are possible:
+///
+///  * Moving the ownership of non-trivial UI-state-driving business logic
+///    out of the list child subtree. For instance, if a list contains posts
+///    with their number of upvotes coming from a cached network response, store
+///    the list of posts and upvote number in a data model outside the list. Let
+///    the list child UI subtree be easily recreate-able from the
+///    source-of-truth model object. Use [StatefulWidget]s in the child
+///    widget subtree to store instantaneous UI state only.
+///
+///  * Letting [KeepAlive] be the root widget of the list child widget subtree
+///    that needs to be preserved. The [KeepAlive] widget marks the child
+///    subtree's top render object child for keepalive. When the associated top
+///    render object is scrolled out of view, the list keeps the child's render
+///    object (and by extension, its associated elements and states) in a cache
+///    list instead of destroying them. When scrolled back into view, the render
+///    object is repainted as-is (if it wasn't marked dirty in the interim).
+///
+///    This only works if `addAutomaticKeepAlives` and `addRepaintBoundaries`
+///    are false since those parameters cause the [ListView] to wrap each child
+///    widget subtree with other widgets.
+///
+///  * Using [AutomaticKeepAlive] widgets (inserted by default when
+///    `addAutomaticKeepAlives` is true). [AutomaticKeepAlive] allows descendant
+///    widgets to control whether the subtree is actually kept alive or not.
+///    This behavior is in contrast with [KeepAlive], which will unconditionally keep
+///    the subtree alive.
+///
+///    As an example, the [EditableText] widget signals its list child element
+///    subtree to stay alive while its text field has input focus. If it doesn't
+///    have focus and no other descendants signaled for keepalive via a
+///    [KeepAliveNotification], the list child element subtree will be destroyed
+///    when scrolled away.
+///
+///    [AutomaticKeepAlive] descendants typically signal it to be kept alive
+///    by using the [AutomaticKeepAliveClientMixin], then implementing the
+///    [AutomaticKeepAliveClientMixin.wantKeepAlive] getter and calling
+///    [AutomaticKeepAliveClientMixin.updateKeepAlive].
+///
+/// ## Transitioning to [CustomScrollView]
+///
+/// A [ListView] is basically a [CustomScrollView] with a single [SliverList] in
+/// its [CustomScrollView.slivers] property.
+///
+/// If [ListView] is no longer sufficient, for example because the scroll view
+/// is to have both a list and a grid, or because the list is to be combined
+/// with a [SliverAppBar], etc, it is straight-forward to port code from using
+/// [ListView] to using [CustomScrollView] directly.
+///
+/// The [key], [scrollDirection], [reverse], [controller], [primary], [physics],
+/// and [shrinkWrap] properties on [ListView] map directly to the identically
+/// named properties on [CustomScrollView].
+///
+/// The [CustomScrollView.slivers] property should be a list containing either:
+///  * a [SliverList] if both [itemExtent] and [prototypeItem] were null;
+///  * a [SliverFixedExtentList] if [itemExtent] was not null; or
+///  * a [SliverPrototypeExtentList] if [prototypeItem] was not null.
+///
+/// The [childrenDelegate] property on [ListView] corresponds to the
+/// [SliverList.delegate] (or [SliverFixedExtentList.delegate]) property. The
+/// [ListView] constructor's `children` argument corresponds to the
+/// [childrenDelegate] being a [SliverChildListDelegate] with that same
+/// argument. The [ListView.builder] constructor's `itemBuilder` and
+/// `itemCount` arguments correspond to the [childrenDelegate] being a
+/// [SliverChildBuilderDelegate] with the equivalent arguments.
+///
+/// The [padding] property corresponds to having a [SliverPadding] in the
+/// [CustomScrollView.slivers] property instead of the list itself, and having
+/// the [SliverList] instead be a child of the [SliverPadding].
+///
+/// [CustomScrollView]s don't automatically avoid obstructions from [MediaQuery]
+/// like [ListView]s do. To reproduce the behavior, wrap the slivers in
+/// [SliverSafeArea]s.
+///
+/// Once code has been ported to use [CustomScrollView], other slivers, such as
+/// [SliverGrid] or [SliverAppBar], can be put in the [CustomScrollView.slivers]
+/// list.
+///
+/// {@tool snippet}
+///
+/// Here are two brief snippets showing a [ListView] and its equivalent using
+/// [CustomScrollView]:
+///
+/// ```dart
+/// ListView(
+///   padding: const EdgeInsets.all(20.0),
+///   children: const <Widget>[
+///     Text("I'm dedicating every day to you"),
+///     Text('Domestic life was never quite my style'),
+///     Text('When you smile, you knock me out, I fall apart'),
+///     Text('And I thought I was so smart'),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+/// {@tool snippet}
+///
+/// ```dart
+/// CustomScrollView(
+///   slivers: <Widget>[
+///     SliverPadding(
+///       padding: const EdgeInsets.all(20.0),
+///       sliver: SliverList(
+///         delegate: SliverChildListDelegate(
+///           <Widget>[
+///             const Text("I'm dedicating every day to you"),
+///             const Text('Domestic life was never quite my style'),
+///             const Text('When you smile, you knock me out, I fall apart'),
+///             const Text('And I thought I was so smart'),
+///           ],
+///         ),
+///       ),
+///     ),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// ## Special handling for an empty list
+///
+/// A common design pattern is to have a custom UI for an empty list. The best
+/// way to achieve this in Flutter is just conditionally replacing the
+/// [ListView] at build time with whatever widgets you need to show for the
+/// empty list state:
+///
+/// {@tool snippet}
+///
+/// Example of simple empty list interface:
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     appBar: AppBar(title: const Text('Empty List Test')),
+///     body: itemCount > 0
+///       ? ListView.builder(
+///           itemCount: itemCount,
+///           itemBuilder: (BuildContext context, int index) {
+///             return ListTile(
+///               title: Text('Item ${index + 1}'),
+///             );
+///           },
+///         )
+///       : const Center(child: Text('No items')),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// ## Selection of list items
+///
+/// [ListView] has no built-in notion of a selected item or items. For a small
+/// example of how a caller might wire up basic item selection, see
+/// [ListTile.selected].
+///
+/// {@tool dartpad}
+/// This example shows a custom implementation of [ListTile] selection in a [ListView] or [GridView].
+/// Long press any [ListTile] to enable selection mode.
+///
+/// ** See code in examples/api/lib/widgets/scroll_view/list_view.0.dart **
+/// {@end-tool}
+///
+/// {@macro flutter.widgets.BoxScroll.scrollBehaviour}
+///
+/// {@macro flutter.widgets.ScrollView.PageStorage}
+///
+/// See also:
+///
+///  * [SingleChildScrollView], which is a scrollable widget that has a single
+///    child.
+///  * [PageView], which is a scrolling list of child widgets that are each the
+///    size of the viewport.
+///  * [GridView], which is a scrollable, 2D array of widgets.
+///  * [CustomScrollView], which is a scrollable widget that creates custom
+///    scroll effects using slivers.
+///  * [ListBody], which arranges its children in a similar manner, but without
+///    scrolling.
+///  * [ScrollNotification] and [NotificationListener], which can be used to watch
+///    the scroll position without using a [ScrollController].
+///  * The [catalog of layout widgets](https://docs.flutter.dev/ui/widgets/layout).
+///  * Cookbook: [Use lists](https://docs.flutter.dev/cookbook/lists/basic-list)
+///  * Cookbook: [Work with long lists](https://docs.flutter.dev/cookbook/lists/long-lists)
+///  * Cookbook: [Create a horizontal list](https://docs.flutter.dev/cookbook/lists/horizontal-list)
+///  * Cookbook: [Create lists with different types of items](https://docs.flutter.dev/cookbook/lists/mixed-list)
+///  * Cookbook: [Implement swipe to dismiss](https://docs.flutter.dev/cookbook/gestures/dismissible)
+class TrinaSmoothListView extends _BoxScrollView {
+  /// Creates a scrollable, linear array of widgets from an explicit [List].
+  ///
+  /// This constructor is appropriate for list views with a small number of
+  /// children because constructing the [List] requires doing work for every
+  /// child that could possibly be displayed in the list view instead of just
+  /// those children that are actually visible.
+  ///
+  /// Like other widgets in the framework, this widget expects that
+  /// the [children] list will not be mutated after it has been passed in here.
+  /// See the documentation at [SliverChildListDelegate.children] for more details.
+  ///
+  /// It is usually more efficient to create children on demand using
+  /// [ListView.builder] because it will create the widget children lazily as necessary.
+  ///
+  /// The `addAutomaticKeepAlives` argument corresponds to the
+  /// [SliverChildListDelegate.addAutomaticKeepAlives] property. The
+  /// `addRepaintBoundaries` argument corresponds to the
+  /// [SliverChildListDelegate.addRepaintBoundaries] property. The
+  /// `addSemanticIndexes` argument corresponds to the
+  /// [SliverChildListDelegate.addSemanticIndexes] property. None
+  /// may be null.
+  TrinaSmoothListView({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap,
+    super.padding,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
+    bool addAutomaticKeepAlives = true,
+    bool addRepaintBoundaries = true,
+    bool addSemanticIndexes = true,
+    super.cacheExtent,
+    List<Widget> children = const <Widget>[],
+    int? semanticChildCount,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+  })  : assert(
+          (itemExtent == null && prototypeItem == null) ||
+              (itemExtent == null && itemExtentBuilder == null) ||
+              (prototypeItem == null && itemExtentBuilder == null),
+          'You can only pass one of itemExtent, prototypeItem and itemExtentBuilder.',
+        ),
+        childrenDelegate = SliverChildListDelegate(
+          children,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addRepaintBoundaries: addRepaintBoundaries,
+          addSemanticIndexes: addSemanticIndexes,
+        ),
+        super(semanticChildCount: semanticChildCount ?? children.length);
+
+  /// Creates a scrollable, linear array of widgets that are created on demand.
+  ///
+  /// This constructor is appropriate for list views with a large (or infinite)
+  /// number of children because the builder is called only for those children
+  /// that are actually visible.
+  ///
+  /// Providing a non-null `itemCount` improves the ability of the [ListView] to
+  /// estimate the maximum scroll extent.
+  ///
+  /// The `itemBuilder` callback will be called only with indices greater than
+  /// or equal to zero and less than `itemCount`.
+  ///
+  /// {@template flutter.widgets.ListView.builder.itemBuilder}
+  /// It is legal for `itemBuilder` to return `null`. If it does, the scroll view
+  /// will stop calling `itemBuilder`, even if it has yet to reach `itemCount`.
+  /// By returning `null`, the [ScrollPosition.maxScrollExtent] will not be accurate
+  /// unless the user has reached the end of the [ScrollView]. This can also cause the
+  /// [Scrollbar] to grow as the user scrolls.
+  ///
+  /// For more accurate [ScrollMetrics], consider specifying `itemCount`.
+  /// {@endtemplate}
+  ///
+  /// The `itemBuilder` should always create the widget instances when called.
+  /// Avoid using a builder that returns a previously-constructed widget; if the
+  /// list view's children are created in advance, or all at once when the
+  /// [ListView] itself is created, it is more efficient to use the [ListView]
+  /// constructor. Even more efficient, however, is to create the instances on
+  /// demand using this constructor's `itemBuilder` callback.
+  ///
+  /// {@macro flutter.widgets.PageView.findChildIndexCallback}
+  ///
+  /// The `addAutomaticKeepAlives` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addAutomaticKeepAlives] property. The
+  /// `addRepaintBoundaries` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. The
+  /// `addSemanticIndexes` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
+  /// null.
+  TrinaSmoothListView.builder({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap,
+    super.padding,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
+    required NullableIndexedWidgetBuilder itemBuilder,
+    ChildIndexGetter? findChildIndexCallback,
+    int? itemCount,
+    bool addAutomaticKeepAlives = true,
+    bool addRepaintBoundaries = true,
+    bool addSemanticIndexes = true,
+    super.cacheExtent,
+    int? semanticChildCount,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+  })  : assert(itemCount == null || itemCount >= 0),
+        assert(semanticChildCount == null || semanticChildCount <= itemCount!),
+        assert(
+          (itemExtent == null && prototypeItem == null) ||
+              (itemExtent == null && itemExtentBuilder == null) ||
+              (prototypeItem == null && itemExtentBuilder == null),
+          'You can only pass one of itemExtent, prototypeItem and itemExtentBuilder.',
+        ),
+        childrenDelegate = SliverChildBuilderDelegate(
+          itemBuilder,
+          findChildIndexCallback: findChildIndexCallback,
+          childCount: itemCount,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addRepaintBoundaries: addRepaintBoundaries,
+          addSemanticIndexes: addSemanticIndexes,
+        ),
+        super(semanticChildCount: semanticChildCount ?? itemCount);
+
+  /// Creates a fixed-length scrollable linear array of list "items" separated
+  /// by list item "separators".
+  ///
+  /// This constructor is appropriate for list views with a large number of
+  /// item and separator children because the builders are only called for
+  /// the children that are actually visible.
+  ///
+  /// The `itemBuilder` callback will be called with indices greater than
+  /// or equal to zero and less than `itemCount`.
+  ///
+  /// Separators only appear between list items: separator 0 appears after item
+  /// 0 and the last separator appears before the last item.
+  ///
+  /// The `separatorBuilder` callback will be called with indices greater than
+  /// or equal to zero and less than `itemCount - 1`.
+  ///
+  /// The `itemBuilder` and `separatorBuilder` callbacks should always
+  /// actually create widget instances when called. Avoid using a builder that
+  /// returns a previously-constructed widget; if the list view's children are
+  /// created in advance, or all at once when the [ListView] itself is created,
+  /// it is more efficient to use the [ListView] constructor.
+  ///
+  /// {@macro flutter.widgets.ListView.builder.itemBuilder}
+  ///
+  /// {@macro flutter.widgets.PageView.findChildIndexCallback}
+  ///
+  /// {@tool snippet}
+  ///
+  /// This example shows how to create [ListView] whose [ListTile] list items
+  /// are separated by [Divider]s.
+  ///
+  /// ```dart
+  /// ListView.separated(
+  ///   itemCount: 25,
+  ///   separatorBuilder: (BuildContext context, int index) => const Divider(),
+  ///   itemBuilder: (BuildContext context, int index) {
+  ///     return ListTile(
+  ///       title: Text('item $index'),
+  ///     );
+  ///   },
+  /// )
+  /// ```
+  /// {@end-tool}
+  ///
+  /// The `addAutomaticKeepAlives` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addAutomaticKeepAlives] property. The
+  /// `addRepaintBoundaries` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. The
+  /// `addSemanticIndexes` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
+  /// null.
+  TrinaSmoothListView.separated({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap,
+    super.padding,
+    required NullableIndexedWidgetBuilder itemBuilder,
+    ChildIndexGetter? findChildIndexCallback,
+    required IndexedWidgetBuilder separatorBuilder,
+    required int itemCount,
+    bool addAutomaticKeepAlives = true,
+    bool addRepaintBoundaries = true,
+    bool addSemanticIndexes = true,
+    super.cacheExtent,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+  })  : assert(itemCount >= 0),
+        itemExtent = null,
+        itemExtentBuilder = null,
+        prototypeItem = null,
+        childrenDelegate = SliverChildBuilderDelegate(
+          (BuildContext context, int index) {
+            final int itemIndex = index ~/ 2;
+            if (index.isEven) {
+              return itemBuilder(context, itemIndex);
+            }
+            return separatorBuilder(context, itemIndex);
+          },
+          findChildIndexCallback: findChildIndexCallback,
+          childCount: _computeActualChildCount(itemCount),
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addRepaintBoundaries: addRepaintBoundaries,
+          addSemanticIndexes: addSemanticIndexes,
+          semanticIndexCallback: (Widget widget, int index) {
+            return index.isEven ? index ~/ 2 : null;
+          },
+        ),
+        super(semanticChildCount: itemCount);
+
+  /// Creates a scrollable, linear array of widgets with a custom child model.
+  ///
+  /// For example, a custom child model can control the algorithm used to
+  /// estimate the size of children that are not actually visible.
+  ///
+  /// {@tool dartpad}
+  /// This example shows a [ListView] that uses a custom [SliverChildBuilderDelegate] to support child
+  /// reordering.
+  ///
+  /// ** See code in examples/api/lib/widgets/scroll_view/list_view.1.dart **
+  /// {@end-tool}
+  const TrinaSmoothListView.custom({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap,
+    super.padding,
+    this.itemExtent,
+    this.prototypeItem,
+    this.itemExtentBuilder,
+    required this.childrenDelegate,
+    super.cacheExtent,
+    super.semanticChildCount,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+  }) : assert(
+          (itemExtent == null && prototypeItem == null) ||
+              (itemExtent == null && itemExtentBuilder == null) ||
+              (prototypeItem == null && itemExtentBuilder == null),
+          'You can only pass one of itemExtent, prototypeItem and itemExtentBuilder.',
+        );
+
+  /// {@template flutter.widgets.list_view.itemExtent}
+  /// If non-null, forces the children to have the given extent in the scroll
+  /// direction.
+  ///
+  /// Specifying an [itemExtent] is more efficient than letting the children
+  /// determine their own extent because the scrolling machinery can make use of
+  /// the foreknowledge of the children's extent to save work, for example when
+  /// the scroll position changes drastically.
+  ///
+  /// See also:
+  ///
+  ///  * [SliverFixedExtentList], the sliver used internally when this property
+  ///    is provided. It constrains its box children to have a specific given
+  ///    extent along the main axis.
+  ///  * The [prototypeItem] property, which allows forcing the children's
+  ///    extent to be the same as the given widget.
+  ///  * The [itemExtentBuilder] property, which allows forcing the children's
+  ///    extent to be the value returned by the callback.
+  /// {@endtemplate}
+  final double? itemExtent;
+
+  /// {@template flutter.widgets.list_view.itemExtentBuilder}
+  /// If non-null, forces the children to have the corresponding extent returned
+  /// by the builder.
+  ///
+  /// Specifying an [itemExtentBuilder] is more efficient than letting the children
+  /// determine their own extent because the scrolling machinery can make use of
+  /// the foreknowledge of the children's extent to save work, for example when
+  /// the scroll position changes drastically.
+  ///
+  /// This will be called multiple times during the layout phase of a frame to find
+  /// the items that should be loaded by the lazy loading process.
+  ///
+  /// Should return null if asked to build an item extent with a greater index than
+  /// exists.
+  ///
+  /// Unlike [itemExtent] or [prototypeItem], this allows children to have
+  /// different extents.
+  ///
+  /// See also:
+  ///
+  ///  * [SliverVariedExtentList], the sliver used internally when this property
+  ///    is provided. It constrains its box children to have a specific given
+  ///    extent along the main axis.
+  ///  * The [itemExtent] property, which allows forcing the children's extent
+  ///    to a given value.
+  ///  * The [prototypeItem] property, which allows forcing the children's
+  ///    extent to be the same as the given widget.
+  /// {@endtemplate}
+  final ItemExtentBuilder? itemExtentBuilder;
+
+  /// {@template flutter.widgets.list_view.prototypeItem}
+  /// If non-null, forces the children to have the same extent as the given
+  /// widget in the scroll direction.
+  ///
+  /// Specifying an [prototypeItem] is more efficient than letting the children
+  /// determine their own extent because the scrolling machinery can make use of
+  /// the foreknowledge of the children's extent to save work, for example when
+  /// the scroll position changes drastically.
+  ///
+  /// See also:
+  ///
+  ///  * [SliverPrototypeExtentList], the sliver used internally when this
+  ///    property is provided. It constrains its box children to have the same
+  ///    extent as a prototype item along the main axis.
+  ///  * The [itemExtent] property, which allows forcing the children's extent
+  ///    to a given value.
+  ///  * The [itemExtentBuilder] property, which allows forcing the children's
+  ///    extent to be the value returned by the callback.
+  /// {@endtemplate}
+  final Widget? prototypeItem;
+
+  /// A delegate that provides the children for the [ListView].
+  ///
+  /// The [ListView.custom] constructor lets you specify this delegate
+  /// explicitly. The [ListView] and [ListView.builder] constructors create a
+  /// [childrenDelegate] that wraps the given [List] and [IndexedWidgetBuilder],
+  /// respectively.
+  final SliverChildDelegate childrenDelegate;
+
+  @override
+  Widget buildChildLayout(BuildContext context) {
+    if (itemExtent != null) {
+      return SliverFixedExtentList(
+          delegate: childrenDelegate, itemExtent: itemExtent!);
+    } else if (itemExtentBuilder != null) {
+      return SliverVariedExtentList(
+        delegate: childrenDelegate,
+        itemExtentBuilder: itemExtentBuilder!,
+      );
+    } else if (prototypeItem != null) {
+      return SliverPrototypeExtentList(
+          delegate: childrenDelegate, prototypeItem: prototypeItem!);
+    }
+    return SliverList(delegate: childrenDelegate);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+        .add(DoubleProperty('itemExtent', itemExtent, defaultValue: null));
+  }
+
+  // Helper method to compute the actual child count for the separated constructor.
+  static int _computeActualChildCount(int itemCount) {
+    return math.max(0, itemCount * 2 - 1);
+  }
+}

--- a/lib/src/ui/scrolls/trina_smooth_scrollable.dart
+++ b/lib/src/ui/scrolls/trina_smooth_scrollable.dart
@@ -1,0 +1,1841 @@
+// A modified version of Flutter's Scrollable widget.
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+library;
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// A widget that manages scrolling in one dimension and informs the [Viewport]
+/// through which the content is viewed.
+///
+/// [Scrollable] implements the interaction model for a scrollable widget,
+/// including gesture recognition, but does not have an opinion about how the
+/// viewport, which actually displays the children, is constructed.
+///
+/// It's rare to construct a [Scrollable] directly. Instead, consider [ListView]
+/// or [GridView], which combine scrolling, viewporting, and a layout model. To
+/// combine layout models (or to use a custom layout mode), consider using
+/// [CustomScrollView].
+///
+/// The static [Scrollable.of] and [Scrollable.ensureVisible] functions are
+/// often used to interact with the [Scrollable] widget inside a [ListView] or
+/// a [GridView].
+///
+/// To further customize scrolling behavior with a [Scrollable]:
+///
+/// 1. You can provide a [viewportBuilder] to customize the child model. For
+///    example, [SingleChildScrollView] uses a viewport that displays a single
+///    box child whereas [CustomScrollView] uses a [Viewport] or a
+///    [ShrinkWrappingViewport], both of which display a list of slivers.
+///
+/// 2. You can provide a custom [ScrollController] that creates a custom
+///    [ScrollPosition] subclass. For example, [PageView] uses a
+///    [PageController], which creates a page-oriented scroll position subclass
+///    that keeps the same page visible when the [Scrollable] resizes.
+///
+/// ## Persisting the scroll position during a session
+///
+/// Scrollables attempt to persist their scroll position using [PageStorage].
+/// This can be disabled by setting [ScrollController.keepScrollOffset] to false
+/// on the [controller]. If it is enabled, using a [PageStorageKey] for the
+/// [key] of this widget (or one of its ancestors, e.g. a [ScrollView]) is
+/// recommended to help disambiguate different [Scrollable]s from each other.
+///
+/// See also:
+///
+///  * [ListView], which is a commonly used [ScrollView] that displays a
+///    scrolling, linear list of child widgets.
+///  * [PageView], which is a scrolling list of child widgets that are each the
+///    size of the viewport.
+///  * [GridView], which is a [ScrollView] that displays a scrolling, 2D array
+///    of child widgets.
+///  * [CustomScrollView], which is a [ScrollView] that creates custom scroll
+///    effects using slivers.
+///  * [SingleChildScrollView], which is a scrollable widget that has a single
+///    child.
+///  * [ScrollNotification] and [NotificationListener], which can be used to watch
+///    the scroll position without using a [ScrollController].
+class TrinaSmoothScrollable extends StatefulWidget implements Scrollable {
+  /// Creates a widget that scrolls.
+  const TrinaSmoothScrollable({
+    super.key,
+    this.axisDirection = AxisDirection.down,
+    this.controller,
+    this.physics,
+    required this.viewportBuilder,
+    this.incrementCalculator,
+    this.excludeFromSemantics = false,
+    this.semanticChildCount,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.restorationId,
+    this.scrollBehavior,
+    this.clipBehavior = Clip.hardEdge,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+  }) : assert(semanticChildCount == null || semanticChildCount >= 0);
+
+  /// {@template flutter.widgets.Scrollable.axisDirection}
+  /// The direction in which this widget scrolls.
+  ///
+  /// For example, if the [Scrollable.axisDirection] is [AxisDirection.down],
+  /// increasing the scroll position will cause content below the bottom of the
+  /// viewport to become visible through the viewport. Similarly, if the
+  /// axisDirection is [AxisDirection.right], increasing the scroll position
+  /// will cause content beyond the right edge of the viewport to become visible
+  /// through the viewport.
+  ///
+  /// Defaults to [AxisDirection.down].
+  /// {@endtemplate}
+  @override
+  final AxisDirection axisDirection;
+
+  /// {@template flutter.widgets.Scrollable.controller}
+  /// An object that can be used to control the position to which this widget is
+  /// scrolled.
+  ///
+  /// A [ScrollController] serves several purposes. It can be used to control
+  /// the initial scroll position (see [ScrollController.initialScrollOffset]).
+  /// It can be used to control whether the scroll view should automatically
+  /// save and restore its scroll position in the [PageStorage] (see
+  /// [ScrollController.keepScrollOffset]). It can be used to read the current
+  /// scroll position (see [ScrollController.offset]), or change it (see
+  /// [ScrollController.animateTo]).
+  ///
+  /// If null, a [ScrollController] will be created internally by [Scrollable]
+  /// in order to create and manage the [ScrollPosition].
+  ///
+  /// See also:
+  ///
+  ///  * [Scrollable.ensureVisible], which animates the scroll position to
+  ///    reveal a given [BuildContext].
+  /// {@endtemplate}
+  @override
+  final ScrollController? controller;
+
+  /// {@template flutter.widgets.Scrollable.physics}
+  /// How the widgets should respond to user input.
+  ///
+  /// For example, determines how the widget continues to animate after the
+  /// user stops dragging the scroll view.
+  ///
+  /// Defaults to matching platform conventions via the physics provided from
+  /// the ambient [ScrollConfiguration].
+  ///
+  /// If an explicit [ScrollBehavior] is provided to
+  /// [Scrollable.scrollBehavior], the [ScrollPhysics] provided by that behavior
+  /// will take precedence after [Scrollable.physics].
+  ///
+  /// The physics can be changed dynamically, but new physics will only take
+  /// effect if the _class_ of the provided object changes. Merely constructing
+  /// a new instance with a different configuration is insufficient to cause the
+  /// physics to be reapplied. (This is because the final object used is
+  /// generated dynamically, which can be relatively expensive, and it would be
+  /// inefficient to speculatively create this object each frame to see if the
+  /// physics should be updated.)
+  ///
+  /// See also:
+  ///
+  ///  * [AlwaysScrollableScrollPhysics], which can be used to indicate that the
+  ///    scrollable should react to scroll requests (and possible overscroll)
+  ///    even if the scrollable's contents fit without scrolling being necessary.
+  /// {@endtemplate}
+  @override
+  final ScrollPhysics? physics;
+
+  /// Builds the viewport through which the scrollable content is displayed.
+  ///
+  /// A typical viewport uses the given [ViewportOffset] to determine which part
+  /// of its content is actually visible through the viewport.
+  ///
+  /// See also:
+  ///
+  ///  * [Viewport], which is a viewport that displays a list of slivers.
+  ///  * [ShrinkWrappingViewport], which is a viewport that displays a list of
+  ///    slivers and sizes itself based on the size of the slivers.
+  @override
+  final ViewportBuilder viewportBuilder;
+
+  /// {@template flutter.widgets.Scrollable.incrementCalculator}
+  /// An optional function that will be called to calculate the distance to
+  /// scroll when the scrollable is asked to scroll via the keyboard using a
+  /// [ScrollAction].
+  ///
+  /// If not supplied, the [Scrollable] will scroll a default amount when a
+  /// keyboard navigation key is pressed (e.g. pageUp/pageDown, control-upArrow,
+  /// etc.), or otherwise invoked by a [ScrollAction].
+  ///
+  /// If [incrementCalculator] is null, the default for
+  /// [ScrollIncrementType.page] is 80% of the size of the scroll window, and
+  /// for [ScrollIncrementType.line], 50 logical pixels.
+  /// {@endtemplate}
+  @override
+  final ScrollIncrementCalculator? incrementCalculator;
+
+  /// {@template flutter.widgets.scrollable.excludeFromSemantics}
+  /// Whether the scroll actions introduced by this [Scrollable] are exposed
+  /// in the semantics tree.
+  ///
+  /// Text fields with an overflow are usually scrollable to make sure that the
+  /// user can get to the beginning/end of the entered text. However, these
+  /// scrolling actions are generally not exposed to the semantics layer.
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///  * [GestureDetector.excludeFromSemantics], which is used to accomplish the
+  ///    exclusion.
+  @override
+  final bool excludeFromSemantics;
+
+  /// {@template flutter.widgets.scrollable.hitTestBehavior}
+  /// Defines the behavior of gesture detector used in this [Scrollable].
+  ///
+  /// This defaults to [HitTestBehavior.opaque] which means it prevents targets
+  /// behind this [Scrollable] from receiving events.
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestBehavior], for an explanation on different behaviors.
+  @override
+  final HitTestBehavior hitTestBehavior;
+
+  /// The number of children that will contribute semantic information.
+  ///
+  /// The value will be null if the number of children is unknown or unbounded.
+  ///
+  /// Some subtypes of [ScrollView] can infer this value automatically. For
+  /// example [ListView] will use the number of widgets in the child list,
+  /// while the [ListView.separated] constructor will use half that amount.
+  ///
+  /// For [CustomScrollView] and other types which do not receive a builder
+  /// or list of widgets, the child count must be explicitly provided.
+  ///
+  /// See also:
+  ///
+  ///  * [CustomScrollView], for an explanation of scroll semantics.
+  ///  * [SemanticsConfiguration.scrollChildCount], the corresponding semantics property.
+  @override
+  final int? semanticChildCount;
+
+  /// {@template flutter.widgets.scrollable.dragStartBehavior}
+  /// Determines the way that drag start behavior is handled.
+  ///
+  /// If set to [DragStartBehavior.start], scrolling drag behavior will
+  /// begin at the position where the drag gesture won the arena. If set to
+  /// [DragStartBehavior.down] it will begin at the position where a down
+  /// event is first detected.
+  ///
+  /// In general, setting this to [DragStartBehavior.start] will make drag
+  /// animation smoother and setting it to [DragStartBehavior.down] will make
+  /// drag behavior feel slightly more reactive.
+  ///
+  /// By default, the drag start behavior is [DragStartBehavior.start].
+  ///
+  /// See also:
+  ///
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
+  ///    the different behaviors.
+  ///
+  /// {@endtemplate}
+  @override
+  final DragStartBehavior dragStartBehavior;
+
+  /// {@template flutter.widgets.scrollable.restorationId}
+  /// Restoration ID to save and restore the scroll offset of the scrollable.
+  ///
+  /// If a restoration id is provided, the scrollable will persist its current
+  /// scroll offset and restore it during state restoration.
+  ///
+  /// The scroll offset is persisted in a [RestorationBucket] claimed from
+  /// the surrounding [RestorationScope] using the provided restoration ID.
+  ///
+  /// See also:
+  ///
+  ///  * [RestorationManager], which explains how state restoration works in
+  ///    Flutter.
+  /// {@endtemplate}
+  @override
+  final String? restorationId;
+
+  /// {@macro flutter.widgets.shadow.scrollBehavior}
+  ///
+  /// [ScrollBehavior]s also provide [ScrollPhysics]. If an explicit
+  /// [ScrollPhysics] is provided in [physics], it will take precedence,
+  /// followed by [scrollBehavior], and then the inherited ancestor
+  /// [ScrollBehavior].
+  @override
+  final ScrollBehavior? scrollBehavior;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  ///
+  /// This is passed to decorators in [ScrollableDetails], and does not directly affect
+  /// clipping of the [Scrollable]. This reflects the same [Clip] that is provided
+  /// to [ScrollView.clipBehavior] and is supplied to the [Viewport].
+  @override
+  final Clip clipBehavior;
+
+  /// The axis along which the scroll view scrolls.
+  ///
+  /// Determined by the [axisDirection].
+  @override
+  Axis get axis => axisDirectionToAxis(axisDirection);
+
+  @override
+  TrinaSmoothScrollableState createState() => TrinaSmoothScrollableState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(EnumProperty<AxisDirection>('axisDirection', axisDirection));
+    properties.add(DiagnosticsProperty<ScrollPhysics>('physics', physics));
+    properties.add(StringProperty('restorationId', restorationId));
+  }
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context, or null if none is found.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// ScrollableState? scrollable = Scrollable.maybeOf(context);
+  /// ```
+  ///
+  /// Calling this method will create a dependency on the [ScrollableState]
+  /// that is returned, if there is one. This is typically the closest
+  /// [Scrollable], but may be a more distant ancestor if [axis] is used to
+  /// target a specific [Scrollable].
+  ///
+  /// Using the optional [Axis] is useful when Scrollables are nested and the
+  /// target [Scrollable] is not the closest instance. When [axis] is provided,
+  /// the nearest enclosing [ScrollableState] in that [Axis] is returned, or
+  /// null if there is none.
+  ///
+  /// This finds the nearest _ancestor_ [Scrollable] of the `context`. This
+  /// means that if the `context` is that of a [Scrollable], it will _not_ find
+  /// _that_ [Scrollable].
+  ///
+  /// See also:
+  ///
+  /// * [Scrollable.of], which is similar to this method, but asserts
+  ///   if no [Scrollable] ancestor is found.
+  static ScrollableState? maybeOf(BuildContext context, {Axis? axis}) {
+    // This is the context that will need to establish the dependency.
+    final BuildContext originalContext = context;
+    InheritedElement? element =
+        context.getElementForInheritedWidgetOfExactType<_ScrollableScope>();
+    while (element != null) {
+      final ScrollableState scrollable =
+          (element.widget as _ScrollableScope).scrollable;
+      if (axis == null ||
+          axisDirectionToAxis(scrollable.axisDirection) == axis) {
+        // Establish the dependency on the correct context.
+        originalContext.dependOnInheritedElement(element);
+        return scrollable;
+      }
+      context = scrollable.context;
+      element =
+          context.getElementForInheritedWidgetOfExactType<_ScrollableScope>();
+    }
+    return null;
+  }
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// ScrollableState scrollable = Scrollable.of(context);
+  /// ```
+  ///
+  /// Calling this method will create a dependency on the [ScrollableState]
+  /// that is returned, if there is one. This is typically the closest
+  /// [Scrollable], but may be a more distant ancestor if [axis] is used to
+  /// target a specific [Scrollable].
+  ///
+  /// Using the optional [Axis] is useful when Scrollables are nested and the
+  /// target [Scrollable] is not the closest instance. When [axis] is provided,
+  /// the nearest enclosing [ScrollableState] in that [Axis] is returned.
+  ///
+  /// This finds the nearest _ancestor_ [Scrollable] of the `context`. This
+  /// means that if the `context` is that of a [Scrollable], it will _not_ find
+  /// _that_ [Scrollable].
+  ///
+  /// If no [Scrollable] ancestor is found, then this method will assert in
+  /// debug mode, and throw an exception in release mode.
+  ///
+  /// See also:
+  ///
+  /// * [Scrollable.maybeOf], which is similar to this method, but returns null
+  ///   if no [Scrollable] ancestor is found.
+  static ScrollableState of(BuildContext context, {Axis? axis}) {
+    final ScrollableState? scrollableState = maybeOf(context, axis: axis);
+    assert(() {
+      if (scrollableState == null) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary(
+            'Scrollable.of() was called with a context that does not contain a '
+            'Scrollable widget.',
+          ),
+          ErrorDescription(
+            'No Scrollable widget ancestor could be found '
+            '${axis == null ? '' : 'for the provided Axis: $axis '}'
+            'starting from the context that was passed to Scrollable.of(). This '
+            'can happen because you are using a widget that looks for a Scrollable '
+            'ancestor, but no such ancestor exists.\n'
+            'The context used was:\n'
+            '  $context',
+          ),
+          if (axis != null)
+            ErrorHint(
+              'When specifying an axis, this method will only look for a Scrollable '
+              'that matches the given Axis.',
+            ),
+        ]);
+      }
+      return true;
+    }());
+    return scrollableState!;
+  }
+
+  /// Provides a heuristic to determine if expensive frame-bound tasks should be
+  /// deferred for the [context] at a specific point in time.
+  ///
+  /// Calling this method does _not_ create a dependency on any other widget.
+  /// This also means that the value returned is only good for the point in time
+  /// when it is called, and callers will not get updated if the value changes.
+  ///
+  /// The heuristic used is determined by the [physics] of this [Scrollable]
+  /// via [ScrollPhysics.recommendDeferredLoading]. That method is called with
+  /// the current [ScrollPosition.activity]'s [ScrollActivity.velocity].
+  ///
+  /// The optional [Axis] allows targeting of a specific [Scrollable] of that
+  /// axis, useful when Scrollables are nested. When [axis] is provided,
+  /// [ScrollPosition.recommendDeferredLoading] is called for the nearest
+  /// [Scrollable] in that [Axis].
+  ///
+  /// If there is no [Scrollable] in the widget tree above the [context], this
+  /// method returns false.
+  static bool recommendDeferredLoadingForContext(BuildContext context,
+      {Axis? axis}) {
+    _ScrollableScope? widget =
+        context.getInheritedWidgetOfExactType<_ScrollableScope>();
+    while (widget != null) {
+      if (axis == null ||
+          axisDirectionToAxis(widget.scrollable.axisDirection) == axis) {
+        return widget.position.recommendDeferredLoading(context);
+      }
+      context = widget.scrollable.context;
+      widget = context.getInheritedWidgetOfExactType<_ScrollableScope>();
+    }
+    return false;
+  }
+
+  /// Scrolls all scrollables that enclose the given context so as to make the
+  /// given context visible.
+  ///
+  /// If a [Scrollable] enclosing the provided [BuildContext] is a
+  /// [TwoDimensionalScrollable], both vertical and horizontal axes will ensure
+  /// the target is made visible.
+  static Future<void> ensureVisible(
+    BuildContext context, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy =
+        ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    final List<Future<void>> futures = <Future<void>>[];
+
+    // The targetRenderObject is used to record the first target renderObject.
+    // If there are multiple scrollable widgets nested, the targetRenderObject
+    // is made to be as visible as possible to improve the user experience. If
+    // the targetRenderObject is already visible, then let the outer
+    // renderObject be as visible as possible.
+    //
+    // Also see https://github.com/flutter/flutter/issues/65100
+    RenderObject? targetRenderObject;
+    ScrollableState? scrollable = Scrollable.maybeOf(context);
+    while (scrollable != null) {
+      final List<Future<void>> newFutures;
+      (newFutures, scrollable) = scrollable._performEnsureVisible(
+        context.findRenderObject()!,
+        alignment: alignment,
+        duration: duration,
+        curve: curve,
+        alignmentPolicy: alignmentPolicy,
+        targetRenderObject: targetRenderObject,
+      );
+      futures.addAll(newFutures);
+
+      targetRenderObject ??= context.findRenderObject();
+      context = scrollable.context;
+      scrollable = Scrollable.maybeOf(context);
+    }
+
+    if (futures.isEmpty || duration == Duration.zero) {
+      return Future<void>.value();
+    }
+    if (futures.length == 1) {
+      return futures.single;
+    }
+    return Future.wait<void>(futures).then<void>((List<void> _) => null);
+  }
+}
+
+/// State object for a [Scrollable] widget.
+///
+/// To manipulate a [Scrollable] widget's scroll position, use the object
+/// obtained from the [position] property.
+///
+/// To be informed of when a [Scrollable] widget is scrolling, use a
+/// [NotificationListener] to listen for [ScrollNotification] notifications.
+///
+/// This class is not intended to be subclassed. To specialize the behavior of a
+/// [Scrollable], provide it with a [ScrollPhysics].
+class TrinaSmoothScrollableState extends State<Scrollable>
+    with TickerProviderStateMixin, RestorationMixin
+    implements ScrollContext, ScrollableState {
+  // GETTERS
+
+  /// The manager for this [Scrollable] widget's viewport position.
+  ///
+  /// To control what kind of [ScrollPosition] is created for a [Scrollable],
+  /// provide it with custom [ScrollController] that creates the appropriate
+  /// [ScrollPosition] in its [ScrollController.createScrollPosition] method.
+  @override
+  ScrollPosition get position => _position!;
+  ScrollPosition? _position;
+
+  /// The resolved [ScrollPhysics] of the [ScrollableState].
+  @override
+  ScrollPhysics? get resolvedPhysics => _physics;
+  ScrollPhysics? _physics;
+
+  /// An [Offset] that represents the absolute distance from the origin, or 0,
+  /// of the [ScrollPosition] expressed in the associated [Axis].
+  ///
+  /// Used by [EdgeDraggingAutoScroller] to progress the position forward when a
+  /// drag gesture reaches the edge of the [Viewport].
+  @override
+  Offset get deltaToScrollOrigin {
+    return switch (axisDirection) {
+      AxisDirection.up => Offset(0, -position.pixels),
+      AxisDirection.down => Offset(0, position.pixels),
+      AxisDirection.left => Offset(-position.pixels, 0),
+      AxisDirection.right => Offset(position.pixels, 0),
+    };
+  }
+
+  ScrollController get _effectiveScrollController =>
+      widget.controller ?? _fallbackScrollController!;
+
+  @override
+  AxisDirection get axisDirection => widget.axisDirection;
+
+  @override
+  TickerProvider get vsync => this;
+
+  @override
+  double get devicePixelRatio => _devicePixelRatio;
+  late double _devicePixelRatio;
+
+  @override
+  BuildContext? get notificationContext => _gestureDetectorKey.currentContext;
+
+  @override
+  BuildContext get storageContext => context;
+
+  @override
+  String? get restorationId => widget.restorationId;
+  final _RestorableScrollOffset _persistedScrollOffset =
+      _RestorableScrollOffset();
+
+  late ScrollBehavior _configuration;
+  ScrollController? _fallbackScrollController;
+  DeviceGestureSettings? _mediaQueryGestureSettings;
+
+  // Only call this from places that will definitely trigger a rebuild.
+  void _updatePosition() {
+    _configuration = widget.scrollBehavior ?? ScrollConfiguration.of(context);
+    _physics = _configuration.getScrollPhysics(context);
+    if (widget.physics != null) {
+      _physics = widget.physics!.applyTo(_physics);
+    } else if (widget.scrollBehavior != null) {
+      _physics =
+          widget.scrollBehavior!.getScrollPhysics(context).applyTo(_physics);
+    }
+    final ScrollPosition? oldPosition = _position;
+    if (oldPosition != null) {
+      _effectiveScrollController.detach(oldPosition);
+      // It's important that we not dispose the old position until after the
+      // viewport has had a chance to unregister its listeners from the old
+      // position. So, schedule a microtask to do it.
+      scheduleMicrotask(oldPosition.dispose);
+    }
+
+    _position = _effectiveScrollController.createScrollPosition(
+        _physics!, this, oldPosition);
+    assert(_position != null);
+    _effectiveScrollController.attach(position);
+  }
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_persistedScrollOffset, 'offset');
+    assert(_position != null);
+    if (_persistedScrollOffset.value != null) {
+      position.restoreOffset(_persistedScrollOffset.value!,
+          initialRestore: initialRestore);
+    }
+  }
+
+  @override
+  void saveOffset(double offset) {
+    assert(debugIsSerializableForRestoration(offset));
+    _persistedScrollOffset.value = offset;
+    // [saveOffset] is called after a scrolling ends and it is usually not
+    // followed by a frame. Therefore, manually flush restoration data.
+    ServicesBinding.instance.restorationManager.flushData();
+  }
+
+  @override
+  void initState() {
+    if (widget.controller == null) {
+      _fallbackScrollController = ScrollController();
+    }
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _mediaQueryGestureSettings = MediaQuery.maybeGestureSettingsOf(context);
+    _devicePixelRatio = MediaQuery.maybeDevicePixelRatioOf(context) ??
+        View.of(context).devicePixelRatio;
+    _updatePosition();
+    super.didChangeDependencies();
+  }
+
+  bool _shouldUpdatePosition(Scrollable oldWidget) {
+    if ((widget.scrollBehavior == null) != (oldWidget.scrollBehavior == null)) {
+      return true;
+    }
+    if (widget.scrollBehavior != null &&
+        oldWidget.scrollBehavior != null &&
+        widget.scrollBehavior!.shouldNotify(oldWidget.scrollBehavior!)) {
+      return true;
+    }
+    ScrollPhysics? newPhysics =
+        widget.physics ?? widget.scrollBehavior?.getScrollPhysics(context);
+    ScrollPhysics? oldPhysics = oldWidget.physics ??
+        oldWidget.scrollBehavior?.getScrollPhysics(context);
+    do {
+      if (newPhysics?.runtimeType != oldPhysics?.runtimeType) {
+        return true;
+      }
+      newPhysics = newPhysics?.parent;
+      oldPhysics = oldPhysics?.parent;
+    } while (newPhysics != null || oldPhysics != null);
+
+    return widget.controller?.runtimeType != oldWidget.controller?.runtimeType;
+  }
+
+  @override
+  void didUpdateWidget(Scrollable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.controller != oldWidget.controller) {
+      if (oldWidget.controller == null) {
+        // The old controller was null, meaning the fallback cannot be null.
+        // Dispose of the fallback.
+        assert(_fallbackScrollController != null);
+        assert(widget.controller != null);
+        _fallbackScrollController!.detach(position);
+        _fallbackScrollController!.dispose();
+        _fallbackScrollController = null;
+      } else {
+        // The old controller was not null, detach.
+        oldWidget.controller?.detach(position);
+        if (widget.controller == null) {
+          // If the new controller is null, we need to set up the fallback
+          // ScrollController.
+          _fallbackScrollController = ScrollController();
+        }
+      }
+      // Attach the updated effective scroll controller.
+      _effectiveScrollController.attach(position);
+    }
+
+    if (_shouldUpdatePosition(oldWidget)) {
+      _updatePosition();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (widget.controller != null) {
+      widget.controller!.detach(position);
+    } else {
+      _fallbackScrollController?.detach(position);
+      _fallbackScrollController?.dispose();
+    }
+
+    position.dispose();
+    _persistedScrollOffset.dispose();
+    super.dispose();
+  }
+
+  // SEMANTICS
+
+  final GlobalKey _scrollSemanticsKey = GlobalKey();
+
+  @override
+  @protected
+  void setSemanticsActions(Set<SemanticsAction> actions) {
+    if (_gestureDetectorKey.currentState != null) {
+      _gestureDetectorKey.currentState!.replaceSemanticsActions(actions);
+    }
+  }
+
+  // GESTURE RECOGNITION AND POINTER IGNORING
+
+  final GlobalKey<RawGestureDetectorState> _gestureDetectorKey =
+      GlobalKey<RawGestureDetectorState>();
+  final GlobalKey _ignorePointerKey = GlobalKey();
+
+  // This field is set during layout, and then reused until the next time it is set.
+  Map<Type, GestureRecognizerFactory> _gestureRecognizers =
+      const <Type, GestureRecognizerFactory>{};
+  bool _shouldIgnorePointer = false;
+
+  bool? _lastCanDrag;
+  Axis? _lastAxisDirection;
+
+  @override
+  @protected
+  void setCanDrag(bool value) {
+    if (value == _lastCanDrag &&
+        (!value || widget.axis == _lastAxisDirection)) {
+      return;
+    }
+    if (!value) {
+      _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
+      // Cancel the active hold/drag (if any) because the gesture recognizers
+      // will soon be disposed by our RawGestureDetector, and we won't be
+      // receiving pointer up events to cancel the hold/drag.
+      _handleDragCancel();
+    } else {
+      switch (widget.axis) {
+        case Axis.vertical:
+          _gestureRecognizers = <Type, GestureRecognizerFactory>{
+            VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+                VerticalDragGestureRecognizer>(
+              () => VerticalDragGestureRecognizer(
+                  supportedDevices: _configuration.dragDevices),
+              (VerticalDragGestureRecognizer instance) {
+                instance
+                  ..onDown = _handleDragDown
+                  ..onStart = _handleDragStart
+                  ..onUpdate = _handleDragUpdate
+                  ..onEnd = _handleDragEnd
+                  ..onCancel = _handleDragCancel
+                  ..minFlingDistance = _physics?.minFlingDistance
+                  ..minFlingVelocity = _physics?.minFlingVelocity
+                  ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..velocityTrackerBuilder =
+                      _configuration.velocityTrackerBuilder(context)
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..multitouchDragStrategy =
+                      _configuration.getMultitouchDragStrategy(context)
+                  ..gestureSettings = _mediaQueryGestureSettings
+                  ..supportedDevices = _configuration.dragDevices;
+              },
+            ),
+          };
+        case Axis.horizontal:
+          _gestureRecognizers = <Type, GestureRecognizerFactory>{
+            HorizontalDragGestureRecognizer:
+                GestureRecognizerFactoryWithHandlers<
+                    HorizontalDragGestureRecognizer>(
+              () => HorizontalDragGestureRecognizer(
+                  supportedDevices: _configuration.dragDevices),
+              (HorizontalDragGestureRecognizer instance) {
+                instance
+                  ..onDown = _handleDragDown
+                  ..onStart = _handleDragStart
+                  ..onUpdate = _handleDragUpdate
+                  ..onEnd = _handleDragEnd
+                  ..onCancel = _handleDragCancel
+                  ..minFlingDistance = _physics?.minFlingDistance
+                  ..minFlingVelocity = _physics?.minFlingVelocity
+                  ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..velocityTrackerBuilder =
+                      _configuration.velocityTrackerBuilder(context)
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..multitouchDragStrategy =
+                      _configuration.getMultitouchDragStrategy(context)
+                  ..gestureSettings = _mediaQueryGestureSettings
+                  ..supportedDevices = _configuration.dragDevices;
+              },
+            ),
+          };
+      }
+    }
+    _lastCanDrag = value;
+    _lastAxisDirection = widget.axis;
+    if (_gestureDetectorKey.currentState != null) {
+      _gestureDetectorKey.currentState!
+          .replaceGestureRecognizers(_gestureRecognizers);
+    }
+  }
+
+  @override
+  @protected
+  void setIgnorePointer(bool value) {
+    if (_shouldIgnorePointer == value) {
+      return;
+    }
+    _shouldIgnorePointer = value;
+    if (_ignorePointerKey.currentContext != null) {
+      final RenderIgnorePointer renderBox = _ignorePointerKey.currentContext!
+          .findRenderObject()! as RenderIgnorePointer;
+      renderBox.ignoring = _shouldIgnorePointer;
+    }
+  }
+
+  // TOUCH HANDLERS
+
+  Drag? _drag;
+  ScrollHoldController? _hold;
+
+  void _handleDragDown(DragDownDetails details) {
+    assert(_drag == null);
+    assert(_hold == null);
+    _hold = position.hold(_disposeHold);
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    // It's possible for _hold to become null between _handleDragDown and
+    // _handleDragStart, for example if some user code calls jumpTo or otherwise
+    // triggers a new activity to begin.
+    assert(_drag == null);
+    _drag = position.drag(details, _disposeDrag);
+    assert(_drag != null);
+    assert(_hold == null);
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _drag?.update(details);
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _drag?.end(details);
+    assert(_drag == null);
+  }
+
+  void _handleDragCancel() {
+    if (_gestureDetectorKey.currentContext == null) {
+      // The cancel was caused by the GestureDetector getting disposed, which
+      // means we will get disposed momentarily as well and shouldn't do
+      // any work.
+      return;
+    }
+    // _hold might be null if the drag started.
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _hold?.cancel();
+    _drag?.cancel();
+    assert(_hold == null);
+    assert(_drag == null);
+  }
+
+  void _disposeHold() {
+    _hold = null;
+  }
+
+  void _disposeDrag() {
+    _drag = null;
+  }
+
+  // SCROLL WHEEL
+
+  // Returns the offset that should result from applying [event] to the current
+  // position, taking min/max scroll extent into account.
+  double _targetScrollOffsetForPointerScroll(double delta) {
+    return math.min(
+      math.max(position.pixels + delta, position.minScrollExtent),
+      position.maxScrollExtent,
+    );
+  }
+
+  // Returns the delta that should result from applying [event] with axis,
+  // direction, and any modifiers specified by the ScrollBehavior taken into
+  // account.
+  double _pointerSignalEventDelta(PointerScrollEvent event) {
+    final Set<LogicalKeyboardKey> pressed =
+        HardwareKeyboard.instance.logicalKeysPressed;
+    final bool flipAxes = pressed
+            .any(_configuration.pointerAxisModifiers.contains) &&
+        // Axes are only flipped for physical mouse wheel input.
+        // On some platforms, like web, trackpad input is handled through pointer
+        // signals, but should not be included in this axis modifying behavior.
+        // This is because on a trackpad, all directional axes are available to
+        // the user, while mouse scroll wheels typically are restricted to one
+        // axis.
+        event.kind == PointerDeviceKind.mouse;
+
+    final Axis axis = flipAxes ? flipAxis(widget.axis) : widget.axis;
+    final double delta = switch (axis) {
+      Axis.horizontal => event.scrollDelta.dx,
+      Axis.vertical => event.scrollDelta.dy,
+    };
+
+    return axisDirectionIsReversed(widget.axisDirection) ? -delta : delta;
+  }
+
+  void _receivedPointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent && _position != null) {
+      if (_physics != null && !_physics!.shouldAcceptUserOffset(position)) {
+        // The handler won't use the `event`, so allow the platform to trigger
+        // any default native actions.
+        event.respond(allowPlatformDefault: true);
+        return;
+      }
+      final double delta = _pointerSignalEventDelta(event);
+      final double targetScrollOffset =
+          _targetScrollOffsetForPointerScroll(delta);
+      // Only express interest in the event if it would actually result in a scroll.
+      if (delta != 0.0 && targetScrollOffset != position.pixels) {
+        GestureBinding.instance.pointerSignalResolver
+            .register(event, _handlePointerScroll);
+        return;
+      }
+      // The `event` won't result in a scroll, so allow the platform to trigger
+      // any default native actions.
+      event.respond(allowPlatformDefault: true);
+    } else if (event is PointerScrollInertiaCancelEvent) {
+      position.pointerScroll(0);
+      // Don't use the pointer signal resolver, all hit-tested scrollables should stop.
+    }
+  }
+
+  // void _handlePointerScroll(PointerEvent event) {
+  //   assert(event is PointerScrollEvent);
+  //   final double delta = _pointerSignalEventDelta(event as PointerScrollEvent);
+  //   final double targetScrollOffset =
+  //       _targetScrollOffsetForPointerScroll(delta);
+  //   if (delta != 0.0 && targetScrollOffset != position.pixels) {
+  //     position.pointerScroll(delta);
+  //   }
+  // }
+
+  Timer? _pointerScrollTimer;
+  double _accumulatedTargetOffset = 0.0;
+
+  void _handlePointerScroll(PointerEvent event) {
+    assert(event is PointerScrollEvent);
+    final double delta = _pointerSignalEventDelta(event as PointerScrollEvent);
+
+    // Get the valid scrolling range.
+    final double minScrollExtent = position.minScrollExtent;
+    final double maxScrollExtent = position.maxScrollExtent;
+
+    if (_pointerScrollTimer != null) {
+      // If the timer is running, accumulate the delta.
+      _accumulatedTargetOffset += delta;
+      // Clamp to the valid range.
+      _accumulatedTargetOffset =
+          _accumulatedTargetOffset.clamp(minScrollExtent, maxScrollExtent);
+    } else {
+      // If no timer is running, initialize the accumulated target.
+      _accumulatedTargetOffset = position.pixels + delta;
+      _accumulatedTargetOffset =
+          _accumulatedTargetOffset.clamp(minScrollExtent, maxScrollExtent);
+
+      _pointerScrollTimer =
+          Timer.periodic(const Duration(milliseconds: 33), (Timer timer) {
+        final double currentOffset = position.pixels;
+        // Ensure the accumulated target is clamped.
+        _accumulatedTargetOffset =
+            _accumulatedTargetOffset.clamp(minScrollExtent, maxScrollExtent);
+        final double difference = _accumulatedTargetOffset - currentOffset;
+
+        // If we're close enough to the target, snap to it.
+        if (difference.abs() < 1.0) {
+          position.jumpTo(_accumulatedTargetOffset);
+          timer.cancel();
+          _pointerScrollTimer = null;
+        } else {
+          // Increment 10% of the remaining difference.
+          final double increment = difference * 0.1;
+          double newOffset = currentOffset + increment;
+          newOffset = newOffset.clamp(minScrollExtent, maxScrollExtent);
+          position.jumpTo(newOffset);
+        }
+      });
+    }
+  }
+
+  bool _handleScrollMetricsNotification(
+      ScrollMetricsNotification notification) {
+    if (notification.depth == 0) {
+      final RenderObject? scrollSemanticsRenderObject =
+          _scrollSemanticsKey.currentContext?.findRenderObject();
+      if (scrollSemanticsRenderObject != null) {
+        scrollSemanticsRenderObject.markNeedsSemanticsUpdate();
+      }
+    }
+    return false;
+  }
+
+  Widget _buildChrome(BuildContext context, Widget child) {
+    final ScrollableDetails details = ScrollableDetails(
+      direction: widget.axisDirection,
+      controller: _effectiveScrollController,
+      decorationClipBehavior: widget.clipBehavior,
+    );
+
+    return _configuration.buildScrollbar(
+      context,
+      _configuration.buildOverscrollIndicator(context, child, details),
+      details,
+    );
+  }
+
+  // DESCRIPTION
+
+  @override
+  Widget build(BuildContext context) {
+    assert(_position != null);
+    // _ScrollableScope must be placed above the BuildContext returned by notificationContext
+    // so that we can get this ScrollableState by doing the following:
+    //
+    // ScrollNotification notification;
+    // Scrollable.of(notification.context)
+    //
+    // Since notificationContext is pointing to _gestureDetectorKey.context, _ScrollableScope
+    // must be placed above the widget using it: RawGestureDetector
+    Widget result = _ScrollableScope(
+      scrollable: this,
+      position: position,
+      child: Listener(
+        onPointerSignal: _receivedPointerSignal,
+        child: RawGestureDetector(
+          key: _gestureDetectorKey,
+          gestures: _gestureRecognizers,
+          behavior: widget.hitTestBehavior,
+          excludeFromSemantics: widget.excludeFromSemantics,
+          child: Semantics(
+            explicitChildNodes: !widget.excludeFromSemantics,
+            child: IgnorePointer(
+              key: _ignorePointerKey,
+              ignoring: _shouldIgnorePointer,
+              child: widget.viewportBuilder(context, position),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (!widget.excludeFromSemantics) {
+      result = NotificationListener<ScrollMetricsNotification>(
+          onNotification: _handleScrollMetricsNotification,
+          child: _ScrollSemantics(
+            key: _scrollSemanticsKey,
+            position: position,
+            allowImplicitScrolling: _physics!.allowImplicitScrolling,
+            semanticChildCount: widget.semanticChildCount,
+            child: result,
+          ));
+    }
+
+    result = _buildChrome(context, result);
+
+    // Selection is only enabled when there is a parent registrar.
+    final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);
+    if (registrar != null) {
+      result = _ScrollableSelectionHandler(
+        state: this,
+        position: position,
+        registrar: registrar,
+        child: result,
+      );
+    }
+
+    return result;
+  }
+
+  // Returns the Future from calling ensureVisible for the ScrollPosition, as
+  // as well as this ScrollableState instance so its context can be used to
+  // check for other ancestor Scrollables in executing ensureVisible.
+  // ignore: unused_element
+  _EnsureVisibleResults _performEnsureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy =
+        ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    final Future<void> ensureVisibleFuture = position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+      targetRenderObject: targetRenderObject,
+    );
+    return (<Future<void>>[ensureVisibleFuture], this);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ScrollPosition>('position', _position));
+    properties
+        .add(DiagnosticsProperty<ScrollPhysics>('effective physics', _physics));
+  }
+}
+
+extension on ScrollableState {
+  // Returns the Future from calling ensureVisible for the ScrollPosition, as
+  // as well as this ScrollableState instance so its context can be used to
+  // check for other ancestor Scrollables in executing ensureVisible.
+  _EnsureVisibleResults _performEnsureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy =
+        ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    final Future<void> ensureVisibleFuture = position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+      targetRenderObject: targetRenderObject,
+    );
+    return (<Future<void>>[ensureVisibleFuture], this);
+  }
+}
+
+// Enable Scrollable.of() to work as if ScrollableState was an inherited widget.
+// ScrollableState.build() always rebuilds its _ScrollableScope.
+class _ScrollableScope extends InheritedWidget {
+  const _ScrollableScope({
+    required this.scrollable,
+    required this.position,
+    required super.child,
+  });
+
+  final ScrollableState scrollable;
+  final ScrollPosition position;
+
+  @override
+  bool updateShouldNotify(_ScrollableScope old) {
+    return position != old.position;
+  }
+}
+
+// The return type of _performEnsureVisible.
+//
+// The list of futures represents each pending ScrollPosition call to
+// ensureVisible. The returned ScrollableState's context is used to find the
+// next potential ancestor Scrollable.
+typedef _EnsureVisibleResults = (List<Future<void>>, ScrollableState);
+
+/// A widget to handle selection for a scrollable.
+///
+/// This widget registers itself to the [registrar] and uses
+/// [SelectionContainer] to collect selectables from its subtree.
+class _ScrollableSelectionHandler extends StatefulWidget {
+  const _ScrollableSelectionHandler({
+    required this.state,
+    required this.position,
+    required this.registrar,
+    required this.child,
+  });
+
+  final ScrollableState state;
+  final ScrollPosition position;
+  final Widget child;
+  final SelectionRegistrar registrar;
+
+  @override
+  _ScrollableSelectionHandlerState createState() =>
+      _ScrollableSelectionHandlerState();
+}
+
+class _ScrollableSelectionHandlerState
+    extends State<_ScrollableSelectionHandler> {
+  late _ScrollableSelectionContainerDelegate _selectionDelegate;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectionDelegate = _ScrollableSelectionContainerDelegate(
+      state: widget.state,
+      position: widget.position,
+    );
+  }
+
+  @override
+  void didUpdateWidget(_ScrollableSelectionHandler oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.position != widget.position) {
+      _selectionDelegate.position = widget.position;
+    }
+  }
+
+  @override
+  void dispose() {
+    _selectionDelegate.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectionContainer(
+      registrar: widget.registrar,
+      delegate: _selectionDelegate,
+      child: widget.child,
+    );
+  }
+}
+
+/// This updater handles the case where the selectables change frequently, and
+/// it optimizes toward scrolling updates.
+///
+/// It keeps track of the drag start offset relative to scroll origin for every
+/// selectable. The records are used to determine whether the selection is up to
+/// date with the scroll position when it sends the drag update event to a
+/// selectable.
+class _ScrollableSelectionContainerDelegate
+    extends MultiSelectableSelectionContainerDelegate {
+  _ScrollableSelectionContainerDelegate(
+      {required this.state, required ScrollPosition position})
+      : _position = position,
+        _autoScroller = EdgeDraggingAutoScroller(state,
+            velocityScalar: _kDefaultSelectToScrollVelocityScalar) {
+    _position.addListener(_scheduleLayoutChange);
+  }
+
+  // Pointer drag is a single point, it should not have a size.
+  static const double _kDefaultDragTargetSize = 0;
+
+  // An eye-balled value for a smooth scrolling speed.
+  static const double _kDefaultSelectToScrollVelocityScalar = 30;
+
+  final ScrollableState state;
+  final EdgeDraggingAutoScroller _autoScroller;
+  bool _scheduledLayoutChange = false;
+  Offset? _currentDragStartRelatedToOrigin;
+  Offset? _currentDragEndRelatedToOrigin;
+
+  // The scrollable only auto scrolls if the selection starts in the scrollable.
+  bool _selectionStartsInScrollable = false;
+
+  ScrollPosition get position => _position;
+  ScrollPosition _position;
+  set position(ScrollPosition other) {
+    if (other == _position) {
+      return;
+    }
+    _position.removeListener(_scheduleLayoutChange);
+    _position = other;
+    _position.addListener(_scheduleLayoutChange);
+  }
+
+  // The layout will only be updated a frame later than position changes.
+  // Schedule PostFrameCallback to capture the accurate layout.
+  void _scheduleLayoutChange() {
+    if (_scheduledLayoutChange) {
+      return;
+    }
+    _scheduledLayoutChange = true;
+    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+      if (!_scheduledLayoutChange) {
+        return;
+      }
+      _scheduledLayoutChange = false;
+      layoutDidChange();
+    }, debugLabel: 'ScrollableSelectionContainer.layoutDidChange');
+  }
+
+  /// Stores the scroll offset when a scrollable receives the last
+  /// [SelectionEdgeUpdateEvent].
+  ///
+  /// The stored scroll offset may be null if a scrollable never receives a
+  /// [SelectionEdgeUpdateEvent].
+  ///
+  /// When a new [SelectionEdgeUpdateEvent] is dispatched to a selectable, this
+  /// updater checks the current scroll offset against the one stored in these
+  /// records. If the scroll offset is different, it synthesizes an opposite
+  /// [SelectionEdgeUpdateEvent] and dispatches the event before dispatching the
+  /// new event.
+  ///
+  /// For example, if a selectable receives an end [SelectionEdgeUpdateEvent]
+  /// and its scroll offset in the records is different from the current value,
+  /// it synthesizes a start [SelectionEdgeUpdateEvent] and dispatches it before
+  /// dispatching the original end [SelectionEdgeUpdateEvent].
+  final Map<Selectable, double> _selectableStartEdgeUpdateRecords =
+      <Selectable, double>{};
+  final Map<Selectable, double> _selectableEndEdgeUpdateRecords =
+      <Selectable, double>{};
+
+  @override
+  void didChangeSelectables() {
+    final Set<Selectable> selectableSet = selectables.toSet();
+    _selectableStartEdgeUpdateRecords.removeWhere(
+        (Selectable key, double value) => !selectableSet.contains(key));
+    _selectableEndEdgeUpdateRecords.removeWhere(
+        (Selectable key, double value) => !selectableSet.contains(key));
+    super.didChangeSelectables();
+  }
+
+  @override
+  SelectionResult handleClearSelection(ClearSelectionEvent event) {
+    _selectableStartEdgeUpdateRecords.clear();
+    _selectableEndEdgeUpdateRecords.clear();
+    _currentDragStartRelatedToOrigin = null;
+    _currentDragEndRelatedToOrigin = null;
+    _selectionStartsInScrollable = false;
+    return super.handleClearSelection(event);
+  }
+
+  @override
+  SelectionResult handleSelectionEdgeUpdate(SelectionEdgeUpdateEvent event) {
+    if (_currentDragEndRelatedToOrigin == null &&
+        _currentDragStartRelatedToOrigin == null) {
+      assert(!_selectionStartsInScrollable);
+      _selectionStartsInScrollable =
+          _globalPositionInScrollable(event.globalPosition);
+    }
+    final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
+    if (event.type == SelectionEventType.endEdgeUpdate) {
+      _currentDragEndRelatedToOrigin =
+          _inferPositionRelatedToOrigin(event.globalPosition);
+      final Offset endOffset = _currentDragEndRelatedToOrigin!
+          .translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
+      event = SelectionEdgeUpdateEvent.forEnd(
+          globalPosition: endOffset, granularity: event.granularity);
+    } else {
+      _currentDragStartRelatedToOrigin =
+          _inferPositionRelatedToOrigin(event.globalPosition);
+      final Offset startOffset = _currentDragStartRelatedToOrigin!
+          .translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
+      event = SelectionEdgeUpdateEvent.forStart(
+          globalPosition: startOffset, granularity: event.granularity);
+    }
+    final SelectionResult result = super.handleSelectionEdgeUpdate(event);
+
+    // Result may be pending if one of the selectable child is also a scrollable.
+    // In that case, the parent scrollable needs to wait for the child to finish
+    // scrolling.
+    if (result == SelectionResult.pending) {
+      _autoScroller.stopAutoScroll();
+      return result;
+    }
+    if (_selectionStartsInScrollable) {
+      _autoScroller.startAutoScrollIfNecessary(_dragTargetFromEvent(event));
+      if (_autoScroller.scrolling) {
+        return SelectionResult.pending;
+      }
+    }
+    return result;
+  }
+
+  Offset _inferPositionRelatedToOrigin(Offset globalPosition) {
+    final RenderBox box = state.context.findRenderObject()! as RenderBox;
+    final Offset localPosition = box.globalToLocal(globalPosition);
+    if (!_selectionStartsInScrollable) {
+      // If the selection starts outside of the scrollable, selecting across the
+      // scrollable boundary will act as selecting the entire content in the
+      // scrollable. This logic move the offset to the 0.0 or infinity to cover
+      // the entire content if the input position is outside of the scrollable.
+      if (localPosition.dy < 0 || localPosition.dx < 0) {
+        return box.localToGlobal(Offset.zero);
+      }
+      if (localPosition.dy > box.size.height ||
+          localPosition.dx > box.size.width) {
+        return Offset.infinite;
+      }
+    }
+    final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
+    return box.localToGlobal(
+        localPosition.translate(deltaToOrigin.dx, deltaToOrigin.dy));
+  }
+
+  /// Infers the [_currentDragStartRelatedToOrigin] and
+  /// [_currentDragEndRelatedToOrigin] from the geometry.
+  ///
+  /// This method is called after a select word and select all event where the
+  /// selection is triggered by none drag events. The
+  /// [_currentDragStartRelatedToOrigin] and [_currentDragEndRelatedToOrigin]
+  /// are essential to handle future [SelectionEdgeUpdateEvent]s.
+  void _updateDragLocationsFromGeometries(
+      {bool forceUpdateStart = true, bool forceUpdateEnd = true}) {
+    final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
+    final RenderBox box = state.context.findRenderObject()! as RenderBox;
+    final Matrix4 transform = box.getTransformTo(null);
+    if (currentSelectionStartIndex != -1 &&
+        (_currentDragStartRelatedToOrigin == null || forceUpdateStart)) {
+      final SelectionGeometry geometry =
+          selectables[currentSelectionStartIndex].value;
+      assert(geometry.hasSelection);
+      final SelectionPoint start = geometry.startSelectionPoint!;
+      final Matrix4 childTransform =
+          selectables[currentSelectionStartIndex].getTransformTo(box);
+      final Offset localDragStart = MatrixUtils.transformPoint(
+        childTransform,
+        start.localPosition + Offset(0, -start.lineHeight / 2),
+      );
+      _currentDragStartRelatedToOrigin =
+          MatrixUtils.transformPoint(transform, localDragStart + deltaToOrigin);
+    }
+    if (currentSelectionEndIndex != -1 &&
+        (_currentDragEndRelatedToOrigin == null || forceUpdateEnd)) {
+      final SelectionGeometry geometry =
+          selectables[currentSelectionEndIndex].value;
+      assert(geometry.hasSelection);
+      final SelectionPoint end = geometry.endSelectionPoint!;
+      final Matrix4 childTransform =
+          selectables[currentSelectionEndIndex].getTransformTo(box);
+      final Offset localDragEnd = MatrixUtils.transformPoint(
+        childTransform,
+        end.localPosition + Offset(0, -end.lineHeight / 2),
+      );
+      _currentDragEndRelatedToOrigin =
+          MatrixUtils.transformPoint(transform, localDragEnd + deltaToOrigin);
+    }
+  }
+
+  @override
+  SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
+    assert(!_selectionStartsInScrollable);
+    final SelectionResult result = super.handleSelectAll(event);
+    assert(
+        (currentSelectionStartIndex == -1) == (currentSelectionEndIndex == -1));
+    if (currentSelectionStartIndex != -1) {
+      _updateDragLocationsFromGeometries();
+    }
+    return result;
+  }
+
+  @override
+  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
+    _selectionStartsInScrollable =
+        _globalPositionInScrollable(event.globalPosition);
+    final SelectionResult result = super.handleSelectWord(event);
+    _updateDragLocationsFromGeometries();
+    return result;
+  }
+
+  @override
+  SelectionResult handleGranularlyExtendSelection(
+      GranularlyExtendSelectionEvent event) {
+    final SelectionResult result = super.handleGranularlyExtendSelection(event);
+    // The selection geometry may not have the accurate offset for the edges
+    // that are outside of the viewport whose transform may not be valid. Only
+    // the edge this event is updating is sure to be accurate.
+    _updateDragLocationsFromGeometries(
+      forceUpdateStart: !event.isEnd,
+      forceUpdateEnd: event.isEnd,
+    );
+    if (_selectionStartsInScrollable) {
+      _jumpToEdge(event.isEnd);
+    }
+    return result;
+  }
+
+  @override
+  SelectionResult handleDirectionallyExtendSelection(
+      DirectionallyExtendSelectionEvent event) {
+    final SelectionResult result =
+        super.handleDirectionallyExtendSelection(event);
+    // The selection geometry may not have the accurate offset for the edges
+    // that are outside of the viewport whose transform may not be valid. Only
+    // the edge this event is updating is sure to be accurate.
+    _updateDragLocationsFromGeometries(
+      forceUpdateStart: !event.isEnd,
+      forceUpdateEnd: event.isEnd,
+    );
+    if (_selectionStartsInScrollable) {
+      _jumpToEdge(event.isEnd);
+    }
+    return result;
+  }
+
+  void _jumpToEdge(bool isExtent) {
+    final Selectable selectable;
+    final double? lineHeight;
+    final SelectionPoint? edge;
+    if (isExtent) {
+      selectable = selectables[currentSelectionEndIndex];
+      edge = selectable.value.endSelectionPoint;
+      lineHeight = selectable.value.endSelectionPoint!.lineHeight;
+    } else {
+      selectable = selectables[currentSelectionStartIndex];
+      edge = selectable.value.startSelectionPoint;
+      lineHeight = selectable.value.startSelectionPoint?.lineHeight;
+    }
+    if (lineHeight == null || edge == null) {
+      return;
+    }
+    final RenderBox scrollableBox =
+        state.context.findRenderObject()! as RenderBox;
+    final Matrix4 transform = selectable.getTransformTo(scrollableBox);
+    final Offset edgeOffsetInScrollableCoordinates =
+        MatrixUtils.transformPoint(transform, edge.localPosition);
+    final Rect scrollableRect = Rect.fromLTRB(
+        0, 0, scrollableBox.size.width, scrollableBox.size.height);
+    switch (state.axisDirection) {
+      case AxisDirection.up:
+        final double edgeBottom = edgeOffsetInScrollableCoordinates.dy;
+        final double edgeTop =
+            edgeOffsetInScrollableCoordinates.dy - lineHeight;
+        if (edgeBottom >= scrollableRect.bottom &&
+            edgeTop <= scrollableRect.top) {
+          return;
+        }
+        if (edgeBottom > scrollableRect.bottom) {
+          position.jumpTo(position.pixels + scrollableRect.bottom - edgeBottom);
+          return;
+        }
+        if (edgeTop < scrollableRect.top) {
+          position.jumpTo(position.pixels + scrollableRect.top - edgeTop);
+        }
+        return;
+      case AxisDirection.right:
+        final double edge = edgeOffsetInScrollableCoordinates.dx;
+        if (edge >= scrollableRect.right && edge <= scrollableRect.left) {
+          return;
+        }
+        if (edge > scrollableRect.right) {
+          position.jumpTo(position.pixels + edge - scrollableRect.right);
+          return;
+        }
+        if (edge < scrollableRect.left) {
+          position.jumpTo(position.pixels + edge - scrollableRect.left);
+        }
+        return;
+      case AxisDirection.down:
+        final double edgeBottom = edgeOffsetInScrollableCoordinates.dy;
+        final double edgeTop =
+            edgeOffsetInScrollableCoordinates.dy - lineHeight;
+        if (edgeBottom >= scrollableRect.bottom &&
+            edgeTop <= scrollableRect.top) {
+          return;
+        }
+        if (edgeBottom > scrollableRect.bottom) {
+          position.jumpTo(position.pixels + edgeBottom - scrollableRect.bottom);
+          return;
+        }
+        if (edgeTop < scrollableRect.top) {
+          position.jumpTo(position.pixels + edgeTop - scrollableRect.top);
+        }
+        return;
+      case AxisDirection.left:
+        final double edge = edgeOffsetInScrollableCoordinates.dx;
+        if (edge >= scrollableRect.right && edge <= scrollableRect.left) {
+          return;
+        }
+        if (edge > scrollableRect.right) {
+          position.jumpTo(position.pixels + scrollableRect.right - edge);
+          return;
+        }
+        if (edge < scrollableRect.left) {
+          position.jumpTo(position.pixels + scrollableRect.left - edge);
+        }
+        return;
+    }
+  }
+
+  bool _globalPositionInScrollable(Offset globalPosition) {
+    final RenderBox box = state.context.findRenderObject()! as RenderBox;
+    final Offset localPosition = box.globalToLocal(globalPosition);
+    final Rect rect = Rect.fromLTWH(0, 0, box.size.width, box.size.height);
+    return rect.contains(localPosition);
+  }
+
+  Rect _dragTargetFromEvent(SelectionEdgeUpdateEvent event) {
+    return Rect.fromCenter(
+        center: event.globalPosition,
+        width: _kDefaultDragTargetSize,
+        height: _kDefaultDragTargetSize);
+  }
+
+  @override
+  SelectionResult dispatchSelectionEventToChild(
+      Selectable selectable, SelectionEvent event) {
+    switch (event.type) {
+      case SelectionEventType.startEdgeUpdate:
+        _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
+        ensureChildUpdated(selectable);
+      case SelectionEventType.endEdgeUpdate:
+        _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
+        ensureChildUpdated(selectable);
+      case SelectionEventType.granularlyExtendSelection:
+      case SelectionEventType.directionallyExtendSelection:
+        ensureChildUpdated(selectable);
+        _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
+        _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
+      case SelectionEventType.clear:
+        _selectableEndEdgeUpdateRecords.remove(selectable);
+        _selectableStartEdgeUpdateRecords.remove(selectable);
+      case SelectionEventType.selectAll:
+      case SelectionEventType.selectWord:
+      case SelectionEventType.selectParagraph:
+        _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
+        _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
+    }
+    return super.dispatchSelectionEventToChild(selectable, event);
+  }
+
+  @override
+  void ensureChildUpdated(Selectable selectable) {
+    final double newRecord = state.position.pixels;
+    final double? previousStartRecord =
+        _selectableStartEdgeUpdateRecords[selectable];
+    if (_currentDragStartRelatedToOrigin != null &&
+        (previousStartRecord == null ||
+            (newRecord - previousStartRecord).abs() >
+                precisionErrorTolerance)) {
+      // Make sure the selectable has up to date events.
+      final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
+      final Offset startOffset = _currentDragStartRelatedToOrigin!
+          .translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
+      selectable.dispatchSelectionEvent(
+          SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
+      // Make sure we track that we have synthesized a start event for this selectable,
+      // so we don't synthesize events unnecessarily.
+      _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
+    }
+    final double? previousEndRecord =
+        _selectableEndEdgeUpdateRecords[selectable];
+    if (_currentDragEndRelatedToOrigin != null &&
+        (previousEndRecord == null ||
+            (newRecord - previousEndRecord).abs() > precisionErrorTolerance)) {
+      // Make sure the selectable has up to date events.
+      final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
+      final Offset endOffset = _currentDragEndRelatedToOrigin!
+          .translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
+      selectable.dispatchSelectionEvent(
+          SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset));
+      // Make sure we track that we have synthesized an end event for this selectable,
+      // so we don't synthesize events unnecessarily.
+      _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
+    }
+  }
+
+  @override
+  void dispose() {
+    _selectableStartEdgeUpdateRecords.clear();
+    _selectableEndEdgeUpdateRecords.clear();
+    _scheduledLayoutChange = false;
+    _autoScroller.stopAutoScroll();
+    super.dispose();
+  }
+}
+
+Offset _getDeltaToScrollOrigin(ScrollableState scrollableState) {
+  return switch (scrollableState.axisDirection) {
+    AxisDirection.up => Offset(0, -scrollableState.position.pixels),
+    AxisDirection.down => Offset(0, scrollableState.position.pixels),
+    AxisDirection.left => Offset(-scrollableState.position.pixels, 0),
+    AxisDirection.right => Offset(scrollableState.position.pixels, 0),
+  };
+}
+
+/// With [_ScrollSemantics] certain child [SemanticsNode]s can be
+/// excluded from the scrollable area for semantics purposes.
+///
+/// Nodes, that are to be excluded, have to be tagged with
+/// [RenderViewport.excludeFromScrolling] and the [RenderAbstractViewport] in
+/// use has to add the [RenderViewport.useTwoPaneSemantics] tag to its
+/// [SemanticsConfiguration] by overriding
+/// [RenderObject.describeSemanticsConfiguration].
+///
+/// If the tag [RenderViewport.useTwoPaneSemantics] is present on the viewport,
+/// two semantics nodes will be used to represent the [Scrollable]: The outer
+/// node will contain all children, that are excluded from scrolling. The inner
+/// node, which is annotated with the scrolling actions, will house the
+/// scrollable children.
+class _ScrollSemantics extends SingleChildRenderObjectWidget {
+  const _ScrollSemantics({
+    super.key,
+    required this.position,
+    required this.allowImplicitScrolling,
+    required this.semanticChildCount,
+    super.child,
+  }) : assert(semanticChildCount == null || semanticChildCount >= 0);
+
+  final ScrollPosition position;
+  final bool allowImplicitScrolling;
+  final int? semanticChildCount;
+
+  @override
+  _RenderScrollSemantics createRenderObject(BuildContext context) {
+    return _RenderScrollSemantics(
+      position: position,
+      allowImplicitScrolling: allowImplicitScrolling,
+      semanticChildCount: semanticChildCount,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, _RenderScrollSemantics renderObject) {
+    renderObject
+      ..allowImplicitScrolling = allowImplicitScrolling
+      ..position = position
+      ..semanticChildCount = semanticChildCount;
+  }
+}
+
+class _RenderScrollSemantics extends RenderProxyBox {
+  _RenderScrollSemantics({
+    required ScrollPosition position,
+    required bool allowImplicitScrolling,
+    required int? semanticChildCount,
+    RenderBox? child,
+  })  : _position = position,
+        _allowImplicitScrolling = allowImplicitScrolling,
+        _semanticChildCount = semanticChildCount,
+        super(child) {
+    position.addListener(markNeedsSemanticsUpdate);
+  }
+
+  /// Whether this render object is excluded from the semantic tree.
+  ScrollPosition get position => _position;
+  ScrollPosition _position;
+  set position(ScrollPosition value) {
+    if (value == _position) {
+      return;
+    }
+    _position.removeListener(markNeedsSemanticsUpdate);
+    _position = value;
+    _position.addListener(markNeedsSemanticsUpdate);
+    markNeedsSemanticsUpdate();
+  }
+
+  /// Whether this node can be scrolled implicitly.
+  bool get allowImplicitScrolling => _allowImplicitScrolling;
+  bool _allowImplicitScrolling;
+  set allowImplicitScrolling(bool value) {
+    if (value == _allowImplicitScrolling) {
+      return;
+    }
+    _allowImplicitScrolling = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  int? get semanticChildCount => _semanticChildCount;
+  int? _semanticChildCount;
+  set semanticChildCount(int? value) {
+    if (value == semanticChildCount) {
+      return;
+    }
+    _semanticChildCount = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.isSemanticBoundary = true;
+    if (position.haveDimensions) {
+      config
+        ..hasImplicitScrolling = allowImplicitScrolling
+        ..scrollPosition = _position.pixels
+        ..scrollExtentMax = _position.maxScrollExtent
+        ..scrollExtentMin = _position.minScrollExtent
+        ..scrollChildCount = semanticChildCount;
+    }
+  }
+
+  SemanticsNode? _innerNode;
+
+  @override
+  void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config,
+      Iterable<SemanticsNode> children) {
+    if (children.isEmpty ||
+        !children.first.isTagged(RenderViewport.useTwoPaneSemantics)) {
+      _innerNode = null;
+      super.assembleSemanticsNode(node, config, children);
+      return;
+    }
+
+    (_innerNode ??= SemanticsNode(showOnScreen: showOnScreen)).rect = node.rect;
+
+    int? firstVisibleIndex;
+    final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];
+    final List<SemanticsNode> included = <SemanticsNode>[];
+    for (final SemanticsNode child in children) {
+      assert(child.isTagged(RenderViewport.useTwoPaneSemantics));
+      if (child.isTagged(RenderViewport.excludeFromScrolling)) {
+        excluded.add(child);
+      } else {
+        if (!child.hasFlag(SemanticsFlag.isHidden)) {
+          firstVisibleIndex ??= child.indexInParent;
+        }
+        included.add(child);
+      }
+    }
+    config.scrollIndex = firstVisibleIndex;
+    node.updateWith(config: null, childrenInInversePaintOrder: excluded);
+    _innerNode!
+        .updateWith(config: config, childrenInInversePaintOrder: included);
+  }
+
+  @override
+  void clearSemantics() {
+    super.clearSemantics();
+    _innerNode = null;
+  }
+}
+
+// Not using a RestorableDouble because we want to allow null values and override
+// [enabled].
+class _RestorableScrollOffset extends RestorableValue<double?> {
+  @override
+  double? createDefaultValue() => null;
+
+  @override
+  void didUpdateValue(double? oldValue) {
+    notifyListeners();
+  }
+
+  @override
+  double fromPrimitives(Object? data) {
+    return data! as double;
+  }
+
+  @override
+  Object? toPrimitives() {
+    return value;
+  }
+
+  @override
+  bool get enabled => value != null;
+}

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -4,6 +4,9 @@ import 'package:trina_grid/src/widgets/trina_horizontal_scroll_bar.dart';
 import 'package:trina_grid/src/widgets/trina_vertical_scroll_bar.dart';
 import 'package:trina_grid/trina_grid.dart';
 
+import 'scrolls/trina_single_child_smooth_scroll_view.dart'
+    show TrinaSingleChildSmoothScrollView;
+import 'scrolls/trina_smooth_list_view.dart' show TrinaSmoothListView;
 import 'ui.dart';
 
 class TrinaBodyRows extends TrinaStatefulWidget {
@@ -203,7 +206,9 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
               children: [
                 // Main grid content
                 Expanded(
-                  child: SingleChildScrollView(
+                  child: (scrollConfig.smoothScrolling
+                      ? TrinaSingleChildSmoothScrollView.new
+                      : SingleChildScrollView.new)(
                     controller: _horizontalScroll,
                     scrollDirection: Axis.horizontal,
                     physics: const ClampingScrollPhysics(),
@@ -224,7 +229,14 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                             ),
                           // Scrollable rows
                           Expanded(
+<<<<<<< Updated upstream
                             child: ListView.builder(
+=======
+                            child: (scrollConfig.smoothScrolling
+                                ? TrinaSmoothListView.builder
+                                : ListView.builder)(
+                              cacheExtent: stateManager.rowsCacheExtent,
+>>>>>>> Stashed changes
                               controller: _verticalScroll,
                               scrollDirection: Axis.vertical,
                               physics: const ClampingScrollPhysics(),

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -229,14 +229,10 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                             ),
                           // Scrollable rows
                           Expanded(
-<<<<<<< Updated upstream
-                            child: ListView.builder(
-=======
                             child: (scrollConfig.smoothScrolling
                                 ? TrinaSmoothListView.builder
                                 : ListView.builder)(
                               cacheExtent: stateManager.rowsCacheExtent,
->>>>>>> Stashed changes
                               controller: _verticalScroll,
                               scrollDirection: Axis.vertical,
                               physics: const ClampingScrollPhysics(),


### PR DESCRIPTION
Smooth scrolling is a nice to have feature. It can enhance the experience for some users and contribute to a more polished and professional feel.

I checked Flutter's `DataTable` widget, the `two_dimensional_scrollables`, `data_table_2`, `material_table_view`, `trina_grid`, `flutter_web_data_table` and `syncfusion_flutter_datagrid` packages, but none of them have smooth scrolling.

I implemented smooth scrolling for this package, because it's the most complete and free (unlike syncfusion) grid/table widget I could find.

I kept it disabled by default, but it can be enabled in the configuration:
```dart
child: TrinaGrid(
  configuration: const TrinaGridConfiguration(
    scrollbar: TrinaGridScrollbarConfig(
      smoothScrolling: true,
    ),
  ),
  ...
),
```

Recording showing the feature disabled and enabled:


https://github.com/user-attachments/assets/b08606c1-b14c-45a8-8828-967a99128b10

