### PR TITLE
fix: discontinued cells vertical border when `enableCellBorderHorizontal` is `false`

### DIFF
--- a/lib/src/ui/trina_base_row.dart
+++ b/lib/src/ui/trina_base_row.dart
@@ -164,7 +164,14 @@ class _RowCellsLayoutDelegate extends MultiChildLayoutDelegate {
       if (hasChild(element.field)) {
         layoutChild(
           element.field,
-          BoxConstraints.tightFor(width: width, height: stateManager.rowHeight),
+          BoxConstraints.tightFor(
+            width: width,
+            height: stateManager.style.enableCellBorderHorizontal
+                ? stateManager.rowHeight
+                // we add `rowBorderWidth` to the row height so the cells are not
+                // vertically-separated by the disabled horizontal border
+                : stateManager.rowHeight + TrinaGridSettings.rowBorderWidth,
+          ),
         );
 
         positionChild(element.field, Offset(dx, 0));


### PR DESCRIPTION
## Purpose

Fix #87

## Changes

When laying out cells in a row, the cell height is calculated based on the value of `stateManager.style.enableCellBorderHorizontal`.

### Notes

- I've added some tests, but I'm not sure if it's in the right place.

## Related Issue
- #87