### PR TITLE
Fix column sorting and reordering when `titleRenderer` is provided

### DIFF
--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -157,16 +157,25 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
     // If a custom title renderer is provided, use it
     if (widget.column.hasTitleRenderer) {
       final rendererContext = _createTitleRendererContext(contextMenuIcon);
-      final customTitleWidget = widget.column.titleRenderer!(rendererContext);
+      Widget customTitleWidget = widget.column.titleRenderer!(rendererContext);
 
       // Ensure dragging functionality works with custom renderer
-      return widget.column.enableColumnDrag
-          ? _DraggableWidget(
-              stateManager: stateManager,
-              column: widget.column,
-              child: customTitleWidget,
-            )
-          : customTitleWidget;
+      if (widget.column.enableColumnDrag) {
+        customTitleWidget = _DraggableWidget(
+          stateManager: stateManager,
+          column: widget.column,
+          child: customTitleWidget,
+        );
+      }
+      // If enabled, add sorting functionality
+      if (widget.column.enableSorting) {
+        customTitleWidget = _SortableWidget(
+          stateManager: stateManager,
+          column: widget.column,
+          child: customTitleWidget,
+        );
+      }
+      return customTitleWidget;
     }
 
     return Stack(

--- a/test/src/ui/columns/trina_column_title_test.dart
+++ b/test/src/ui/columns/trina_column_title_test.dart
@@ -743,4 +743,78 @@ void main() {
       },
     );
   });
+  group('with titleRenderer', () {
+    final customTitleWidget = Text('Custom Title');
+    final originalTitleText = 'original title';
+
+    aColumnWithTitleRenderer({
+      bool enableSorting = true,
+      bool enableColumnDrag = true,
+    }) =>
+        TrinaWidgetTestHelper(
+          'a column with titleRenderer ',
+          (widgetTester) async {
+            final TrinaColumn column = TrinaColumn(
+              title: originalTitleText,
+              field: 'column_field_name',
+              type: TrinaColumnType.text(),
+              enableColumnDrag: enableColumnDrag,
+              enableSorting: enableSorting,
+              titleRenderer: (context) => customTitleWidget,
+            );
+            await widgetTester.pumpWidget(buildApp(column: column));
+          },
+        );
+
+    aColumnWithTitleRenderer().test(
+      'Custom title renderer should be used when provided',
+      (WidgetTester tester) async {
+        // then
+        expect(find.byWidget(customTitleWidget), findsOneWidget);
+        expect(find.text(originalTitleText), findsNothing);
+      },
+    );
+    aColumnWithTitleRenderer(enableSorting: true).test(
+      'When enableSorting is true and titleRenderer is provided, '
+      'tapping title should call toggleSortColumn function',
+      (WidgetTester tester) async {
+        // act
+        await tester.tap(find.byKey(sortableGestureKey));
+        // assert
+        verify(stateManager.toggleSortColumn(captureAny)).called(1);
+      },
+    );
+
+    aColumnWithTitleRenderer(enableSorting: false).test(
+        'When enableSorting is false and titleRender is provided, '
+        'GestureDetector widget should not exist', (WidgetTester tester) async {
+      // given
+      Finder gestureDetector = find.byKey(sortableGestureKey);
+
+      // then
+      expect(gestureDetector, findsNothing);
+
+      verifyNever(stateManager.toggleSortColumn(captureAny));
+    });
+
+    aColumnWithTitleRenderer(enableColumnDrag: false).test(
+        'WHEN enableColumnDrag is false '
+        'THEN Draggable should not be visible', (WidgetTester tester) async {
+      // then
+      final draggable = find.byType(Draggable);
+
+      expect(draggable, findsNothing);
+    });
+
+    aColumnWithTitleRenderer(enableColumnDrag: true).test(
+        'WHEN enableDraggable is true '
+        'THEN Draggable should be visible', (WidgetTester tester) async {
+      // then
+      final draggable = find.byType(
+        TestHelperUtil.typeOf<Draggable<TrinaColumn>>(),
+      );
+
+      expect(draggable, findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Purpose

When a title renderer is provided for `TrinaColumn`, the following issues are present (As shown in the vid below):

1. When `enableSorting` is true, clicking on the title doesn't activate the sorting functionality.
2. When `enableColumnDrag` is true, columns can be dragged but not reordered.

https://github.com/user-attachments/assets/baae112b-98f3-4d55-9f46-28dd40e650ff

## Changes

- When `enableColumnDrag` is true, wrap the custom title widget in a `DragTarget`.
- Refactored code to remove duplications and improve clarity.
- Added widget test to ensure sorting and reordering functions work correctly when `TrinaColumn.titleRenderer` is provided.

### Demo (with issues fixed)

https://github.com/user-attachments/assets/2523b527-9629-4dfa-aa8b-f53b9bdcb471


## Related Issues

- fix #63 


---

_Thank You_