### PR TITLE
Add cell-level padding property to TrinaCell

### DIFF
--- a/lib/src/model/trina_cell.dart
+++ b/lib/src/model/trina_cell.dart
@@ -32,7 +32,7 @@ class TrinaCell {
   /// The [renderer] parameter allows for custom rendering of the cell.
   /// The [onChanged] parameter allows for cell-level control over value changes.
   /// The [onKeyPressed] parameter allows for capturing keyboard events in the cell.
-  TrinaCell({dynamic value, Key? key, this.renderer, this.onChanged, this.onKeyPressed})
+  TrinaCell({dynamic value, Key? key, this.renderer, this.onChanged, this.onKeyPressed, this.padding})
       : _key = key ?? UniqueKey(),
         _value = value,
         _originalValue = value,
@@ -63,6 +63,10 @@ class TrinaCell {
   /// Callback that is triggered when a key is pressed in this specific cell.
   /// This allows for capturing keyboard events like Enter, Tab, Escape, etc.
   final TrinaOnKeyPressedEventCallback? onKeyPressed;
+
+  /// Custom padding for this specific cell.
+  /// If provided, this will override the column padding and default padding.
+  final EdgeInsets? padding;
 
   /// Returns true if this cell has a custom renderer.
   bool get hasRenderer => renderer != null;

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -133,7 +133,8 @@ class TrinaBaseCell extends StatelessWidget
         rowIdx: rowIdx,
         row: row,
         column: column,
-        cellPadding: column.cellPadding ??
+        cellPadding: cell.padding ??
+            column.cellPadding ??
             stateManager.configuration.style.defaultCellPadding,
         stateManager: stateManager,
         child: _Cell(


### PR DESCRIPTION
## Summary
- Add padding property to TrinaCell for individual cell padding control
- Implement padding priority: cell > column > config

## Details
Individual cells can now override both column and configuration padding settings using:

```dart
TrinaCell(
  value: 'your value',
  padding: EdgeInsets.all(10), // Custom padding for this cell
)
```

The padding resolution follows this priority:
1. Cell level: `cell.padding` (highest priority)
2. Column level: `column.cellPadding` 
3. Configuration level: `style.defaultCellPadding` (fallback)

## Test plan
- [ ] Verify cells with custom padding override column/config padding
- [ ] Verify cells without custom padding use column/config defaults
- [ ] Test various EdgeInsets configurations at cell level