### PR TITLE
Allow users to configure cell border width

### DIFF
--- a/doc/getting-started/configuration.md
+++ b/doc/getting-started/configuration.md
@@ -35,6 +35,8 @@ TrinaGridConfiguration(
     // Cell styles
     cellColorInEditState: Colors.white,
     cellColorInReadOnlyState: Colors.grey[200]!,
+    cellHorizontalBorderWidth: 1.0,
+    cellVerticalBorderWidth: 1.0,
     
     // Text styles
     columnTextStyle: TextStyle(
@@ -301,6 +303,8 @@ TrinaGrid(
       iconColor: Colors.blue,
       enableCellBorderHorizontal: true,
       enableCellBorderVertical: true,
+      cellVerticalBorderWidth: 1.0,
+      cellHorizontalBorderWidth: 1.0,
       gridBorderRadius: BorderRadius.circular(8),
       gridPopupBorderRadius: BorderRadius.circular(8),
       enableGridBorderShadow: true,

--- a/lib/src/manager/state/layout_state.dart
+++ b/lib/src/manager/state/layout_state.dart
@@ -310,7 +310,8 @@ mixin LayoutState implements ITrinaGridState {
   double get rowHeight => configuration.style.rowHeight;
 
   @override
-  double get rowTotalHeight => rowHeight + TrinaGridSettings.rowBorderWidth;
+  double get rowTotalHeight =>
+      rowHeight + configuration.style.cellHorizontalBorderWidth;
 
   @override
   double get gridPadding => configuration.style.gridPadding;

--- a/lib/src/manager/state/scroll_state.dart
+++ b/lib/src/manager/state/scroll_state.dart
@@ -101,7 +101,7 @@ mixin ScrollState implements ITrinaGridState {
         columnHeight -
         columnFilterHeight -
         columnFooterHeight -
-        TrinaGridSettings.rowBorderWidth;
+        configuration.style.cellHorizontalBorderWidth;
 
     double offsetToMove =
         direction.isUp ? (rowIdx! - 1) * rowSize : (rowIdx! + 1) * rowSize;

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -318,6 +318,9 @@ class TrinaGridStyleConfig {
     this.gridPopupBorderRadius = BorderRadius.zero,
     this.gridPadding = TrinaGridSettings.gridPadding,
     this.gridBorderWidth = TrinaGridSettings.gridBorderWidth,
+    this.cellVerticalBorderWidth = TrinaGridSettings.cellVerticalBorderWidth,
+    this.cellHorizontalBorderWidth =
+        TrinaGridSettings.cellHorizontalBorderWidth,
     this.filterHeaderColor,
     this.filterHeaderIconColor,
   })  : columnCheckedColor = (columnCheckedColor ?? activatedColor),
@@ -395,6 +398,9 @@ class TrinaGridStyleConfig {
     this.gridPopupBorderRadius = BorderRadius.zero,
     this.gridPadding = TrinaGridSettings.gridPadding,
     this.gridBorderWidth = TrinaGridSettings.gridBorderWidth,
+    this.cellVerticalBorderWidth = TrinaGridSettings.cellVerticalBorderWidth,
+    this.cellHorizontalBorderWidth =
+        TrinaGridSettings.cellHorizontalBorderWidth,
     this.filterHeaderColor,
     this.filterHeaderIconColor,
   })  : columnCheckedColor = (columnCheckedColor ?? activatedColor),
@@ -613,6 +619,12 @@ class TrinaGridStyleConfig {
   /// A flag indicating whether the style is dark or not
   final bool isDarkStyle;
 
+  /// Cell vertical border width
+  final double cellVerticalBorderWidth;
+
+  /// Cell horizontal border width
+  final double cellHorizontalBorderWidth;
+
   TrinaGridStyleConfig copyWith({
     bool? enableGridBorderShadow,
     bool? enableColumnBorderVertical,
@@ -665,10 +677,16 @@ class TrinaGridStyleConfig {
     BorderRadiusGeometry? gridPopupBorderRadius,
     double? gridPadding,
     double? gridBorderWidth,
+    double? cellVerticalBorderWidth,
+    double? cellHorizontalBorderWidth,
     Color? filterHeaderColor,
     Color? filterHeaderIconColor,
   }) {
     return TrinaGridStyleConfig(
+      cellVerticalBorderWidth:
+          cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
+      cellHorizontalBorderWidth:
+          cellHorizontalBorderWidth ?? this.cellHorizontalBorderWidth,
       enableGridBorderShadow:
           enableGridBorderShadow ?? this.enableGridBorderShadow,
       enableColumnBorderVertical:
@@ -804,6 +822,10 @@ class TrinaGridStyleConfig {
             gridPopupBorderRadius == other.gridPopupBorderRadius &&
             gridPadding == other.gridPadding &&
             gridBorderWidth == other.gridBorderWidth &&
+            cellVerticalBorderWidth == other.cellVerticalBorderWidth &&
+            cellHorizontalBorderWidth == other.cellHorizontalBorderWidth &&
+            filterHeaderColor == other.filterHeaderColor &&
+            filterHeaderIconColor == other.filterHeaderIconColor &&
             isDarkStyle == other.isDarkStyle;
   }
 
@@ -860,6 +882,8 @@ class TrinaGridStyleConfig {
         gridPopupBorderRadius,
         gridPadding,
         gridBorderWidth,
+        cellVerticalBorderWidth,
+        cellHorizontalBorderWidth,
         filterHeaderColor,
         filterHeaderIconColor,
         isDarkStyle

--- a/lib/src/trina_grid_settings.dart
+++ b/lib/src/trina_grid_settings.dart
@@ -30,11 +30,14 @@ abstract class TrinaGridSettings {
   /// Row - Default row height
   static const double rowHeight = 45.0;
 
-  /// Row - border width
-  static const double rowBorderWidth = 1.0;
+  /// Cell vertical border width (between rows)
+  static const double cellVerticalBorderWidth = 1.0;
+
+  /// Cell horizontal border width (between columns)
+  static const double cellHorizontalBorderWidth = 1.0;
 
   /// Row - total height
-  static const double rowTotalHeight = rowHeight + rowBorderWidth;
+  static const double rowTotalHeight = rowHeight + cellHorizontalBorderWidth;
 
   /// Cell - padding
   static const EdgeInsets cellPadding = EdgeInsets.symmetric(horizontal: 10);

--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -574,8 +574,8 @@ class _ColumnTextWidgetState extends TrinaStateWithChange<_ColumnTextWidget> {
               ),
               onPressed: _handleOnPressedFilter,
               constraints: BoxConstraints(
-                maxHeight:
-                    widget.height + (TrinaGridSettings.rowBorderWidth * 2),
+                maxHeight: widget.height +
+                    (widget.stateManager.style.cellHorizontalBorderWidth * 2),
               ),
             ),
           ),

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -303,7 +303,10 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
                 : null,
         border: enableCellVerticalBorder
             ? BorderDirectional(
-                end: BorderSide(color: borderColor, width: 1.0),
+                end: BorderSide(
+                  color: borderColor,
+                  width: stateManager.style.cellVerticalBorderWidth,
+                ),
               )
             : null,
       );

--- a/lib/src/ui/trina_base_row.dart
+++ b/lib/src/ui/trina_base_row.dart
@@ -74,8 +74,7 @@ class TrinaBaseRow extends StatelessWidget {
       stateManager: stateManager,
       rowIdx: rowIdx,
       row: row,
-      enableRowColorAnimation:
-          stateManager.configuration.style.enableRowColorAnimation,
+      enableRowColorAnimation: stateManager.style.enableRowColorAnimation,
       key: ValueKey('rowContainer_${row.key}'),
       child: visibilityLayout
           ? TrinaVisibilityLayout(
@@ -168,9 +167,10 @@ class _RowCellsLayoutDelegate extends MultiChildLayoutDelegate {
             width: width,
             height: stateManager.style.enableCellBorderHorizontal
                 ? stateManager.rowHeight
-                // we add `rowBorderWidth` to the row height so the cells are not
+                // we add `cellHorizontalBorderWidth` to the row height so the cells are not
                 // vertically-separated by the disabled horizontal border
-                : stateManager.rowHeight + TrinaGridSettings.rowBorderWidth,
+                : stateManager.rowHeight +
+                    stateManager.style.cellHorizontalBorderWidth,
           ),
         );
 
@@ -296,11 +296,11 @@ class _RowContainerWidgetState extends TrinaStateWithChange<_RowContainerWidget>
     final frozenBorder = widget.row.frozen != TrinaRowFrozen.none
         ? Border(
             top: BorderSide(
-              width: TrinaGridSettings.rowBorderWidth,
+              width: stateManager.configuration.style.cellHorizontalBorderWidth,
               color: stateManager.configuration.style.frozenRowBorderColor,
             ),
             bottom: BorderSide(
-              width: TrinaGridSettings.rowBorderWidth,
+              width: stateManager.configuration.style.cellHorizontalBorderWidth,
               color: stateManager.configuration.style.frozenRowBorderColor,
             ),
           )
@@ -312,21 +312,20 @@ class _RowContainerWidgetState extends TrinaStateWithChange<_RowContainerWidget>
           Border(
             top: isTopDragTarget
                 ? BorderSide(
-                    width: TrinaGridSettings.rowBorderWidth,
+                    width: stateManager.style.cellHorizontalBorderWidth,
                     color:
                         stateManager.configuration.style.activatedBorderColor,
                   )
                 : BorderSide.none,
             bottom: isBottomDragTarget
                 ? BorderSide(
-                    width: TrinaGridSettings.rowBorderWidth,
-                    color:
-                        stateManager.configuration.style.activatedBorderColor,
+                    width: stateManager.style.cellHorizontalBorderWidth,
+                    color: stateManager.style.activatedBorderColor,
                   )
-                : stateManager.configuration.style.enableCellBorderHorizontal
+                : stateManager.style.enableCellBorderHorizontal
                     ? BorderSide(
-                        width: TrinaGridSettings.rowBorderWidth,
-                        color: stateManager.configuration.style.borderColor,
+                        width: stateManager.style.cellHorizontalBorderWidth,
+                        color: stateManager.style.borderColor,
                       )
                     : BorderSide.none,
           ),

--- a/test/helper/row_helper.dart
+++ b/test/helper/row_helper.dart
@@ -64,7 +64,7 @@ class RowHelper {
     return TrinaCell(value: Random().nextInt(10000));
   }
 
-  static double resolveRowTotalHeight(double rowHeight) {
-    return rowHeight + TrinaGridSettings.rowBorderWidth;
+  static double resolveRowTotalHeight(TrinaGridStyleConfig style) {
+    return style.rowHeight + style.cellHorizontalBorderWidth;
   }
 }

--- a/test/scenario/configuration/behavior_setting_row_height_test.dart
+++ b/test/scenario/configuration/behavior_setting_row_height_test.dart
@@ -65,11 +65,12 @@ void main() {
     const rowHeight = 90.0;
 
     buildRowsWithSettingRowHeight(rowHeight: rowHeight).test(
-      'When rowHeight is set to 90, rowTotalHeight should be 90 + TrinaDefaultSettings.rowBorderWidth',
+      'When rowHeight is set to 90, rowTotalHeight should be 90 + cellHorizontalBorderWidth',
       (tester) async {
         expect(
           stateManager!.rowTotalHeight,
-          rowHeight + TrinaGridSettings.rowBorderWidth,
+          rowHeight +
+              stateManager!.configuration.style.cellHorizontalBorderWidth,
         );
       },
     );
@@ -114,7 +115,7 @@ void main() {
             .descendant(of: popupGrid, matching: find.byType(TrinaBaseCell))
             .first);
 
-        // Check the height of the select popup 
+        // Check the height of the select popup
         expect(cellPopupSize.height, rowHeight);
       },
     );

--- a/test/src/manager/trina_grid_key_manager_test.dart
+++ b/test/src/manager/trina_grid_key_manager_test.dart
@@ -21,9 +21,7 @@ void main() {
     when(stateManager.configuration).thenReturn(configuration);
     when(stateManager.keyPressed).thenReturn(TrinaGridKeyPressed());
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
+      RowHelper.resolveRowTotalHeight(stateManager.configuration.style),
     );
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.gridFocusNode).thenReturn(FocusNode());

--- a/test/src/ui/cells/trina_currency_cell_test.dart
+++ b/test/src/ui/cells/trina_currency_cell_test.dart
@@ -27,9 +27,7 @@ void main() {
       stateManager.configuration.style.columnHeight,
     );
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
+      RowHelper.resolveRowTotalHeight(stateManager.configuration.style),
     );
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.keepFocus).thenReturn(true);

--- a/test/src/ui/cells/trina_date_cell_test.dart
+++ b/test/src/ui/cells/trina_date_cell_test.dart
@@ -28,9 +28,7 @@ void main() {
       stateManager.configuration.style.columnHeight,
     );
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
+      RowHelper.resolveRowTotalHeight(stateManager.configuration.style),
     );
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.keepFocus).thenReturn(true);

--- a/test/src/ui/cells/trina_default_cell_test.dart
+++ b/test/src/ui/cells/trina_default_cell_test.dart
@@ -35,10 +35,7 @@ void main() {
     when(stateManager.configuration).thenReturn(const TrinaGridConfiguration());
     when(stateManager.keyPressed).thenReturn(TrinaGridKeyPressed());
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
-    );
+        RowHelper.resolveRowTotalHeight(stateManager.configuration.style));
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.keepFocus).thenReturn(true);
     when(stateManager.hasFocus).thenReturn(true);

