### PR TITLE
enhance: add cell field to TrinaGridOnChangedEvent

### DIFF
--- a/doc/features/cell_value_change_handling.md
+++ b/doc/features/cell_value_change_handling.md
@@ -148,6 +148,7 @@ Both callback types receive a `TrinaGridOnChangedEvent` object that contains inf
 | `column` | `TrinaColumn` | The column object |
 | `rowIdx` | `int` | The index of the row in the current view |
 | `row` | `TrinaRow` | The row object |
+| `cell` | `TrinaCell` | The cell that was changed |
 | `value` | `dynamic` | The new value |
 | `oldValue` | `dynamic` | The previous value |
 
@@ -159,6 +160,15 @@ onChanged: (event) {
   print('Field: ${event.column.field}');
   print('Row index: ${event.rowIdx}');
   print('Changed from: ${event.oldValue} to ${event.value}');
+  
+  // Direct access to the changed cell
+  print('Cell key: ${event.cell.key}');
+  print('Original value: ${event.cell.originalValue}');
+  print('Is dirty: ${event.cell.isDirty}');
+  
+  // Access formatted value
+  String formattedValue = event.column.formattedValueForDisplay(event.value);
+  print('Formatted value: $formattedValue');
   
   // Access other cells in the same row
   final otherCellValue = event.row.cells['otherField']?.value;

--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -322,6 +322,7 @@ mixin EditingState implements ITrinaGridState {
       column: currentColumn,
       rowIdx: rowIdx,
       row: currentRow,
+      cell: cell,
       value: value,
       oldValue: oldValue,
     );
@@ -446,6 +447,7 @@ mixin EditingState implements ITrinaGridState {
           column: currentColumn,
           rowIdx: rowIdx,
           row: refRows[rowIdx],
+          cell: currentCell,
           value: newValue,
           oldValue: oldValue,
         );

--- a/lib/src/trina_grid_events.dart
+++ b/lib/src/trina_grid_events.dart
@@ -25,6 +25,7 @@ class TrinaGridOnChangedEvent {
   final TrinaColumn column;
   final int rowIdx;
   final TrinaRow row;
+  final TrinaCell cell;
   final dynamic value;
   final dynamic oldValue;
 
@@ -33,6 +34,7 @@ class TrinaGridOnChangedEvent {
     required this.column,
     required this.rowIdx,
     required this.row,
+    required this.cell,
     this.value,
     this.oldValue,
   });

--- a/test/src/helper/filter_helper_test.dart
+++ b/test/src/helper/filter_helper_test.dart
@@ -755,6 +755,7 @@ void main() {
           column: columns.first,
           rowIdx: 0,
           row: rows.first,
+          cell: rows.first.cells[columns.first.field]!,
         ),
       );
 


### PR DESCRIPTION
- Add TrinaCell field to TrinaGridOnChangedEvent for direct cell access
- Update all event creation sites to include the cell parameter
- Update documentation with new cell field and usage examples
- Update test to include required cell parameter

This enhancement provides:
- Direct access to cell properties (key, originalValue, isDirty, etc.)
- Consistency with other events like TrinaGridOnKeyEvent
- Easier access to formatted values via event.column.formattedValueForDisplay()
- No need to lookup cells via event.row.cells[event.column.field]

Breaking change: TrinaGridOnChangedEvent constructor now requires cell parameter