### PR TITLE
fix: improve vertical centering and text styling for edited cells

### DIFF
--- a/demo/lib/screen/feature/boolean_type_column_screen.dart
+++ b/demo/lib/screen/feature/boolean_type_column_screen.dart
@@ -125,6 +125,8 @@ class _BooleanTypeColumnScreenState extends State<BooleanTypeColumnScreen> {
               },
               configuration: TrinaGridConfiguration(
                 style: TrinaGridStyleConfig(
+                  rowHeight: 100,
+                  cellTextStyle: TextStyle(fontSize: 10),
                   cellDirtyColor: Colors.amber[100]!,
                 ),
               ),

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -231,24 +231,28 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       cellFocus.requestFocus();
     }
 
-    Widget w = TextField(
-      focusNode: cellFocus,
-      controller: _textController,
-      readOnly: widget.column.checkReadOnly(widget.row, widget.cell),
-      onChanged: _handleOnChanged,
-      onEditingComplete: _handleOnComplete,
-      onSubmitted: (_) => _handleOnComplete(),
-      onTap: _handleOnTap,
-      style: widget.stateManager.configuration.style.cellTextStyle,
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(borderSide: BorderSide.none),
-        contentPadding: EdgeInsets.zero,
+    Widget w = Container(
+      alignment: Alignment.center,
+      child: TextField(
+        focusNode: cellFocus,
+        controller: _textController,
+        readOnly: widget.column.checkReadOnly(widget.row, widget.cell),
+        onChanged: _handleOnChanged,
+        onEditingComplete: _handleOnComplete,
+        onSubmitted: (_) => _handleOnComplete(),
+        onTap: _handleOnTap,
+        style: widget.stateManager.configuration.style.cellTextStyle,
+        decoration: const InputDecoration(
+          border: InputBorder.none,
+          contentPadding: EdgeInsets.zero,
+          isDense: true,
+        ),
+        maxLines: 1,
+        keyboardType: keyboardType,
+        inputFormatters: inputFormatters,
+        textAlignVertical: TextAlignVertical.center,
+        textAlign: widget.column.textAlign.value,
       ),
-      maxLines: 1,
-      keyboardType: keyboardType,
-      inputFormatters: inputFormatters,
-      textAlignVertical: TextAlignVertical.center,
-      textAlign: widget.column.textAlign.value,
     );
 
     // Use column-level editCellRenderer if available, otherwise fall back to grid-level

--- a/lib/src/ui/miscellaneous/trina_popup_cell_state_with_menu.dart
+++ b/lib/src/ui/miscellaneous/trina_popup_cell_state_with_menu.dart
@@ -71,6 +71,7 @@ abstract class TrinaPopupCellStateWithMenu<T extends PopupCell> extends State<T>
           child: TrinaDefaultPopupCellEditingWidget(
             popupMenuIcon: popupMenuIcon,
             controller: textController,
+            stateManager: widget.stateManager,
             onTap: () {
               if (widget.column.readOnly) {
                 return;

--- a/lib/src/ui/widgets/trina_default_popup_cell_editing_widget.dart
+++ b/lib/src/ui/widgets/trina_default_popup_cell_editing_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
 
 /// Used as the default widget for popup cells when in editing state.
 class TrinaDefaultPopupCellEditingWidget extends StatelessWidget {
@@ -7,11 +8,13 @@ class TrinaDefaultPopupCellEditingWidget extends StatelessWidget {
   /// [controller] controls the text displayed in the field.
   /// [onTap] is called when the field is tapped.
   /// [popupMenuIcon] optionally overrides the default icon.
+  /// [stateManager] provides access to grid configuration for styling.
   const TrinaDefaultPopupCellEditingWidget({
     super.key,
     required this.controller,
     required this.onTap,
     this.popupMenuIcon,
+    this.stateManager,
   });
 
   /// The controller for the text field.
@@ -23,21 +26,31 @@ class TrinaDefaultPopupCellEditingWidget extends StatelessWidget {
   /// The icon to display as the popup menu indicator.
   final IconData? popupMenuIcon;
 
+  /// The state manager for accessing grid configuration.
+  final TrinaGridStateManager? stateManager;
+
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      onTap: onTap,
-      controller: controller,
-      mouseCursor: SystemMouseCursors.click,
-      readOnly: true,
-      decoration: InputDecoration(
-        border: InputBorder.none,
-        suffixIcon: popupMenuIcon != null
-            ? MouseRegion(
-                cursor: SystemMouseCursors.click,
-                child: Icon(popupMenuIcon),
-              )
-            : null,
+    return Container(
+      alignment: Alignment.center,
+      child: TextFormField(
+        onTap: onTap,
+        controller: controller,
+        mouseCursor: SystemMouseCursors.click,
+        readOnly: true,
+        style: stateManager?.configuration.style.cellTextStyle,
+        textAlignVertical: TextAlignVertical.center,
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          contentPadding: EdgeInsets.zero,
+          isDense: true,
+          suffixIcon: popupMenuIcon != null
+              ? MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  child: Icon(popupMenuIcon),
+                )
+              : null,
+        ),
       ),
     );
   }


### PR DESCRIPTION
- Wrap TextField in Container with center alignment for proper vertical centering
- Apply cellTextStyle consistently to all popup cell types (boolean, select, etc.)
- Add stateManager parameter to TrinaDefaultPopupCellEditingWidget for style access
- Use InputBorder.none and isDense: true for cleaner input decoration
- Ensure consistent styling between display and edit modes for all cell types