### PR TITLE
fixes #80: `TrinaGridStyleConfig.cellTextStyle.color` can be null

### DIFF
--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -111,7 +111,12 @@ List<PopupMenuEntry<dynamic>> _getDefaultColumnMenuItems({
   required TrinaGridStateManager stateManager,
   required TrinaColumn column,
 }) {
-  final Color textColor = stateManager.style.cellTextStyle.color!;
+  final defaultTextStyle = stateManager.style.isDarkStyle
+      ? TrinaGridStyleConfig.defaultDarkCellTextStyle
+      : TrinaGridStyleConfig.defaultLightCellTextStyle;
+
+  final textTheme = defaultTextStyle.merge(stateManager.style.cellTextStyle);
+  final Color textColor = textTheme.color!;
 
   final Color disableTextColor = textColor.withAlpha((0.5 * 255).toInt());
 

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -227,6 +227,12 @@ class TrinaGridConfiguration {
 }
 
 class TrinaGridStyleConfig {
+  static const TextStyle defaultLightCellTextStyle =
+      TextStyle(fontSize: 14, color: Colors.black);
+
+  static const TextStyle defaultDarkCellTextStyle =
+      TextStyle(fontSize: 14, color: Colors.white);
+
   const TrinaGridStyleConfig({
     this.enableGridBorderShadow = false,
     this.enableColumnBorderVertical = true,
@@ -278,7 +284,7 @@ class TrinaGridStyleConfig {
     Color? columnActiveColor,
     Color? cellUnselectedColor,
     Color? cellActiveColor,
-    this.cellTextStyle = const TextStyle(color: Colors.black, fontSize: 14),
+    this.cellTextStyle = defaultLightCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
     this.columnAscendingIcon,
@@ -301,7 +307,8 @@ class TrinaGridStyleConfig {
         columnUnselectedColor = (columnUnselectedColor ?? iconColor),
         columnActiveColor = (columnActiveColor ?? activatedBorderColor),
         cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-        cellActiveColor = (cellActiveColor ?? activatedBorderColor);
+        cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+        isDarkStyle = false;
 
   const TrinaGridStyleConfig.dark({
     this.enableGridBorderShadow = false,
@@ -354,7 +361,7 @@ class TrinaGridStyleConfig {
     Color? columnActiveColor,
     Color? cellUnselectedColor,
     Color? cellActiveColor,
-    this.cellTextStyle = const TextStyle(color: Colors.white, fontSize: 14),
+    this.cellTextStyle = defaultDarkCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
     this.columnAscendingIcon,
@@ -377,7 +384,8 @@ class TrinaGridStyleConfig {
         columnUnselectedColor = (columnUnselectedColor ?? iconColor),
         columnActiveColor = (columnActiveColor ?? activatedBorderColor),
         cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-        cellActiveColor = (cellActiveColor ?? activatedBorderColor);
+        cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+        isDarkStyle = true;
 
   /// Enable borderShadow in [TrinaGrid].
   final bool enableGridBorderShadow;
@@ -584,6 +592,9 @@ class TrinaGridStyleConfig {
   /// Set color of filter popup header icon
   final Color? filterHeaderIconColor;
 
+  /// A flag indicating whether the style is dark or not
+  final bool isDarkStyle;
+
   TrinaGridStyleConfig copyWith({
     bool? enableGridBorderShadow,
     bool? enableColumnBorderVertical,
@@ -774,7 +785,8 @@ class TrinaGridStyleConfig {
             gridBorderRadius == other.gridBorderRadius &&
             gridPopupBorderRadius == other.gridPopupBorderRadius &&
             gridPadding == other.gridPadding &&
-            gridBorderWidth == other.gridBorderWidth;
+            gridBorderWidth == other.gridBorderWidth &&
+            isDarkStyle == other.isDarkStyle;
   }
 
   @override
@@ -832,6 +844,7 @@ class TrinaGridStyleConfig {
         gridBorderWidth,
         filterHeaderColor,
         filterHeaderIconColor,
+        isDarkStyle
       ]);
 }
 


### PR DESCRIPTION
## Purpose

When building the default column's context menu items, we get the item text color from the `TrinaGridStyleConfig.cellTextStyle` and we assume it's not a `null` value as shown below:

```dart
final Color textColor = stateManager.style.cellTextStyle.color!;
```

### How can this be a problem?

If we provide a `TextStyle` for the `cellTextStyle` without setting a color, then we'll get an exception when we try to build the column context menu items.

For more info, please reference #80 

## Changes

- Added constants for default text styles.
- Added `isDarkStyle` property for `TrinaGridStyleConfig`.
- Handled if provided `cellTextStyle` is missing required perperties(color, etc..)

## Related Issue
- #80 

## Notes:

- Having a constants for the test styles is convenient but it doesnt follow the coding style in the codebase.
- Usually we can have much simpler solution if we construct the TextStyle using default Material style when having a `BuildContext`. This can be done maybe [here](https://github.com/doonfrs/trina_grid/blob/main/lib/src/trina_grid.dart#L714).
