### PR TITLE
feat: add keyboard event handling to TrinaCell

### DIFF
--- a/lib/src/model/trina_cell.dart
+++ b/lib/src/model/trina_cell.dart
@@ -25,13 +25,14 @@ class TrinaCellRendererContext {
 }
 
 class TrinaCell {
-  /// Creates a cell with an optional initial value, key, renderer, and onChanged callback.
+  /// Creates a cell with an optional initial value, key, renderer, onChanged callback, and onKeyPressed callback.
   ///
   /// The [value] parameter sets the initial value of the cell.
   /// The [key] parameter provides a unique identifier for the cell.
   /// The [renderer] parameter allows for custom rendering of the cell.
   /// The [onChanged] parameter allows for cell-level control over value changes.
-  TrinaCell({dynamic value, Key? key, this.renderer, this.onChanged})
+  /// The [onKeyPressed] parameter allows for capturing keyboard events in the cell.
+  TrinaCell({dynamic value, Key? key, this.renderer, this.onChanged, this.onKeyPressed})
       : _key = key ?? UniqueKey(),
         _value = value,
         _originalValue = value,
@@ -58,6 +59,10 @@ class TrinaCell {
   /// Callback that is triggered when this specific cell's value is changed.
   /// This allows for cell-level control over value changes.
   final TrinaOnChangedEventCallback? onChanged;
+
+  /// Callback that is triggered when a key is pressed in this specific cell.
+  /// This allows for capturing keyboard events like Enter, Tab, Escape, etc.
+  final TrinaOnKeyPressedEventCallback? onKeyPressed;
 
   /// Returns true if this cell has a custom renderer.
   bool get hasRenderer => renderer != null;

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -16,6 +16,9 @@ typedef TrinaOnLoadedEventCallback = void Function(
 typedef TrinaOnChangedEventCallback = void Function(
     TrinaGridOnChangedEvent event);
 
+typedef TrinaOnKeyPressedEventCallback = void Function(
+    TrinaGridOnKeyEvent event);
+
 typedef TrinaOnSelectedEventCallback = void Function(
     TrinaGridOnSelectedEvent event);
 

--- a/lib/src/trina_grid_events.dart
+++ b/lib/src/trina_grid_events.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 /// [TrinaGrid.onLoaded] Argument received by registering callback.
@@ -284,5 +284,76 @@ class TrinaGridOnLazyFetchCompletedEvent {
   @override
   String toString() {
     return '[TrinaGridOnLazyFetchCompletedEvent] page: $page, totalPage: $totalPage, totalRecords: $totalRecords';
+  }
+}
+
+/// Event triggered when a key is pressed in a cell.
+/// This allows developers to capture keyboard interactions like Enter, Shift, Tab, etc.
+class TrinaGridOnKeyEvent {
+  /// The column where the key was pressed
+  final TrinaColumn column;
+  
+  /// The row where the key was pressed
+  final TrinaRow row;
+  
+  /// The row index
+  final int rowIdx;
+  
+  /// The cell where the key was pressed
+  final TrinaCell cell;
+  
+  /// The raw KeyEvent from Flutter
+  final KeyEvent event;
+  
+  /// Whether the Enter key was pressed
+  final bool isEnter;
+  
+  /// Whether the Escape key was pressed
+  final bool isEscape;
+  
+  /// Whether the Tab key was pressed
+  final bool isTab;
+  
+  /// Whether Shift is pressed
+  final bool isShiftPressed;
+  
+  /// Whether Ctrl/Cmd is pressed
+  final bool isCtrlPressed;
+  
+  /// Whether Alt is pressed
+  final bool isAltPressed;
+  
+  /// The logical key that was pressed
+  final LogicalKeyboardKey logicalKey;
+  
+  /// The current text value in the cell (if editing)
+  final String? currentValue;
+  
+  const TrinaGridOnKeyEvent({
+    required this.column,
+    required this.row,
+    required this.rowIdx,
+    required this.cell,
+    required this.event,
+    required this.isEnter,
+    required this.isEscape,
+    required this.isTab,
+    required this.isShiftPressed,
+    required this.isCtrlPressed,
+    required this.isAltPressed,
+    required this.logicalKey,
+    this.currentValue,
+  });
+  
+  @override
+  String toString() {
+    String out = '[TrinaGridOnKeyEvent] ';
+    out += 'Column: ${column.title}, RowIndex: $rowIdx\n';
+    out += '::: Key: ${logicalKey.debugName}\n';
+    out += '::: Modifiers: Shift=$isShiftPressed, Ctrl=$isCtrlPressed, Alt=$isAltPressed\n';
+    if (currentValue != null) {
+      out += '::: Current value: $currentValue';
+    }
+    return out;
   }
 }

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -40,6 +40,27 @@ mixin PopupCellState<T extends PopupCell> on State<T>
   ) {
     final trinaKeyEvent = TrinaKeyManagerEvent(focusNode: node, event: event);
 
+    // Trigger onKeyPressed callback if it exists
+    if (widget.cell.onKeyPressed != null && !trinaKeyEvent.isKeyUpEvent) {
+      final keyEvent = TrinaGridOnKeyEvent(
+        column: widget.column,
+        row: widget.row,
+        rowIdx: widget.stateManager.refRows.indexOf(widget.row),
+        cell: widget.cell,
+        event: event,
+        isEnter: trinaKeyEvent.isEnter,
+        isEscape: trinaKeyEvent.isEsc,
+        isTab: trinaKeyEvent.isTab,
+        isShiftPressed: trinaKeyEvent.isShiftPressed,
+        isCtrlPressed: trinaKeyEvent.isCtrlPressed,
+        isAltPressed: trinaKeyEvent.isAltPressed,
+        logicalKey: event.logicalKey,
+        currentValue: textController.text,
+      );
+      
+      widget.cell.onKeyPressed!(keyEvent);
+    }
+
     // If the column is readOnly, do not open the popup.
     if (widget.column.readOnly) {
       node.unfocus();

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -185,6 +185,27 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       return KeyEventResult.handled;
     }
 
+    // Trigger onKeyPressed callback if it exists
+    if (widget.cell.onKeyPressed != null) {
+      final keyEvent = TrinaGridOnKeyEvent(
+        column: widget.column,
+        row: widget.row,
+        rowIdx: widget.stateManager.refRows.indexOf(widget.row),
+        cell: widget.cell,
+        event: event,
+        isEnter: keyManager.isEnter,
+        isEscape: keyManager.isEsc,
+        isTab: keyManager.isTab,
+        isShiftPressed: keyManager.isShiftPressed,
+        isCtrlPressed: keyManager.isCtrlPressed,
+        isAltPressed: keyManager.isAltPressed,
+        logicalKey: event.logicalKey,
+        currentValue: _textController.text,
+      );
+      
+      widget.cell.onKeyPressed!(keyEvent);
+    }
+
     final skip = !(keyManager.isVertical ||
         _moveHorizontal(keyManager) ||
         keyManager.isEsc ||


### PR DESCRIPTION
- Add TrinaGridOnKeyEvent class for capturing keyboard interactions
- Add onKeyPressed callback to TrinaCell for cell-level keyboard event handling
- Integrate keyboard event support in text_cell.dart and popup_cell.dart
- Support for special keys (Enter, Tab, Escape) and modifier keys (Shift, Ctrl, Alt)
- Update documentation with comprehensive examples and usage guidelines
- Create example demonstrating keyboard event handling capabilities

This allows developers to capture and respond to keyboard events at the cell level, enabling custom navigation patterns, keyboard shortcuts, and enhanced user interactions.