--- a/test/src/ui/cells/trina_select_cell_test.dart
+++ b/test/src/ui/cells/trina_select_cell_test.dart
@@ -34,10 +34,7 @@ void main() {
       stateManager.configuration.style.columnHeight,
     );
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
-    );
+        RowHelper.resolveRowTotalHeight(stateManager.configuration.style));
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.keepFocus).thenReturn(true);
     when(stateManager.hasFocus).thenReturn(true);

--- a/test/src/ui/cells/trina_time_cell_test.dart
+++ b/test/src/ui/cells/trina_time_cell_test.dart
@@ -19,10 +19,7 @@ void main() {
     when(stateManager.style).thenReturn(configuration.style);
     when(stateManager.keyPressed).thenReturn(TrinaGridKeyPressed());
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
-    );
+        RowHelper.resolveRowTotalHeight(stateManager.configuration.style));
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.keepFocus).thenReturn(true);
     when(stateManager.hasFocus).thenReturn(true);

--- a/test/src/ui/trina_base_cell_test.dart
+++ b/test/src/ui/trina_base_cell_test.dart
@@ -5,8 +5,8 @@ import 'package:trina_grid/trina_grid.dart';
 import 'package:trina_grid/src/ui/ui.dart';
 import 'package:rxdart/rxdart.dart';
 
