### PR TITLE
Prevent entering edit mode on character key when filter has focus

### DIFF
--- a/lib/src/manager/trina_grid_key_manager.dart
+++ b/lib/src/manager/trina_grid_key_manager.dart
@@ -91,6 +91,12 @@ class TrinaGridKeyManager {
     final hasAllowedModifier =
         !keyEvent.isModifierPressed || keyEvent.isShiftPressed;
 
+    // If grid has yielded focus (e.g., a column filter TextField is focused),
+    // do not start editing from character input.
+    if (!stateManager.keepFocus) {
+      return;
+    }
+
     if (keyEvent.isCharacter && hasAllowedModifier) {
       _handleCharacter(keyEvent);
     }

--- a/test/scenario/filtering/column_filter_focus_test.dart
+++ b/test/scenario/filtering/column_filter_focus_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:trina_grid/src/ui/ui.dart';
+
+// No helper imports needed; build explicit demo-like columns/rows
+
+void main() {
+  late TrinaGridStateManager stateManager;
+
+  Widget buildGrid({
+    required List<TrinaColumn> columns,
+    required List<TrinaRow> rows,
+  }) {
+    return MaterialApp(
+      home: Material(
+        child: TrinaGrid(
+          columns: columns,
+          rows: rows,
+          onLoaded: (e) {
+            e.stateManager.setShowColumnFilter(true);
+            stateManager = e.stateManager;
+          },
+        ),
+      ),
+    );
+  }
+
+  Finder findFilterTextField() {
+    return find.descendant(
+      of: find.byType(TrinaColumnFilter),
+      matching: find.byType(TextField),
+    );
+  }
+
+  //
+  // Removed legacy test
+
+
+  testWidgets(
+    'Filter focus + character key should NOT enable editing',
+    (tester) async {
+      final columns = <TrinaColumn>[
+        TrinaColumn(title: 'Text', field: 'text', type: TrinaColumnType.text()),
+      ];
+      final rows = <TrinaRow>[
+        TrinaRow(cells: {'text': TrinaCell(value: 'Text value 0')}),
+        TrinaRow(cells: {'text': TrinaCell(value: 'Text value 1')}),
+      ];
+
+      await tester.pumpWidget(buildGrid(columns: columns, rows: rows));
+      await tester.pumpAndSettle();
+
+      // Click a grid cell once to establish currentCell
+      await tester.tap(find.text('Text value 0'));
+      await tester.pumpAndSettle();
+
+      // Focus the column filter TextField
+      final filter = findFilterTextField();
+      expect(filter, findsOneWidget);
+      await tester.tap(filter);
+      await tester.pumpAndSettle();
+
+      // Attach keyboard and send a character key event
+      await tester.showKeyboard(filter);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.pumpAndSettle();
+
+      // Grid should NOT enter editing from a character key when filter has focus
+      expect(stateManager.isEditing, isFalse);
+
+    },
+  );
+}


### PR DESCRIPTION
This PR fixes the issue below by preventing character input from entering a cell into edit mode when the filter column is focused.

[Bug] First character typed in a column filter input also edits the focused cell #164
