### PR TITLE
fix: export TrinaDropdownMenuVariant to make it publicly accessible

### DIFF
--- a/lib/trina_grid.dart
+++ b/lib/trina_grid.dart
@@ -67,6 +67,7 @@ export 'src/model/column_types/trina_column_type_percentage.dart';
 export 'src/model/column_types/trina_column_type_text.dart';
 export 'src/model/trina_column_type_has_format.dart';
 export 'src/model/trina_dropdown_menu_filter.dart';
+export 'src/ui/widgets/trina_dropdown_menu.dart' show TrinaDropdownMenuVariant;
 
 // Export grid export functionality
 export './src/export/trina_grid_export.dart';

--- a/test/export_test.dart
+++ b/test/export_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  test('TrinaDropdownMenuVariant should be publicly exported', () {
+    // This test verifies that TrinaDropdownMenuVariant is accessible
+    // without needing implementation imports
+
+    const variant1 = TrinaDropdownMenuVariant.select;
+    const variant2 = TrinaDropdownMenuVariant.selectWithSearch;
+    const variant3 = TrinaDropdownMenuVariant.selectWithFilters;
+
+    expect(variant1, TrinaDropdownMenuVariant.select);
+    expect(variant2, TrinaDropdownMenuVariant.selectWithSearch);
+    expect(variant3, TrinaDropdownMenuVariant.selectWithFilters);
+
+    // Test that all enum values are accessible
+    expect(TrinaDropdownMenuVariant.values.length, 3);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes issue #216 where `TrinaDropdownMenuVariant` required implementation imports despite being part of the public API.

## Problem
`TrinaDropdownMenuVariant` is used in several public APIs but wasn't exported in the main library file:

**Used in public APIs:**
- `TrinaColumnTypeSelect.menuVariant` property
- `TrinaColumnTypeBoolean.menuVariant` getter  
- `TrinaColumnTypeHasMenuPopup.menuVariant` interface
- Documented in public documentation

**Required ugly workaround:**
```dart
// ignore: implementation_imports
import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart' show TrinaDropdownMenuVariant;
```

## Solution
Added explicit export in `lib/trina_grid.dart`:

```dart
export 'src/ui/widgets/trina_dropdown_menu.dart' show TrinaDropdownMenuVariant;
```

## Code Changes
- **Modified**: `lib/trina_grid.dart` - Added export for `TrinaDropdownMenuVariant`
- **Added**: `test/export_test.dart` - Test verifying the enum is publicly accessible

## Usage
**Before (required implementation import):**
```dart
// ignore: implementation_imports
import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart' show TrinaDropdownMenuVariant;

const variant = TrinaDropdownMenuVariant.select;
```

**After (clean public import):**
```dart
import 'package:trina_grid/trina_grid.dart';

const variant = TrinaDropdownMenuVariant.select; // ✅ Now works directly
```

## Testing
- ✅ Added test verifying all enum values are accessible via public import
- ✅ All existing tests continue to pass
- ✅ No breaking changes - pure API improvement

## Breaking Changes
None - this is a pure addition that maintains full backward compatibility.

Closes #216