### PR TITLE
Feat: make `TrinaColumnTypeSelect` generic

### DIFF
--- a/demo/lib/dummy_data/development.dart
+++ b/demo/lib/dummy_data/development.dart
@@ -97,7 +97,7 @@ class DummyData {
     if (column.type.isNumber || column.type.isCurrency) {
       return faker.randomGenerator.decimal(scale: 1000000000, min: -500000000);
     } else if (column.type.isSelect) {
-      return (column.type.select.items.toList()..shuffle()).first;
+      return (column.type.asSelect().items.toList()..shuffle()).first;
     } else if (column.type.isDate) {
       return DateTime.now()
           .add(Duration(days: faker.randomGenerator.integer(365, min: -365)))

--- a/demo/lib/screen/feature/selection_type_column_screen.dart
+++ b/demo/lib/screen/feature/selection_type_column_screen.dart
@@ -129,7 +129,9 @@ class _SelectionTypeColumnScreenState extends State<SelectionTypeColumnScreen> {
           return DropdownButton<String>(
             value: cell.value,
             hint: Text(cell.value),
-            items: cell.column.type.select.items
+            items: cell.column.type
+                .asSelect()
+                .items
                 .map((e) => DropdownMenuItem<String>(value: e, child: Text(e)))
                 .toList(),
             onChanged: (value) {

--- a/lib/src/manager/state/cell_state.dart
+++ b/lib/src/manager/state/cell_state.dart
@@ -290,7 +290,7 @@ mixin CellState implements ITrinaGridState {
     if (typeResult.$1) return typeResult.$2;
 
     if (column.type.isSelect) {
-      return column.type.select.items.contains(newValue) == true
+      return column.type.asSelect().items.contains(newValue) == true
           ? newValue
           : oldValue;
     }

--- a/lib/src/model/column_types/trina_column_type_boolean.dart
+++ b/lib/src/model/column_types/trina_column_type_boolean.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_menu_popup.dart';
+import 'package:trina_grid/src/ui/cells/trina_boolean_cell.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 import 'package:trina_grid/trina_grid.dart';
 
@@ -10,7 +11,7 @@ import 'package:trina_grid/trina_grid.dart';
 /// `false`, `1`, `0`, 'true', 'false', and empty values.
 class TrinaColumnTypeBoolean
     with TrinaColumnTypeDefaultMixin
-    implements TrinaColumnType, TrinaColumnTypeHasMenuPopup {
+    implements TrinaColumnType, TrinaColumnTypeHasMenuPopup<bool?> {
   /// Creates a boolean column type with customizable behavior.
   TrinaColumnTypeBoolean({
     required this.defaultValue,
@@ -40,7 +41,7 @@ class TrinaColumnTypeBoolean
 
   /// {@macro TrinaColumnTypeHasMenuPopup.onItemSelected}
   @override
-  final void Function(dynamic)? onItemSelected;
+  final void Function(bool?)? onItemSelected;
 
   dynamic get value => defaultValue;
 
@@ -54,7 +55,7 @@ class TrinaColumnTypeBoolean
   TrinaDropdownMenuVariant get menuVariant => TrinaDropdownMenuVariant.select;
 
   @override
-  final ItemBuilder? menuItemBuilder;
+  final ItemBuilder<bool?>? menuItemBuilder;
 
   @override
   double get menuMaxHeight => 300;
@@ -161,4 +162,19 @@ class TrinaColumnTypeBoolean
 
   @override
   final Function(dynamic item)? itemToValue = null;
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaBooleanCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
+  }
 }

--- a/lib/src/model/column_types/trina_column_type_currency.dart
+++ b/lib/src/model/column_types/trina_column_type_currency.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
+import 'package:trina_grid/src/ui/cells/trina_currency_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeCurrency
@@ -51,4 +53,19 @@ class TrinaColumnTypeCurrency
 
   @override
   late final int decimalPoint;
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaCurrencyCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
+  }
 }

--- a/lib/src/model/column_types/trina_column_type_date.dart
+++ b/lib/src/model/column_types/trina_column_type_date.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart' as intl;
 import 'package:trina_grid/src/helper/trina_general_helper.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_date_format.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_popup_icon.dart';
+import 'package:trina_grid/src/ui/cells/trina_date_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeDate
@@ -102,5 +103,20 @@ class TrinaColumnTypeDate
     if (date == null) return '';
 
     return dateFormat.format(date);
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaDateCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/column_types/trina_column_type_date_time.dart
+++ b/lib/src/model/column_types/trina_column_type_date_time.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart' as intl;
 import 'package:trina_grid/src/helper/trina_general_helper.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_date_format.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_popup_icon.dart';
+import 'package:trina_grid/src/ui/cells/trina_date_time_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeDateTime
@@ -99,5 +100,20 @@ class TrinaColumnTypeDateTime
     if (date == null) return '';
 
     return dateFormat.format(date);
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaDateTimeCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/column_types/trina_column_type_number.dart
+++ b/lib/src/model/column_types/trina_column_type_number.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
+import 'package:trina_grid/src/ui/cells/trina_number_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeNumber
@@ -42,5 +44,20 @@ class TrinaColumnTypeNumber
     final int dotIndex = format.indexOf('.');
 
     return dotIndex < 0 ? 0 : format.substring(dotIndex).length - 1;
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaNumberCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/column_types/trina_column_type_percentage.dart
+++ b/lib/src/model/column_types/trina_column_type_percentage.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
+import 'package:trina_grid/src/ui/cells/trina_percentage_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypePercentage
@@ -127,6 +129,21 @@ class TrinaColumnTypePercentage
     } else {
       return formattedNumber / 100;
     }
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaPercentageCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }
 

--- a/lib/src/model/column_types/trina_column_type_select.dart
+++ b/lib/src/model/column_types/trina_column_type_select.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:trina_grid/src/helper/trina_general_helper.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_menu_popup.dart';
+import 'package:trina_grid/src/ui/cells/trina_select_cell.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 import 'package:trina_grid/trina_grid.dart';
 
@@ -10,9 +11,9 @@ import 'package:trina_grid/trina_grid.dart';
 /// to choose from options you provide. It is highly customizable, offering
 /// different menu styles (simple, with search, with filters) and allowing
 /// for custom rendering of the items in the list.
-class TrinaColumnTypeSelect
+class TrinaColumnTypeSelect<T>
     with TrinaColumnTypeDefaultMixin
-    implements TrinaColumnType, TrinaColumnTypeHasMenuPopup {
+    implements TrinaColumnType, TrinaColumnTypeHasMenuPopup<T> {
   /// Creates a select column type.
   const TrinaColumnTypeSelect({
     required this.items,
@@ -34,7 +35,7 @@ class TrinaColumnTypeSelect
   });
 
   @override
-  final dynamic defaultValue;
+  final T? defaultValue;
 
   @override
   final List<TrinaDropdownMenuFilter> menuFilters;
@@ -56,18 +57,18 @@ class TrinaColumnTypeSelect
 
   /// {@macro TrinaDropdownMenu.itemBuilder}
   @override
-  final ItemBuilder<dynamic>? menuItemBuilder;
+  final ItemBuilder<T>? menuItemBuilder;
 
   /// {@macro TrinaDropdownMenu.items}
   @override
-  final List<dynamic> items;
+  final List<T> items;
 
   /// Whether to enable the default column filtering UI for this column.
   final bool enableColumnFilter;
 
   /// {@macro TrinaDropdownMenu.onItemSelected}
   @override
-  final void Function(dynamic item)? onItemSelected;
+  final void Function(T item)? onItemSelected;
 
   /// {@macro TrinaDropdownMenu.filtersInitiallyExpanded}
   @override
@@ -81,11 +82,11 @@ class TrinaColumnTypeSelect
 
   /// {@macro TrinaDropdownMenu.itemToString}
   @override
-  final String Function(dynamic item)? itemToString;
+  final String Function(T item)? itemToString;
 
   /// {@macro TrinaDropdownMenu.itemToValue}
   @override
-  final dynamic Function(dynamic item)? itemToValue;
+  final dynamic Function(T item)? itemToValue;
 
   /// {@macro TrinaDropdownMenu.emptyFilterResultBuilder}
   @override
@@ -111,5 +112,20 @@ class TrinaColumnTypeSelect
   @override
   dynamic makeCompareValue(dynamic v) {
     return v;
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaSelectCell<T>(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/column_types/trina_column_type_text.dart
+++ b/lib/src/model/column_types/trina_column_type_text.dart
@@ -1,5 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:trina_grid/src/helper/trina_general_helper.dart';
-import 'package:trina_grid/src/model/trina_column_type.dart';
+import 'package:trina_grid/src/ui/cells/trina_text_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeText
@@ -27,5 +28,20 @@ class TrinaColumnTypeText
   @override
   dynamic makeCompareValue(dynamic v) {
     return v.toString();
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaTextCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/column_types/trina_column_type_time.dart
+++ b/lib/src/model/column_types/trina_column_type_time.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:trina_grid/src/helper/trina_general_helper.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_popup_icon.dart';
+import 'package:trina_grid/src/ui/cells/trina_time_cell.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 class TrinaColumnTypeTime
@@ -73,5 +74,20 @@ class TrinaColumnTypeTime
   @override
   dynamic makeCompareValue(dynamic v) {
     return v;
+  }
+
+  @override
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  ) {
+    return TrinaTimeCell(
+      stateManager: stateManager,
+      cell: cell,
+      column: column,
+      row: row,
+    );
   }
 }

--- a/lib/src/model/trina_column_type.dart
+++ b/lib/src/model/trina_column_type.dart
@@ -148,20 +148,20 @@ abstract interface class TrinaColumnType {
   /// - [itemToValue]:
   ///   {@macro TrinaDropdownMenu.itemToValue}
   ///
-  factory TrinaColumnType.select(
-    List items, {
-    void Function(dynamic item)? onItemSelected,
-    dynamic defaultValue = '',
+  static TrinaColumnType select<T>(
+    List<T> items, {
+    void Function(T item)? onItemSelected,
+    T? defaultValue,
     bool enableColumnFilter = false,
     IconData? popupIcon = Icons.arrow_drop_down,
     double? menuWidth,
     double menuItemHeight = 40,
     double menuMaxHeight = 300,
-    ItemBuilder<dynamic>? menuItemBuilder,
-    String Function(dynamic item)? itemToString,
-    dynamic Function(dynamic item)? itemToValue,
+    ItemBuilder<T>? menuItemBuilder,
+    String Function(T item)? itemToString,
+    dynamic Function(T item)? itemToValue,
   }) {
-    return TrinaColumnTypeSelect(
+    return TrinaColumnTypeSelect<T>(
       menuVariant: TrinaDropdownMenuVariant.select,
       onItemSelected: onItemSelected,
       defaultValue: defaultValue,
@@ -204,21 +204,21 @@ abstract interface class TrinaColumnType {
   ///   {@macro TrinaDropdownMenu.itemToString}
   /// - [itemToValue]:
   ///   {@macro TrinaDropdownMenu.itemToValue}
-  factory TrinaColumnType.selectWithSearch(
-    List items, {
-    required String Function(dynamic item) itemToString,
-    dynamic defaultValue = '',
+  static TrinaColumnType selectWithSearch<T>(
+    List<T> items, {
+    required String Function(T item) itemToString,
+    T? defaultValue,
     bool enableColumnFilter = false,
     IconData? popupIcon = Icons.arrow_drop_down,
-    ItemBuilder<dynamic>? menuItemBuilder,
+    ItemBuilder<T>? menuItemBuilder,
     double? menuWidth,
     double menuItemHeight = 40,
     double menuMaxHeight = 300,
-    void Function(dynamic item)? onItemSelected,
+    void Function(T item)? onItemSelected,
     WidgetBuilder? menuEmptySearchResultBuilder,
-    dynamic Function(dynamic item)? itemToValue,
+    dynamic Function(T item)? itemToValue,
   }) {
-    return TrinaColumnTypeSelect(
+    return TrinaColumnTypeSelect<T>(
       onItemSelected: onItemSelected,
       defaultValue: defaultValue,
       items: items,
@@ -263,23 +263,23 @@ abstract interface class TrinaColumnType {
   ///   {@macro TrinaDropdownMenu.itemToString}
   /// - [itemToValue]:
   ///   {@macro TrinaDropdownMenu.itemToValue}
-  factory TrinaColumnType.selectWithFilters(
-    List items, {
+  static TrinaColumnType selectWithFilters<T>(
+    List<T> items, {
     required List<TrinaDropdownMenuFilter> menuFilters,
-    dynamic defaultValue = '',
+    T? defaultValue,
     bool enableColumnFilter = false,
     IconData? popupIcon = Icons.arrow_drop_down,
-    ItemBuilder<dynamic>? menuItemBuilder,
+    ItemBuilder<T>? menuItemBuilder,
     WidgetBuilder? menuEmptyFilterResultBuilder,
     double? menuWidth,
     double menuItemHeight = 40,
     double menuMaxHeight = 300,
     bool menuFiltersInitiallyExpanded = true,
-    void Function(dynamic item)? onItemSelected,
-    String Function(dynamic item)? itemToString,
-    dynamic Function(dynamic item)? itemToValue,
+    void Function(T item)? onItemSelected,
+    String Function(T item)? itemToString,
+    dynamic Function(T item)? itemToValue,
   }) {
-    return TrinaColumnTypeSelect(
+    return TrinaColumnTypeSelect<T>(
       items: items,
       menuVariant: TrinaDropdownMenuVariant.selectWithFilters,
       defaultValue: defaultValue,
@@ -438,6 +438,13 @@ abstract interface class TrinaColumnType {
   /// new cell value.
   /// If `false`, the original `newValue` is used.
   (bool, dynamic) filteredValue({dynamic newValue, dynamic oldValue});
+
+  Widget buildCell(
+    TrinaGridStateManager stateManager,
+    TrinaCell cell,
+    TrinaColumn column,
+    TrinaRow row,
+  );
 }
 
 /// A mixin that provides a default implementation for [TrinaColumnType.filteredValue].

--- a/lib/src/model/trina_column_type_extension.dart
+++ b/lib/src/model/trina_column_type_extension.dart
@@ -47,11 +47,11 @@ extension TrinaColumnTypeExtension on TrinaColumnType {
     return this as TrinaColumnTypeBoolean;
   }
 
-  TrinaColumnTypeSelect get select {
+  TrinaColumnTypeSelect<T> asSelect<T>() {
     if (this is! TrinaColumnTypeSelect) {
       throw TypeError();
     }
-    return this as TrinaColumnTypeSelect;
+    return this as TrinaColumnTypeSelect<T>;
   }
 
   TrinaColumnTypeDate get date {

--- a/lib/src/model/trina_column_type_has_menu_popup.dart
+++ b/lib/src/model/trina_column_type_has_menu_popup.dart
@@ -6,12 +6,12 @@ import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 ///
 /// This interface should be implemented by column types that want to use
 /// [TrinaPopupCellStateWithMenu] for their cell's state.
-abstract class TrinaColumnTypeHasMenuPopup {
+abstract class TrinaColumnTypeHasMenuPopup<T> {
   /// The icon to display in the popup cell.
   IconData? get popupIcon;
 
   /// {@macro TrinaDropdownMenu.items}
-  List<dynamic> get items;
+  List<T> get items;
 
   /// {@macro TrinaDropdownMenu.variant}
   TrinaDropdownMenuVariant get menuVariant;
@@ -26,19 +26,19 @@ abstract class TrinaColumnTypeHasMenuPopup {
   double? get menuWidth;
 
   /// {@macro TrinaDropdownMenu.itemBuilder}
-  ItemBuilder<dynamic>? get menuItemBuilder;
+  ItemBuilder<T>? get menuItemBuilder;
 
   /// {@macro TrinaDropdownMenu.filters}
   List<TrinaDropdownMenuFilter> get menuFilters;
 
   /// {@macro TrinaDropdownMenu.itemToString}
-  String Function(dynamic item)? get itemToString;
+  String Function(T item)? get itemToString;
 
   /// {@macro TrinaDropdownMenu.filtersInitiallyExpanded}
   bool get menuFiltersInitiallyExpanded;
 
   /// {@macro TrinaDropdownMenu.itemToValue}
-  dynamic Function(dynamic item)? get itemToValue;
+  dynamic Function(T item)? get itemToValue;
 
   /// {@macro TrinaDropdownMenu.emptyFilterResultBuilder}
   WidgetBuilder? get menuEmptyFilterResultBuilder;
@@ -49,5 +49,5 @@ abstract class TrinaColumnTypeHasMenuPopup {
   /// A callback invoked when a value is selected from the popup menu.
   ///
   /// The callback receives the newly selected value.
-  void Function(dynamic item)? get onItemSelected;
+  void Function(T item)? get onItemSelected;
 }

--- a/lib/src/ui/cells/trina_boolean_cell.dart
+++ b/lib/src/ui/cells/trina_boolean_cell.dart
@@ -37,12 +37,12 @@ class TrinaBooleanCellState
   IconData? get popupMenuIcon => widget.column.type.boolean.popupIcon;
 
   @override
-  List<dynamic> get menuItems {
+  List<bool?> get menuItems {
     return [if (_column.allowEmpty) null, true, false];
   }
 
   @override
-  TrinaDropdownMenu buildMenu() {
+  TrinaDropdownMenu<bool?> buildMenu() {
     return TrinaDropdownMenu(
       items: menuItems,
       itemHeight: _column.menuItemHeight,

--- a/lib/src/ui/cells/trina_select_cell.dart
+++ b/lib/src/ui/cells/trina_select_cell.dart
@@ -5,7 +5,7 @@ import 'package:trina_grid/trina_grid.dart';
 
 import 'popup_cell.dart';
 
-class TrinaSelectCell extends StatefulWidget implements PopupCell {
+class TrinaSelectCell<T> extends StatefulWidget implements PopupCell {
   @override
   final TrinaGridStateManager stateManager;
 
@@ -27,21 +27,21 @@ class TrinaSelectCell extends StatefulWidget implements PopupCell {
   });
 
   @override
-  TrinaSelectCellState createState() => TrinaSelectCellState();
+  TrinaSelectCellState<T> createState() => TrinaSelectCellState<T>();
 }
 
-class TrinaSelectCellState
-    extends TrinaPopupCellStateWithMenu<TrinaSelectCell> {
-  TrinaColumnTypeSelect get _column => widget.column.type.select;
+class TrinaSelectCellState<T>
+    extends TrinaPopupCellStateWithMenu<TrinaSelectCell<T>> {
+  TrinaColumnTypeSelect<T> get _column => widget.column.type.asSelect();
 
   @override
   IconData? get popupMenuIcon => _column.popupIcon;
 
   @override
-  List get menuItems => _column.items;
+  List<T> get menuItems => _column.items;
 
   @override
-  TrinaDropdownMenu buildMenu() {
+  TrinaDropdownMenu<T> buildMenu() {
     return TrinaDropdownMenu.variant(
       _column.menuVariant,
       items: menuItems,

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -1,11 +1,8 @@
+import 'ui.dart';
 import 'package:flutter/material.dart';
 import 'package:trina_grid/trina_grid.dart';
 import 'package:trina_grid/src/helper/platform_helper.dart';
 import 'package:trina_grid/src/helper/trina_double_tap_detector.dart';
-import 'package:trina_grid/src/ui/cells/trina_boolean_cell.dart';
-import 'package:trina_grid/src/ui/cells/trina_date_time_cell.dart';
-
-import 'ui.dart';
 
 class TrinaBaseCell extends StatelessWidget
     implements TrinaVisibilityLayoutChild {
@@ -393,70 +390,8 @@ class _CellState extends TrinaStateWithChange<_Cell> {
   @override
   Widget build(BuildContext context) {
     if (_showTypedCell && widget.column.enableEditingMode == true) {
-      if (widget.column.type.isSelect) {
-        return TrinaSelectCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isNumber) {
-        return TrinaNumberCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isPercentage) {
-        return TrinaPercentageCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isDate) {
-        return TrinaDateCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isDateTime) {
-        return TrinaDateTimeCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isTime) {
-        return TrinaTimeCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isText) {
-        return TrinaTextCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isCurrency) {
-        return TrinaCurrencyCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      } else if (widget.column.type.isBoolean) {
-        return TrinaBooleanCell(
-          stateManager: stateManager,
-          cell: widget.cell,
-          column: widget.column,
-          row: widget.row,
-        );
-      }
+      return widget.column.type
+          .buildCell(stateManager, widget.cell, widget.column, widget.row);
     }
 
     return TrinaDefaultCell(

--- a/test/helper/row_helper.dart
+++ b/test/helper/row_helper.dart
@@ -58,7 +58,7 @@ class RowHelper {
 
   static TrinaCell cellOfSelectColumn(TrinaColumn column, int rowIdx) {
     return TrinaCell(
-      value: (column.type.select.items.toList()..shuffle()).first,
+      value: (column.type.asSelect().items.toList()..shuffle()).first,
     );
   }
 

--- a/test/src/model/trina_column_type_test.dart
+++ b/test/src/model/trina_column_type_test.dart
@@ -30,7 +30,7 @@ void main() {
     test(
       'When accessing the select property, a TypeError should be thrown.',
       () {
-        expect(() => textTypeColumn.select, throwsA(isA<TypeError>()));
+        expect(() => textTypeColumn.asSelect(), throwsA(isA<TypeError>()));
       },
     );
 

--- a/test/src/ui/cells/trina_select_cell_test.dart
+++ b/test/src/ui/cells/trina_select_cell_test.dart
@@ -168,29 +168,29 @@ void main() {
       // Open popup
       await tester.sendKeyEvent(LogicalKeyboardKey.f2);
       await tester.pumpAndSettle();
-      expect(find.byType(TrinaDropdownMenu), findsOneWidget);
+      expect(find.byType(TrinaDropdownMenu<String>), findsOneWidget);
 
       // Close popup with escape
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pumpAndSettle();
-      expect(find.byType(TrinaDropdownMenu), findsNothing);
+      expect(find.byType(TrinaDropdownMenu<String>), findsNothing);
 
       // Reopen popup
       await tester.sendKeyEvent(LogicalKeyboardKey.f2);
       await tester.pumpAndSettle();
-      expect(find.byType(TrinaDropdownMenu), findsOneWidget);
+      expect(find.byType(TrinaDropdownMenu<String>), findsOneWidget);
     });
 
     testWidgets(
       'After selecting an item with arrow keys and enter, value should be updated',
       (tester) async {
         await buildCellAndEdit(tester);
-        expect(find.byType(TrinaDropdownMenu), findsNothing);
+        expect(find.byType(TrinaDropdownMenu<String>), findsNothing);
 
         // Open popup
         await tester.sendKeyEvent(LogicalKeyboardKey.f2);
         await tester.pumpAndSettle();
-        expect(find.byType(TrinaDropdownMenu), findsOneWidget);
+        expect(find.byType(TrinaDropdownMenu<String>), findsOneWidget);
 
         // Select next item and press enter
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -198,7 +198,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Verify popup is closed and value is updated
-        expect(find.byType(TrinaDropdownMenu), findsNothing);
+        expect(find.byType(TrinaDropdownMenu<String>), findsNothing);
         expect(cell.value, selectItems[1]);
       },
     );

--- a/test/src/ui/trina_base_cell_test.dart
+++ b/test/src/ui/trina_base_cell_test.dart
@@ -366,7 +366,7 @@ void main() {
     final TrinaColumn column = TrinaColumn(
       title: 'header',
       field: 'header',
-      type: TrinaColumnType.select(<String>['one', 'two', 'three']),
+      type: TrinaColumnType.select<String>(['one', 'two', 'three']),
     );
 
     final TrinaRow row = TrinaRow(
@@ -392,7 +392,7 @@ void main() {
 
     // then
     expect(find.text('one'), findsOneWidget);
-    expect(find.byType(TrinaSelectCell), findsOneWidget);
+    expect(find.byType(TrinaSelectCell<String>), findsOneWidget);
     expect(find.byType(TrinaNumberCell), findsNothing);
     expect(find.byType(TrinaDateCell), findsNothing);
     expect(find.byType(TrinaTimeCell), findsNothing);


### PR DESCRIPTION
## Purpose

- When using `TrinaColumnType.select` or any other selection column variant, the selection values are a list of `dynamic` items and
`onItemSelected` callback will contain an item with `dynamic` type.
- Since Dart supports generic types, I thought we can benefit from it to make the select column type "strongly typed".

## Changes

Previously, cell widgets were constructed using a large `if/else if` chain in `_CellState.build`, which checked the type of the column (e.g., `isSelect`, `isNumber`). This approach had a significant drawback: it was impossible to pass generic type information from the `TrinaColumnType` to the cell widget.

- A new abstract `buildCell` method has been added to the `TrinaColumnType` interface.

- Implemented `buildCell` in `TrinaColumnType` subtypes.

- The `if/else if` logic in `_CellState.build` has been replaced with  `widget.column.type.buildCell(...)`.

### Note

This should NOT create any issues with existing code using the select column type.