### PR TITLE
feat: add validate parameter to changeCellValue method

### DIFF
--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -45,12 +45,14 @@ abstract class IEditingState {
 
   /// Change cell value
   /// [callOnChangedEvent] triggers a [TrinaOnChangedEventCallback] callback.
+  /// [validate] determines whether to validate the value before setting it.
   void changeCellValue(
     TrinaCell cell,
     dynamic value, {
     bool callOnChangedEvent = true,
     bool force = false,
     bool notify = true,
+    bool validate = true,
   });
 }
 
@@ -260,6 +262,7 @@ mixin EditingState implements ITrinaGridState {
     bool callOnChangedEvent = true,
     bool force = false,
     bool notify = true,
+    bool validate = true,
   }) {
     final currentColumn = cell.column;
     final currentRow = cell.row;
@@ -272,7 +275,10 @@ mixin EditingState implements ITrinaGridState {
       oldValue: oldValue,
     );
 
-    value = castValueByColumnType(value, currentColumn);
+    // Only cast value if we're validating
+    if (validate) {
+      value = castValueByColumnType(value, currentColumn);
+    }
 
     if (force == false &&
         canNotChangeCellValue(
@@ -283,30 +289,32 @@ mixin EditingState implements ITrinaGridState {
       return;
     }
 
-    // Validate the value before applying the change
-    final validationError = validateValue(
-      value,
-      currentColumn,
-      currentRow,
-      rowIdx,
-      oldValue,
-    );
+    // Validate the value before applying the change (only if validate is true)
+    if (validate) {
+      final validationError = validateValue(
+        value,
+        currentColumn,
+        currentRow,
+        rowIdx,
+        oldValue,
+      );
 
-    if (validationError != null) {
-      // Trigger validation failed callback
-      if (onValidationFailed != null) {
-        onValidationFailed!(
-          TrinaGridValidationEvent(
-            column: currentColumn,
-            row: currentRow,
-            rowIdx: rowIdx,
-            value: value,
-            oldValue: oldValue,
-            errorMessage: validationError,
-          ),
-        );
+      if (validationError != null) {
+        // Trigger validation failed callback
+        if (onValidationFailed != null) {
+          onValidationFailed!(
+            TrinaGridValidationEvent(
+              column: currentColumn,
+              row: currentRow,
+              rowIdx: rowIdx,
+              value: value,
+              oldValue: oldValue,
+              errorMessage: validationError,
+            ),
+          );
+        }
+        return;
       }
-      return;
     }
 
     // Store the old value if change tracking is enabled

--- a/test/mock/shared_mocks.mocks.dart
+++ b/test/mock/shared_mocks.mocks.dart
@@ -2358,6 +2358,7 @@ class MockTrinaGridStateManager extends _i1.Mock
     bool? callOnChangedEvent = true,
     bool? force = false,
     bool? notify = true,
+    bool? validate = true,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -2370,6 +2371,7 @@ class MockTrinaGridStateManager extends _i1.Mock
             #callOnChangedEvent: callOnChangedEvent,
             #force: force,
             #notify: notify,
+            #validate: validate,
           },
         ),
         returnValueForMissingStub: null,

--- a/test/src/manager/state/editing_state_validate_test.dart
+++ b/test/src/manager/state/editing_state_validate_test.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  group('EditingState.changeCellValue validate parameter', () {
+    late TrinaGridStateManager stateManager;
+    late List<TrinaColumn> columns;
+    late List<TrinaRow> rows;
+
+    setUp(() {
+      columns = [
+        TrinaColumn(
+          title: 'Boolean Column',
+          field: 'bool_field',
+          type: TrinaColumnType.boolean(
+            allowEmpty: false, // This will reject null values when validating
+          ),
+        ),
+        TrinaColumn(
+          title: 'Number Column',
+          field: 'num_field',
+          type: TrinaColumnType.number(),
+        ),
+        TrinaColumn(
+          title: 'Text Column',
+          field: 'text_field',
+          type: TrinaColumnType.text(),
+          validator: (value, context) {
+            // Custom validator that rejects empty strings
+            if (value == null || value.toString().isEmpty) {
+              return 'Text cannot be empty';
+            }
+            return null;
+          },
+        ),
+      ];
+
+      rows = [
+        TrinaRow(
+          cells: {
+            'bool_field': TrinaCell(value: true),
+            'num_field': TrinaCell(value: 42),
+            'text_field': TrinaCell(value: 'Initial Text'),
+          },
+        ),
+        TrinaRow(
+          cells: {
+            'bool_field': TrinaCell(value: false),
+            'num_field': TrinaCell(value: 100),
+            'text_field': TrinaCell(value: 'Second Row'),
+          },
+        ),
+      ];
+
+      stateManager = TrinaGridStateManager(
+        columns: columns,
+        rows: rows,
+        gridFocusNode: FocusNode(),
+        scroll: TrinaGridScrollController(),
+      );
+    });
+
+    group('Boolean field validation', () {
+      test('should reject null value when validate is true (default)', () {
+        final cell = rows[0].cells['bool_field']!;
+        final originalValue = cell.value;
+
+        // Try to set null with validation (should fail)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          // validate: true is default
+        );
+
+        // Value should remain unchanged because validation failed
+        expect(cell.value, equals(originalValue));
+        expect(cell.value, isNot(null));
+      });
+
+      test('should accept null value when validate is false', () {
+        final cell = rows[0].cells['bool_field']!;
+
+        // Set null without validation (should succeed)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+        );
+
+        // Value should be changed to null
+        expect(cell.value, isNull);
+      });
+
+      test('should accept valid boolean values regardless of validate parameter', () {
+        final cell = rows[0].cells['bool_field']!;
+
+        // With validation (should succeed)
+        stateManager.changeCellValue(
+          cell,
+          false,
+          validate: true,
+        );
+        expect(cell.value, equals(false));
+
+        // Without validation (should also succeed)
+        stateManager.changeCellValue(
+          cell,
+          true,
+          validate: false,
+        );
+        expect(cell.value, equals(true));
+      });
+    });
+
+    group('Number field validation', () {
+      test('should convert invalid number to 0 when validate is true', () {
+        final cell = rows[0].cells['num_field']!;
+
+        // Try to set invalid number with validation
+        // It will pass validation but get converted to 0 during casting
+        stateManager.changeCellValue(
+          cell,
+          'not_a_number',
+          validate: true,
+        );
+
+        // Value should be converted to 0 (the default for invalid numbers)
+        expect(cell.value, equals(0));
+      });
+
+      test('should accept invalid value as-is when validate is false', () {
+        final cell = rows[0].cells['num_field']!;
+
+        // Set invalid value without validation (should succeed without casting)
+        stateManager.changeCellValue(
+          cell,
+          'bypassed_validation',
+          validate: false,
+        );
+
+        // Value should be stored as-is without type casting
+        expect(cell.value, equals('bypassed_validation'));
+      });
+
+      test('should properly validate negative numbers when negative is false', () {
+        // Create a column that doesn't allow negative numbers
+        final nonNegativeColumn = TrinaColumn(
+          title: 'Non-negative Number',
+          field: 'non_neg',
+          type: TrinaColumnType.number(negative: false),
+        );
+        
+        final testRow = TrinaRow(
+          cells: {
+            'non_neg': TrinaCell(value: 10),
+          },
+        );
+        
+        final testStateManager = TrinaGridStateManager(
+          columns: [nonNegativeColumn],
+          rows: [testRow],
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+        );
+        
+        final cell = testRow.cells['non_neg']!;
+
+        // Try to set negative number with validation (should fail)
+        testStateManager.changeCellValue(
+          cell,
+          -5,
+          validate: true,
+        );
+
+        // Value should be converted to 0 (since negative is not allowed)
+        expect(cell.value, equals(0));
+
+        // But with validation bypassed, it should accept the negative value
+        testStateManager.changeCellValue(
+          cell,
+          -5,
+          validate: false,
+        );
+
+        expect(cell.value, equals(-5));
+      });
+    });
+
+    group('Custom validator', () {
+      test('should reject empty string when validate is true with custom validator', () {
+        final cell = rows[0].cells['text_field']!;
+        final originalValue = cell.value;
+
+        // Try to set empty string with validation (should fail due to custom validator)
+        stateManager.changeCellValue(
+          cell,
+          '',
+          validate: true,
+        );
+
+        // Value should remain unchanged
+        expect(cell.value, equals(originalValue));
+      });
+
+      test('should accept empty string when validate is false, bypassing custom validator', () {
+        final cell = rows[0].cells['text_field']!;
+
+        // Set empty string without validation (should succeed)
+        stateManager.changeCellValue(
+          cell,
+          '',
+          validate: false,
+        );
+
+        // Value should be changed to empty string
+        expect(cell.value, equals(''));
+      });
+    });
+
+    group('Validation failed callback', () {
+      test('should trigger onValidationFailed when validation fails', () {
+        TrinaGridValidationEvent? capturedEvent;
+        
+        stateManager = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          onValidationFailed: (event) {
+            capturedEvent = event;
+          },
+        );
+
+        final cell = rows[0].cells['bool_field']!;
+
+        // Try to set null with validation (should fail and trigger callback)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: true,
+        );
+
+        // Validation failed callback should have been called
+        expect(capturedEvent, isNotNull);
+        expect(capturedEvent!.column.field, equals('bool_field'));
+        expect(capturedEvent!.value, isNull);
+        expect(capturedEvent!.errorMessage, isNotNull);
+      });
+
+      test('should not trigger onValidationFailed when validate is false', () {
+        TrinaGridValidationEvent? capturedEvent;
+        
+        stateManager = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          onValidationFailed: (event) {
+            capturedEvent = event;
+          },
+        );
+
+        final cell = rows[0].cells['bool_field']!;
+
+        // Set null without validation (should not trigger callback)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+        );
+
+        // Validation failed callback should NOT have been called
+        expect(capturedEvent, isNull);
+        // But the value should have changed
+        expect(cell.value, isNull);
+      });
+    });
+
+    group('Change tracking with validation bypass', () {
+      test('should track changes even when validation is bypassed', () {
+        stateManager = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+        );
+        
+        // Enable change tracking
+        stateManager.setChangeTracking(true);
+
+        final cell = rows[0].cells['bool_field']!;
+        final originalValue = cell.value;
+
+        // Set invalid value without validation
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+        );
+
+        // Change should be tracked
+        expect(cell.isDirty, isTrue);
+        expect(cell.oldValue, equals(originalValue));
+        expect(cell.value, isNull);
+      });
+    });
+
+    group('OnChanged callback with validation bypass', () {
+      test('should trigger onChanged callback regardless of validate parameter', () {
+        int onChangedCallCount = 0;
+        TrinaGridOnChangedEvent? lastEvent;
+
+        stateManager = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          onChanged: (event) {
+            onChangedCallCount++;
+            lastEvent = event;
+          },
+        );
+
+        final cell = rows[0].cells['bool_field']!;
+
+        // Test with validation bypassed
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+        );
+
+        expect(onChangedCallCount, equals(1));
+        expect(lastEvent, isNotNull);
+        expect(lastEvent!.value, isNull);
+        expect(lastEvent!.cell, equals(cell));
+
+        // Test with validation enabled (should fail, no callback)
+        onChangedCallCount = 0;
+        stateManager.changeCellValue(
+          cell,
+          'invalid_bool',
+          validate: true,
+        );
+
+        // Should not trigger onChanged because validation failed
+        expect(onChangedCallCount, equals(0));
+      });
+    });
+
+    group('Edge cases', () {
+      test('validate parameter should default to true when not specified', () {
+        final cell = rows[0].cells['bool_field']!;
+        final originalValue = cell.value;
+
+        // Call without specifying validate parameter
+        stateManager.changeCellValue(cell, null);
+
+        // Should behave as if validate: true (validation should prevent the change)
+        expect(cell.value, equals(originalValue));
+      });
+
+      test('force parameter should work independently of validate parameter', () {
+        final cell = rows[0].cells['bool_field']!;
+        
+        // Make cell read-only
+        columns[0].readOnly = true;
+
+        // Try to change with validate: false but without force (should fail due to readOnly)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+          force: false,
+        );
+        expect(cell.value, isNot(null));
+
+        // Try with both validate: false and force: true (should succeed)
+        stateManager.changeCellValue(
+          cell,
+          null,
+          validate: false,
+          force: true,
+        );
+        expect(cell.value, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds an optional `validate` parameter to the `changeCellValue` method, allowing developers to bypass validation and type casting when setting cell values programmatically.

## Problem Solved
Previously, it was impossible to set certain "invalid" values programmatically, such as:
- Setting `null` in boolean fields when `allowEmpty: false`
- Setting non-numeric values in number fields for migration purposes
- Bypassing custom validators for bulk imports

## Solution
Added an optional `validate` parameter (default: `true`) to `changeCellValue`:
```dart
// With validation (default behavior)
stateManager.changeCellValue(cell, null);  // May fail validation

// Bypass validation
stateManager.changeCellValue(cell, null, validate: false);  // Always succeeds
```

## Key Changes
1. **IEditingState interface** - Added `validate` parameter to method signature
2. **changeCellValue implementation** - Conditional validation and type casting based on parameter
3. **Mock class updates** - Updated to match new signature
4. **Comprehensive unit tests** - 14 test cases covering all scenarios

## Behavior
- When `validate: true` (default):
  - Validates value against column type
  - Applies type casting (e.g., invalid numbers → 0)
  - Triggers validation callbacks on failure
  
- When `validate: false`:
  - Bypasses all validation
  - Bypasses type casting (stores raw values)
  - Always succeeds (unless blocked by other constraints like readOnly)

## Use Cases
- **Data migration** - Set temporary invalid values during migration
- **Bulk imports** - Handle validation separately from value setting
- **Boolean nulls** - Set null in boolean fields regardless of `allowEmpty`
- **Programmatic updates** - Full control over cell values

## Testing
✅ All existing tests pass
✅ 14 new unit tests added covering:
- Boolean field validation bypass
- Number field validation bypass
- Custom validator bypass
- Validation callbacks
- Change tracking
- OnChanged callbacks
- Edge cases

## Breaking Changes
None - The parameter is optional with a default value that maintains existing behavior.

## Test Plan
- [x] Unit tests pass
- [x] Manual testing with boolean fields
- [x] Manual testing with number fields
- [x] Manual testing with custom validators
- [x] Flutter analyze passes