### PR TITLE
fix: `TrinaGridScrollbarConfig.dragDevices` is overridden

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -915,7 +915,14 @@ class TrinaGridScrollbarConfig {
   const TrinaGridScrollbarConfig({
     // Basic scrollbar behavior settings
     this.isAlwaysShown = false,
-    this.dragDevices,
+    this.dragDevices = const <PointerDeviceKind>{
+      PointerDeviceKind.touch,
+      PointerDeviceKind.stylus,
+      PointerDeviceKind.invertedStylus,
+      PointerDeviceKind.trackpad,
+      PointerDeviceKind.mouse,
+      PointerDeviceKind.unknown,
+    },
     this.isDraggable = true,
 
     // Advanced scrollbar appearance settings
@@ -937,7 +944,7 @@ class TrinaGridScrollbarConfig {
   final bool isAlwaysShown;
 
   /// Set of devices that can interact with the scrollbar
-  final Set<PointerDeviceKind>? dragDevices;
+  final Set<PointerDeviceKind> dragDevices;
 
   /// Whether scrollbar thumbs can be dragged with pointer devices
   final bool isDraggable;

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -920,7 +920,6 @@ class TrinaGridScrollbarConfig {
       PointerDeviceKind.stylus,
       PointerDeviceKind.invertedStylus,
       PointerDeviceKind.trackpad,
-      PointerDeviceKind.mouse,
       PointerDeviceKind.unknown,
     },
     this.isDraggable = true,
@@ -944,6 +943,12 @@ class TrinaGridScrollbarConfig {
   final bool isAlwaysShown;
 
   /// Set of devices that can interact with the scrollbar
+  ///
+  /// By default only [PointerDeviceKind.touch], [PointerDeviceKind.stylus],
+  /// [PointerDeviceKind.invertedStylus], and [PointerDeviceKind.trackpad]
+  /// are configured to create drag gestures.
+  ///
+  /// See [ScrollBehavior.dragDevices] for more information.
   final Set<PointerDeviceKind> dragDevices;
 
   /// Whether scrollbar thumbs can be dragged with pointer devices

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -204,73 +204,62 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
               children: [
                 // Main grid content
                 Expanded(
-                  child: ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context).copyWith(
-                      dragDevices: <PointerDeviceKind>{
-                        PointerDeviceKind.touch,
-                        PointerDeviceKind.stylus,
-                        PointerDeviceKind.invertedStylus,
-                        PointerDeviceKind.trackpad,
-                        PointerDeviceKind.unknown,
-                      },
-                    ),
-                    child: SingleChildScrollView(
-                      controller: _horizontalScroll,
-                      scrollDirection: Axis.horizontal,
-                      physics: const ClampingScrollPhysics(),
-                      child: CustomSingleChildLayout(
-                        delegate: ListResizeDelegate(stateManager, _columns),
-                        child: Column(
-                          children: [
-                            // Frozen top rows
-                            if (_frozenTopRows.isNotEmpty)
-                              Column(
-                                children: _frozenTopRows
-                                    .asMap()
-                                    .entries
-                                    .map(
-                                      (e) => _buildRow(context, e.value, e.key),
-                                    )
-                                    .toList(),
-                              ),
-                            // Scrollable rows
-                            Expanded(
-                              child: ListView.builder(
-                                cacheExtent: stateManager.rowsCacheExtent,
-                                controller: _verticalScroll,
-                                scrollDirection: Axis.vertical,
-                                physics: const ClampingScrollPhysics(),
-                                itemCount: _scrollableRows.length,
-                                itemExtent: stateManager.rowWrapper != null
-                                    ? null
-                                    : stateManager.rowTotalHeight,
-                                addRepaintBoundaries: false,
-                                itemBuilder: (ctx, i) => _buildRow(
-                                  context,
-                                  _scrollableRows[i],
-                                  i + _frozenTopRows.length,
-                                ),
+                  child: SingleChildScrollView(
+                    controller: _horizontalScroll,
+                    scrollDirection: Axis.horizontal,
+                    physics: const ClampingScrollPhysics(),
+                    child: CustomSingleChildLayout(
+                      delegate: ListResizeDelegate(stateManager, _columns),
+                      child: Column(
+                        children: [
+                          // Frozen top rows
+                          if (_frozenTopRows.isNotEmpty)
+                            Column(
+                              children: _frozenTopRows
+                                  .asMap()
+                                  .entries
+                                  .map(
+                                    (e) => _buildRow(context, e.value, e.key),
+                                  )
+                                  .toList(),
+                            ),
+                          // Scrollable rows
+                          Expanded(
+                            child: ListView.builder(
+                              cacheExtent: stateManager.rowsCacheExtent,
+                              controller: _verticalScroll,
+                              scrollDirection: Axis.vertical,
+                              physics: const ClampingScrollPhysics(),
+                              itemCount: _scrollableRows.length,
+                              itemExtent: stateManager.rowWrapper != null
+                                  ? null
+                                  : stateManager.rowTotalHeight,
+                              addRepaintBoundaries: false,
+                              itemBuilder: (ctx, i) => _buildRow(
+                                context,
+                                _scrollableRows[i],
+                                i + _frozenTopRows.length,
                               ),
                             ),
-                            // Frozen bottom rows
-                            if (_frozenBottomRows.isNotEmpty)
-                              Column(
-                                children: _frozenBottomRows
-                                    .asMap()
-                                    .entries
-                                    .map(
-                                      (e) => _buildRow(
-                                        context,
-                                        e.value,
-                                        e.key +
-                                            _frozenTopRows.length +
-                                            _scrollableRows.length,
-                                      ),
-                                    )
-                                    .toList(),
-                              ),
-                          ],
-                        ),
+                          ),
+                          // Frozen bottom rows
+                          if (_frozenBottomRows.isNotEmpty)
+                            Column(
+                              children: _frozenBottomRows
+                                  .asMap()
+                                  .entries
+                                  .map(
+                                    (e) => _buildRow(
+                                      context,
+                                      e.value,
+                                      e.key +
+                                          _frozenTopRows.length +
+                                          _scrollableRows.length,
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                        ],
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Changes

- Remove `ScrollConfiguration` in  `TrinaBodyRows` in which we override the dragDevices resulting in users not being able to set custom dragDevices.
- By default, allow scrolling with all drag devices except `PointerDeviceKind.mouse` (fix #126).

## Related Issues

- Fixes #132