### PR TITLE
fix: improve text cell vertical alignment during editing

### DIFF
--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -250,7 +250,6 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
         maxLines: 1,
         keyboardType: keyboardType,
         inputFormatters: inputFormatters,
-        textAlignVertical: TextAlignVertical.center,
         textAlign: widget.column.textAlign.value,
       ),
     );


### PR DESCRIPTION
Remove textAlignVertical property from TextField in text cells to ensure consistent vertical positioning when switching between display and edit modes. The Container's alignment property provides sufficient centering without causing content to shift vertically during editing transitions.