### PR TITLE
fix: unregistered key events do not function when grid in focus

### DIFF
--- a/lib/src/manager/trina_grid_key_manager.dart
+++ b/lib/src/manager/trina_grid_key_manager.dart
@@ -15,24 +15,17 @@ import 'package:rxdart/rxdart.dart';
 /// arrow keys, backspace, etc. are not input (characters are input normally)
 /// https://github.com/flutter/flutter/issues/93873
 class TrinaGridKeyEventResult {
-  bool _skip = false;
+  bool _handled = false;
 
-  bool get isSkip => _skip;
+  /// Returns `true` if the event is handled by the grid.
+  bool get isHandled => _handled;
 
-  KeyEventResult skip(KeyEventResult result) {
-    _skip = true;
-
-    return result;
-  }
-
-  KeyEventResult consume(KeyEventResult result) {
-    if (_skip) {
-      _skip = false;
-
-      return KeyEventResult.ignored;
-    }
-
-    return result;
+  /// Sets the handled state of the event.
+  ///
+  /// If `true`, the event is considered consumed by the grid.
+  /// If `false`, the event is ignored, allowing it to propagate.
+  set handled(bool handled) {
+    _handled = handled;
   }
 }
 
@@ -41,9 +34,7 @@ class TrinaGridKeyManager {
 
   TrinaGridKeyEventResult eventResult = TrinaGridKeyEventResult();
 
-  TrinaGridKeyManager({
-    required this.stateManager,
-  });
+  TrinaGridKeyManager({required this.stateManager});
 
   final PublishSubject<TrinaKeyManagerEvent> _subject =
       PublishSubject<TrinaKeyManagerEvent>();
@@ -63,28 +54,35 @@ class TrinaGridKeyManager {
   void init() {
     final normalStream = _subject.stream.where((event) => !event.needsThrottle);
 
-    final movingStream =
-        _subject.stream.where((event) => event.needsThrottle).transform(
-              ThrottleStreamTransformer(
-                // ignore: void_checks
-                (e) => TimerStream(e, const Duration(milliseconds: 1)),
-              ),
-            );
+    final movingStream = _subject.stream
+        .where((event) => event.needsThrottle)
+        .transform(
+          ThrottleStreamTransformer(
+            // ignore: void_checks
+            (e) => TimerStream(e, const Duration(milliseconds: 1)),
+          ),
+        );
 
     _subscription = MergeStream([normalStream, movingStream]).listen(_handler);
   }
 
   void _handler(TrinaKeyManagerEvent keyEvent) {
-    if (keyEvent.isKeyUpEvent) return;
+    if (keyEvent.isKeyUpEvent) {
+      eventResult.handled = false;
+      return;
+    }
 
+    // If a registered shortcut handles the event, mark it as handled and stop.
     if (stateManager.configuration.shortcut.handle(
       keyEvent: keyEvent,
       stateManager: stateManager,
       state: HardwareKeyboard.instance,
     )) {
+      eventResult.handled = true;
       return;
     }
 
+    // If no shortcut was triggered, process default actions (e.g., character input).
     _handleDefaultActions(keyEvent);
   }
 

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -695,13 +695,13 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       }
     }
 
-    if (_keyManager.eventResult.isSkip == false) {
-      _keyManager.subject.add(
-        TrinaKeyManagerEvent(focusNode: focusNode, event: event),
-      );
-    }
+    _keyManager.subject.add(
+      TrinaKeyManagerEvent(focusNode: focusNode, event: event),
+    );
 
-    return _keyManager.eventResult.consume(KeyEventResult.handled);
+    return _keyManager.eventResult.isHandled
+        ? KeyEventResult.handled
+        : KeyEventResult.ignored;
   }
 
   @override

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -192,9 +192,8 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
 
     // Movement and enter key, non-editable cell left and right movement, etc. key input is propagated to text field.
     if (skip) {
-      return widget.stateManager.keyManager!.eventResult.skip(
-        KeyEventResult.ignored,
-      );
+      widget.stateManager.keyManager!.eventResult.handled = false;
+      return KeyEventResult.ignored;
     }
 
     if (_debounce.isDebounced(

--- a/lib/src/ui/columns/trina_column_filter.dart
+++ b/lib/src/ui/columns/trina_column_filter.dart
@@ -157,9 +157,8 @@ class TrinaColumnFilterState extends TrinaStateWithChange<TrinaColumnFilter> {
         stateManager.configuration.enterKeyAction;
 
     if (enterKeyAction.isNone) {
-      return stateManager.keyManager!.eventResult.skip(
-        KeyEventResult.ignored,
-      );
+      stateManager.keyManager!.eventResult.handled = false;
+      return KeyEventResult.ignored;
     }
 
     if (keyManager.isKeyUpEvent) {
@@ -167,9 +166,8 @@ class TrinaColumnFilterState extends TrinaStateWithChange<TrinaColumnFilter> {
     }
     // If it's Enter key and the action is none, handle it here
     if (keyManager.isEnter && enterKeyAction.isNone) {
-      return stateManager.keyManager!.eventResult.skip(
-        KeyEventResult.ignored,
-      );
+      stateManager.keyManager!.eventResult.handled = false;
+      return KeyEventResult.ignored;
     }
 
     final handleMoveDown = (keyManager.isDown ||
@@ -187,9 +185,8 @@ class TrinaColumnFilterState extends TrinaStateWithChange<TrinaColumnFilter> {
         return KeyEventResult.handled;
       }
 
-      return stateManager.keyManager!.eventResult.skip(
-        KeyEventResult.ignored,
-      );
+      stateManager.keyManager!.eventResult.handled = false;
+      return KeyEventResult.ignored;
     }
 
     if (handleMoveDown) {

--- a/test/src/manager/trina_grid_key_manager_test.dart
+++ b/test/src/manager/trina_grid_key_manager_test.dart
@@ -31,6 +31,45 @@ void main() {
     keyboardFocusNode = FocusNode();
   });
 
+  group('Key Event Propagation', () {
+    testWidgets(
+      'should not handle an unregistered key event, allowing it to propagate.',
+      (WidgetTester tester) async {
+        // given
+        final TrinaGridKeyManager keyManager = TrinaGridKeyManager(
+          stateManager: stateManager,
+        );
+        keyManager.init();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: KeyboardListener(
+                onKeyEvent: (event) {
+                  keyManager.subject.add(TrinaKeyManagerEvent(
+                    focusNode: FocusNode(),
+                    event: event,
+                  ));
+                },
+                focusNode: keyboardFocusNode,
+                child: const TextField(),
+              ),
+            ),
+          ),
+        );
+
+        // when
+        keyboardFocusNode.requestFocus();
+        await tester.sendKeyEvent(LogicalKeyboardKey.f5);
+        await tester.pump();
+
+        // then
+        // The key manager should not handle the event, allowing it to propagate.
+        expect(keyManager.eventResult.isHandled, isFalse);
+      },
+    );
+  });
+
   testWidgets(
     'Ctrl + C',
     (WidgetTester tester) async {


### PR DESCRIPTION
## Describtion

This PR fixes a bug where the grid would consume all keyboard events, preventing default platform shortcuts (like F5 for refresh in a browser) from working.

### The Problem

When the grid has focus, it incorrectly "handle" every key press, even if no specific grid action was linked to it. This blocks the event from propagating to the browser or OS.

**Example:**
1.  When a cell is focused, a user presses a key not handled by the grid (e.g., `F5`).
2.  The `TrinaGridKeyManager` receives the event but finds no matching shortcut.
3.  The old logic in `TrinaGridKeyManager` handler did not explicitly mark the event to be skipped. The `_skip` flag in `TrinaGridKeyEventResult` remained `false`:

    ```dart
        // In old TrinaGridKeyManager
        // skip was not updated in case of the event was handled or not
        if (stateManager.configuration.shortcut.handle(
          keyEvent: keyEvent,
          stateManager: stateManager,
          state: HardwareKeyboard.instance,
        )) {
          return;
        }
    ```
4.  The `consume` method was then called in `_handleGridFocusOnKey`. Since `_skip` is false (was false and wasn't updated), it returned the `KeyEventResult.handled` passed into it:

    ```dart
    // In old TrinaGridKeyEventResult
    KeyEventResult consume(KeyEventResult result) {
      if (_skip) { // This is false
        _skip = false;
        return KeyEventResult.ignored;
      }
      return result; // Returns KeyEventResult.handled
    }
    ```

5.  The `_handleGridFocusOnKey` method in `trina_grid.dart` would then return `KeyEventResult.handled`, "swallowing" the event:

    ```dart
    // In old TrinaGridState
    return _keyManager.eventResult.consume(KeyEventResult.handled);
    ```

6.  As a result, the browser never received the key press, and the refresh action was blocked.

### The Solution

The event handling logic has been refactored to correctly identify and propagate unhandled events.

1.  **Explicit `isHandled` Flag:** The `TrinaGridKeyEventResult` now uses a clear boolean `isHandled` flag, which defaults to `false`.
2.  **Targeted Handling:** `TrinaGridKeyManager` now sets `isHandled = true` **only if** a registered grid shortcut is successfully executed.
3.  **Correct Propagation:** The `_handleGridFocusOnKey` method in `trina_grid.dart` now checks `isHandled` and returns `KeyEventResult.ignored` if the flag is `false`, allowing the event to pass through:
    ```dart
    // In new TrinaGridState
    return _keyManager.eventResult.isHandled
        ? KeyEventResult.handled
        : KeyEventResult.ignored;
    ```
 
 ### Related Issues
 
- close #123 
