### PR TITLE
Fix date validation in `TrinaColumnTypeDate.isValid`

### DIFF
--- a/lib/src/model/column_types/trina_column_type_date.dart
+++ b/lib/src/model/column_types/trina_column_type_date.dart
@@ -50,7 +50,7 @@ class TrinaColumnTypeDate
 
   @override
   bool isValid(dynamic value) {
-    final parsedDate = DateTime.tryParse(value.toString());
+    final parsedDate = dateFormat.tryParse(value.toString());
 
     if (parsedDate == null) {
       return false;


### PR DESCRIPTION
## Purpose

- Currently we use `DateTime.tryParse` to get the parsed date:

```dart

class TrinaColumnTypeDate {

 @override
  bool isValid(dynamic value) {
    final parsedDate = DateTime.tryParse(value.toString());

    //...rest of the code
  }
}
```

This introduces a bug due to the limited input accepted by `DateTime.parse`, as it says in the [API doc](https://api.flutter.dev/flutter/dart-core/DateTime/parse.html):

> A date: A signed four-to-six digit year, two digit month and two digit day, optionally separated by - characters. Examples: "19700101", "-0004-12-24", "81030-04-01".

It means that `DateTime.tryParse` will return `null` with date strings formatted with a separator other than '-'.

### How is this an issue?

If we have this date column with custom format:

```dart
TrinaColumn(
        title: 'MM/dd/yyyy',
        field: 'mm_dd_yyyy',
        type: TrinaColumnType.date(
          format: 'MM/dd/yyyy',
        ),
      ),
```

When we select a new value from the date picker it will not be changed due to not being valid. 

```dart

class TrinaColumnTypeDate {

  @override
  bool isValid(dynamic value) {
    // this will be null for date formats with separators other than '-'
    final parsedDate = DateTime.tryParse(value.toString());

    if (parsedDate == null) {
      return false;
    }

}
```
<details>
<summary>
What happens behind the scenes?
</summary>

1. First the date picker `onSelected` is called

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/trina_grid_date_picker.dart#L179-L185

2. This will call `onSelected` from `PopupCellState`, which then calls `handleSelected`

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/ui/cells/popup_cell.dart#L153-L184

3. `handleSelected` will call `handleAfterSelectingRow`

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/manager/state/selecting_state.dart#L535-L550

4.  `EditingState.changeCellValue` is called and the new value is validated before its accepted.

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/manager/state/editing_state.dart#L285-L294

in `validateValue`

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/manager/state/editing_state.dart#L235-L239

This calls 

https://github.com/doonfrs/trina_grid/blob/886280c4221c1b9f37fe4b128f561781adcd5027/lib/src/model/column_types/trina_column_type_date.dart#L51-L58

</details>

## Changes

- use `TrinaColumnTypeDate.dateFormat` to parse the value to a `DateTime`.

## Related Issues

- Fix #85 
