### PR TITLE
feat: enhance rowWrapper callback with TrinaRow data parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [2.0.2] - 2025. 09. 01
+## [2.1.0] - 2025. 09. 01
 
 * Fix: Restored mouse scrolling/dragging functionality that was broken since v1.6.11. @doonfrs
+* Breaking Change: Enhanced rowWrapper callback to include TrinaRow data parameter and renamed row widget parameter to rowWidget for clarity. @doonfrs
+
 
 ## [2.0.1] - 2025. 09. 01
 

--- a/demo/lib/screen/feature/row_wrapper_screen.dart
+++ b/demo/lib/screen/feature/row_wrapper_screen.dart
@@ -46,7 +46,7 @@ class _RowWrapperScreenState extends State<RowWrapperScreen> {
       body: TrinaGrid(
         columns: columns,
         rows: rows,
-        rowWrapper: (context, row, stateManager) {
+        rowWrapper: (context, rowWidget, rowData, stateManager) {
           return Container(
             margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
             decoration: BoxDecoration(
@@ -61,7 +61,7 @@ class _RowWrapperScreenState extends State<RowWrapperScreen> {
               ],
               color: Colors.white,
             ),
-            child: row,
+            child: rowWidget,
           );
         },
       ),

--- a/doc/features/row-wrapper.md
+++ b/doc/features/row-wrapper.md
@@ -4,13 +4,14 @@ The `rowWrapper` feature in TrinaGrid allows you to customize the rendering of e
 
 ## Overview
 
-- **Purpose:** Customize how each row is displayed.
+- **Purpose:** Customize how each row is displayed with access to both the row widget and its data.
 - **Type:**
 
   ```dart
   typedef RowWrapper = Widget Function(
     BuildContext context,
-    Widget row,
+    Widget rowWidget,
+    TrinaRow rowData,
     TrinaGridStateManager stateManager,
   );
   ```
@@ -23,7 +24,7 @@ The `rowWrapper` feature in TrinaGrid allows you to customize the rendering of e
 TrinaGrid(
   columns: columns,
   rows: rows,
-  rowWrapper: (context, row, stateManager) {
+  rowWrapper: (context, rowWidget, rowData, stateManager) {
     // Example: Add a colored border to each row
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 2),
@@ -31,7 +32,34 @@ TrinaGrid(
         border: Border.all(color: Colors.blueAccent),
         borderRadius: BorderRadius.circular(4),
       ),
-      child: row,
+      child: rowWidget,
+    );
+  },
+)
+```
+
+### Advanced Example: Conditional Styling Based on Row Data
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowWrapper: (context, rowWidget, rowData, stateManager) {
+    // Access cell values from rowData to apply conditional styling
+    final statusValue = rowData.cells['status']?.value;
+    final isHighPriority = statusValue == 'urgent';
+    
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      decoration: BoxDecoration(
+        color: isHighPriority ? Colors.red.withOpacity(0.1) : null,
+        border: Border.all(
+          color: isHighPriority ? Colors.red : Colors.blueAccent,
+          width: isHighPriority ? 2 : 1,
+        ),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: rowWidget,
     );
   },
 )
@@ -40,10 +68,35 @@ TrinaGrid(
 ## Use Cases
 
 - Add custom borders, backgrounds, or shadows to rows.
+- Apply conditional styling based on row data values.
 - Attach gesture detectors or context menus.
 - Animate row appearance or add tooltips.
+- Implement row-level status indicators or badges based on cell values.
+- Create row-specific hover effects or highlights.
 
 ## Notes
 
 - If `rowWrapper` is not provided, the default row widget is used.
-- The wrapper receives the build context, the default row widget, and the grid state manager for maximum flexibility.
+- The wrapper receives:
+  - `context`: The build context
+  - `rowWidget`: The default row widget (previously named `row`)
+  - `rowData`: The TrinaRow instance containing all cell data
+  - `stateManager`: The grid state manager for maximum flexibility
+- You can access cell values through `rowData.cells[fieldName]?.value`
+- The `rowData` parameter enables data-driven row customization without requiring state manager queries.
+
+## Migration from Previous Versions
+
+If you're upgrading from a version prior to 2.1.0, update your rowWrapper callbacks:
+
+```dart
+// Old signature (before 2.1.0)
+rowWrapper: (context, row, stateManager) {
+  return Container(child: row);
+}
+
+// New signature (2.1.0+)
+rowWrapper: (context, rowWidget, rowData, stateManager) {
+  return Container(child: rowWidget);
+}
+```

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -72,7 +72,8 @@ typedef TrinaOnLazyFetchCompletedEventCallback = void Function(
 
 typedef RowWrapper = Widget Function(
   BuildContext context,
-  Widget row,
+  Widget rowWidget,
+  TrinaRow rowData,
   TrinaGridStateManager stateManager,
 );
 

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -179,7 +179,7 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
       visibilityLayout: true,
     );
 
-    return stateManager.rowWrapper?.call(context, rowWidget, stateManager) ??
+    return stateManager.rowWrapper?.call(context, rowWidget, row, stateManager) ??
         rowWidget;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: trina_grid
 description: A data grid that can be controlled by the keyboard on desktop and web. Of course, it works well on Android and IOS. (DataGrid, DataTable, Data Grid, Data Table, Sticky)
-version: 2.0.2
+version: 2.1.0
 repository: https://github.com/doonfrs/trina_grid
 issue_tracker: https://github.com/doonfrs/trina_grid/issues
 

--- a/test/src/trina_grid_row_wrapper_test.dart
+++ b/test/src/trina_grid_row_wrapper_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../helper/column_helper.dart';
+import '../helper/row_helper.dart';
+
+void main() {
+  group('TrinaGrid rowWrapper', () {
+    late List<TrinaColumn> columns;
+    late List<TrinaRow> rows;
+
+    setUp(() {
+      columns = ColumnHelper.textColumn('header', count: 3);
+      rows = RowHelper.count(3, columns);
+      
+      // Set specific values for testing
+      rows[0].cells['header0']!.value = 'Row 1 Data';
+      rows[1].cells['header0']!.value = 'Row 2 Data';
+      rows[2].cells['header0']!.value = 'Row 3 Data';
+    });
+
+    testWidgets(
+      'rowWrapper should receive correct parameters including rowData',
+      (WidgetTester tester) async {
+        // Captured parameters from rowWrapper callback
+        BuildContext? capturedContext;
+        Widget? capturedRowWidget;
+        TrinaRow? capturedRowData;
+        TrinaGridStateManager? capturedStateManager;
+        int callCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                rowWrapper: (context, rowWidget, rowData, stateManager) {
+                  callCount++;
+                  capturedContext = context;
+                  capturedRowWidget = rowWidget;
+                  capturedRowData = rowData;
+                  capturedStateManager = stateManager;
+                  
+                  return Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.blue),
+                    ),
+                    child: rowWidget,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify rowWrapper was called
+        expect(callCount, greaterThan(0));
+        
+        // Verify parameters are not null
+        expect(capturedContext, isNotNull);
+        expect(capturedRowWidget, isNotNull);
+        expect(capturedRowData, isNotNull);
+        expect(capturedStateManager, isNotNull);
+        
+        // Verify rowData contains expected cell data
+        expect(capturedRowData!.cells, isNotEmpty);
+        expect(capturedRowData!.cells.containsKey('header0'), isTrue);
+      },
+    );
+
+    testWidgets(
+      'rowWrapper should be called for each visible row with correct row data',
+      (WidgetTester tester) async {
+        final List<TrinaRow> capturedRowData = [];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                rowWrapper: (context, rowWidget, rowData, stateManager) {
+                  capturedRowData.add(rowData);
+                  
+                  return Container(
+                    decoration: BoxDecoration(
+                      color: rowData.cells['header0']?.value == 'Row 1 Data' 
+                          ? Colors.red.withOpacity(0.1)
+                          : Colors.blue.withOpacity(0.1),
+                    ),
+                    child: rowWidget,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify we captured row data for visible rows
+        expect(capturedRowData, isNotEmpty);
+        
+        // Verify each captured row has the expected data
+        final capturedValues = capturedRowData
+            .map((row) => row.cells['header0']?.value)
+            .toList();
+        
+        expect(capturedValues, contains('Row 1 Data'));
+        expect(capturedValues, contains('Row 2 Data'));
+        expect(capturedValues, contains('Row 3 Data'));
+
+        // Verify the grid still displays the data correctly
+        expect(find.text('Row 1 Data'), findsOneWidget);
+        expect(find.text('Row 2 Data'), findsOneWidget);
+        expect(find.text('Row 3 Data'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'rowWrapper can apply conditional styling based on row data',
+      (WidgetTester tester) async {
+        bool firstRowFound = false;
+        bool otherRowFound = false;
+        
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                rowWrapper: (context, rowWidget, rowData, stateManager) {
+                  final isFirstRow = rowData.cells['header0']?.value == 'Row 1 Data';
+                  
+                  if (isFirstRow) {
+                    firstRowFound = true;
+                  } else {
+                    otherRowFound = true;
+                  }
+                  
+                  return Container(
+                    decoration: BoxDecoration(
+                      color: isFirstRow ? Colors.yellow : Colors.transparent,
+                      border: Border.all(
+                        color: isFirstRow ? Colors.red : Colors.grey,
+                        width: isFirstRow ? 2 : 1,
+                      ),
+                    ),
+                    child: rowWidget,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify conditional logic was executed for different rows
+        expect(firstRowFound, isTrue, reason: 'First row should have been processed');
+        expect(otherRowFound, isTrue, reason: 'Other rows should have been processed');
+
+        // Verify the grid still displays the data correctly after wrapping
+        expect(find.text('Row 1 Data'), findsOneWidget);
+        expect(find.text('Row 2 Data'), findsOneWidget);
+        expect(find.text('Row 3 Data'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'grid works correctly without rowWrapper',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                // No rowWrapper provided
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify grid renders correctly without rowWrapper
+        expect(find.text('Row 1 Data'), findsOneWidget);
+        expect(find.text('Row 2 Data'), findsOneWidget);
+        expect(find.text('Row 3 Data'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Breaking Change: Updated rowWrapper signature to include TrinaRow data
- Added rowData parameter to provide direct access to row data
- Renamed row parameter to rowWidget for clarity
- Updated documentation with migration guide
- Updated demo example to use new signature

This allows developers to access both the visual representation (widget) and the underlying data (TrinaRow) when customizing row appearance.