### PR TITLE
fix(#126): cannot scroll with touch on windows

### DIFF
--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:trina_grid/src/widgets/trina_horizontal_scroll_bar.dart';
@@ -203,62 +204,73 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
               children: [
                 // Main grid content
                 Expanded(
-                  child: SingleChildScrollView(
-                    controller: _horizontalScroll,
-                    scrollDirection: Axis.horizontal,
-                    physics: const ClampingScrollPhysics(),
-                    child: CustomSingleChildLayout(
-                      delegate: ListResizeDelegate(stateManager, _columns),
-                      child: Column(
-                        children: [
-                          // Frozen top rows
-                          if (_frozenTopRows.isNotEmpty)
-                            Column(
-                              children: _frozenTopRows
-                                  .asMap()
-                                  .entries
-                                  .map(
-                                    (e) => _buildRow(context, e.value, e.key),
-                                  )
-                                  .toList(),
-                            ),
-                          // Scrollable rows
-                          Expanded(
-                            child: ListView.builder(
-                              cacheExtent: stateManager.rowsCacheExtent,
-                              controller: _verticalScroll,
-                              scrollDirection: Axis.vertical,
-                              physics: const ClampingScrollPhysics(),
-                              itemCount: _scrollableRows.length,
-                              itemExtent: stateManager.rowWrapper != null
-                                  ? null
-                                  : stateManager.rowTotalHeight,
-                              addRepaintBoundaries: false,
-                              itemBuilder: (ctx, i) => _buildRow(
-                                context,
-                                _scrollableRows[i],
-                                i + _frozenTopRows.length,
+                  child: ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context).copyWith(
+                      dragDevices: <PointerDeviceKind>{
+                        PointerDeviceKind.touch,
+                        PointerDeviceKind.stylus,
+                        PointerDeviceKind.invertedStylus,
+                        PointerDeviceKind.trackpad,
+                        PointerDeviceKind.unknown,
+                      },
+                    ),
+                    child: SingleChildScrollView(
+                      controller: _horizontalScroll,
+                      scrollDirection: Axis.horizontal,
+                      physics: const ClampingScrollPhysics(),
+                      child: CustomSingleChildLayout(
+                        delegate: ListResizeDelegate(stateManager, _columns),
+                        child: Column(
+                          children: [
+                            // Frozen top rows
+                            if (_frozenTopRows.isNotEmpty)
+                              Column(
+                                children: _frozenTopRows
+                                    .asMap()
+                                    .entries
+                                    .map(
+                                      (e) => _buildRow(context, e.value, e.key),
+                                    )
+                                    .toList(),
+                              ),
+                            // Scrollable rows
+                            Expanded(
+                              child: ListView.builder(
+                                cacheExtent: stateManager.rowsCacheExtent,
+                                controller: _verticalScroll,
+                                scrollDirection: Axis.vertical,
+                                physics: const ClampingScrollPhysics(),
+                                itemCount: _scrollableRows.length,
+                                itemExtent: stateManager.rowWrapper != null
+                                    ? null
+                                    : stateManager.rowTotalHeight,
+                                addRepaintBoundaries: false,
+                                itemBuilder: (ctx, i) => _buildRow(
+                                  context,
+                                  _scrollableRows[i],
+                                  i + _frozenTopRows.length,
+                                ),
                               ),
                             ),
-                          ),
-                          // Frozen bottom rows
-                          if (_frozenBottomRows.isNotEmpty)
-                            Column(
-                              children: _frozenBottomRows
-                                  .asMap()
-                                  .entries
-                                  .map(
-                                    (e) => _buildRow(
-                                      context,
-                                      e.value,
-                                      e.key +
-                                          _frozenTopRows.length +
-                                          _scrollableRows.length,
-                                    ),
-                                  )
-                                  .toList(),
-                            ),
-                        ],
+                            // Frozen bottom rows
+                            if (_frozenBottomRows.isNotEmpty)
+                              Column(
+                                children: _frozenBottomRows
+                                    .asMap()
+                                    .entries
+                                    .map(
+                                      (e) => _buildRow(
+                                        context,
+                                        e.value,
+                                        e.key +
+                                            _frozenTopRows.length +
+                                            _scrollableRows.length,
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                          ],
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Purpose

- resolve #126 

## Changes

- Explicitly set supported drag devices for the scroll behavior of grid rows.