### PR TITLE
Resolve the package analysis issues on [Pub.dev] 

### DIFF
--- a/lib/src/model/trina_cell.dart
+++ b/lib/src/model/trina_cell.dart
@@ -193,7 +193,7 @@ class TrinaCell {
   }
 }
 
-_assertUnInitializedCell(bool flag) {
+void _assertUnInitializedCell(bool flag) {
   assert(
     flag,
     'TrinaCell is not initialized.'

--- a/lib/src/trina_dual_grid.dart
+++ b/lib/src/trina_dual_grid.dart
@@ -81,7 +81,7 @@ class TrinaDualGrid extends StatefulWidget {
 }
 
 class TrinaDualGridResizeNotifier extends ChangeNotifier {
-  resize() {
+  void resize() {
     notifyListeners();
   }
 }

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -410,7 +410,7 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// initializeDateFormatting();
   /// ```
   /// {@endtemplate}
-  static setDefaultLocale(String locale) {
+  static void setDefaultLocale(String locale) {
     Intl.defaultLocale = locale;
   }
 
@@ -418,7 +418,7 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// when you need to set date format when changing locale.
   ///
   /// {@macro intl_default_locale}
-  static initializeDateFormat() {
+  static void initializeDateFormat() {
     initializeDateFormatting();
   }
 

--- a/lib/src/trina_grid_popup.dart
+++ b/lib/src/trina_grid_popup.dart
@@ -109,7 +109,7 @@ class TrinaGridPopup {
     open();
   }
 
-  setColumnConfig() {
+  List<TrinaColumn> setColumnConfig() {
     columns.map((element) {
       if (configuration.style.filterHeaderColor != null) {
         element.backgroundColor = configuration.style.filterHeaderColor!;

--- a/lib/src/ui/trina_base_row.dart
+++ b/lib/src/ui/trina_base_row.dart
@@ -70,7 +70,12 @@ class TrinaBaseRow extends StatelessWidget {
     );
   }
 
-  Widget _dragTargetBuilder(dragContext, candidate, rejected) {
+// BuildContext, List<TrinaRow<dynamic>?>,
+  Widget _dragTargetBuilder(
+    BuildContext dragContext,
+    List<TrinaRow<dynamic>?> candidate,
+    List<dynamic> rejected,
+  ) {
     return _RowContainerWidget(
       stateManager: stateManager,
       rowIdx: rowIdx,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,15 +28,15 @@ dependencies:
     sdk: flutter
   # Follows the intl version included in Flutter.
   # https://github.com/flutter/flutter/blob/84a1e904f44f9b0e9c4510138010edcc653163f8/packages/flutter_localizations/pubspec.yaml#L11
-  intl: any
+  intl: ^0.20.2
   rxdart: ^0.28.0
-  collection: ^1.18.0
-  path: ^1.8.3
+  collection: ^1.19.1
+  path: ^1.9.1
   pdf: ^3.11.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.3
-  build_runner: ^2.4.7
-  flutter_lints: ^5.0.0
+  mockito: ^5.5.0
+  build_runner: ^2.6.0
+  flutter_lints: ^6.0.0


### PR DESCRIPTION
## Description

- The analysis below failed because TrinaGrid depends on `intl: any` and we use an API that was added in `v0.19.0` so we have to use a version >= 0.19.0.

<img width="1065" height="346" alt="Screenshot 2025-07-22 202618" src="https://github.com/user-attachments/assets/db7d12bd-913c-4be6-a4bd-f48c080da4fb" />

## Checklist

- I've run the tests and all is green ✅.
- The demo app builds successfully.