-import '../../helper/trina_widget_test_helper.dart';
 import '../../helper/row_helper.dart';
+import '../../helper/trina_widget_test_helper.dart';
 import '../../matcher/trina_object_matcher.dart';
 import '../../mock/shared_mocks.mocks.dart';
 
@@ -37,10 +37,7 @@ void main() {
       stateManager.configuration.style.columnHeight,
     );
     when(stateManager.rowTotalHeight).thenReturn(
-      RowHelper.resolveRowTotalHeight(
-        stateManager.configuration.style.rowHeight,
-      ),
-    );
+        RowHelper.resolveRowTotalHeight(stateManager.configuration.style));
     when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
     when(stateManager.gridFocusNode).thenReturn(FocusNode());
     when(stateManager.keepFocus).thenReturn(true);
@@ -829,7 +826,7 @@ void main() {
       final cellFinder = find.byType(TrinaBaseCell).first;
 
       final size = tester.getSize(cellFinder);
-      expect(size.height, TrinaGridSettings.rowTotalHeight);
+      expect(size.height, stateManager.rowTotalHeight);
     });
   });
 }

--- a/test/src/ui/trina_base_row_test.dart
+++ b/test/src/ui/trina_base_row_test.dart
@@ -130,7 +130,7 @@ void main() {
 
       expect(
         rowContainerDecoration.border!.top.width,
-        TrinaGridSettings.rowBorderWidth,
+        stateManager.configuration.style.cellHorizontalBorderWidth,
       );
     },
   );
@@ -153,7 +153,7 @@ void main() {
 
       expect(
         rowContainerDecoration.border!.bottom.width,
-        TrinaGridSettings.rowBorderWidth,
+        stateManager.configuration.style.cellHorizontalBorderWidth,
       );
     },
   );


### PR DESCRIPTION
## Purpose

This PR aims to provide a config to set cell border width (vertical & horizontal)

## Changes

- Added `cellVerticalBorderWidth` and `cellHorizontalBorderWidth` to `TrinaGridStyleConfig`
- Removed `TrinaGridSettings.rowBorderWidth` and replaced it with the appropriate border width config.
- Edited configuration wiki-doc with new feature.

## Related Issue

- close #73 