### PR TITLE
fix: resolve frozen row alignment issue with dynamic row heights

### DIFF
--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -95,7 +95,7 @@ class TrinaLeftFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            itemExtent: stateManager.rowTotalHeight,
+            // Remove fixed itemExtent for variable heights
             itemBuilder: (ctx, i) =>
                 _buildRow(_scrollableRows[i], i + _frozenTopRows.length),
           ),

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -95,7 +95,7 @@ class TrinaRightFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            itemExtent: stateManager.rowTotalHeight,
+            // Remove fixed itemExtent for variable heights
             itemBuilder: (ctx, i) =>
                 _buildRow(_scrollableRows[i], i + _frozenTopRows.length),
           ),


### PR DESCRIPTION
Remove fixed itemExtent from frozen row ListView.builder widgets to match the dynamic row height implementation. This fixes misalignment between frozen columns and regular columns when dynamic row heights are used.

Fixes issue caused by commit 34283f1 which updated main body rows but missed the frozen row components.

🤖 Generated with [Claude Code](https://claude.ai/code)