### PR TITLE
fix: filter popup dropdown text show column title, not filed

### DIFF
--- a/lib/src/helper/filter_helper.dart
+++ b/lib/src/helper/filter_helper.dart
@@ -502,7 +502,12 @@ class FilterPopupState {
       TrinaColumn(
         title: configuration.localeText.filterColumn,
         field: FilterHelper.filterFieldColumn,
-        type: TrinaColumnType.select(columnMap.keys.toList(growable: false)),
+        type: TrinaColumnType.select(
+          columnMap.keys.toList(growable: false),
+          itemToString: (item) {
+            return columnMap[item] ?? '';
+          },
+        ),
         enableFilterMenuItem: false,
         applyFormatterInEditing: true,
         formatter: (dynamic value) {


### PR DESCRIPTION
I think show the title (not field) is easier to read.