### PR TITLE
docs: add documentation for checkReadOnly dynamic cell read-only functionality

### DIFF
--- a/doc/features/cell-editing.md
+++ b/doc/features/cell-editing.md
@@ -41,6 +41,36 @@ TrinaColumn(
 )
 ```
 
+### Dynamic Cell Read-Only Control
+
+For more advanced scenarios, you can make individual cells read-only dynamically using the `checkReadOnly` callback function. This allows you to control cell editability based on the row's data or other conditions:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableEditingMode: true,
+  checkReadOnly: (TrinaRow row, TrinaCell cell) {
+    // Return true to make the cell read-only, false to allow editing
+    // Example: Make cell read-only based on another cell's value
+    return row.cells['status']?.value == 'locked';
+  },
+)
+```
+
+The `checkReadOnly` function provides:
+- `row`: The current row containing the cell
+- `cell`: The current cell being evaluated
+
+This callback is evaluated dynamically each time the grid needs to determine if a cell is editable, and it takes precedence over the static `readOnly` property. This allows for real-time updates when the underlying data changes.
+
+**Common use cases:**
+- Make cells read-only based on row status
+- Conditional editing based on user permissions
+- Time-based restrictions
+- Complex business logic for field editability
+
 ## Editing Modes
 
 ### Manual Editing


### PR DESCRIPTION
## Summary
- Add new section "Dynamic Cell Read-Only Control" to cell-editing.md documentation
- Document the `checkReadOnly` callback function for controlling individual cell editability
- Include practical code example and usage patterns

## Changes
- Added comprehensive documentation for the previously undocumented `checkReadOnly` functionality
- Explained function parameters (`row`, `cell`) and their usage
- Documented precedence over static `readOnly` property and real-time update behavior
- Listed common use cases for dynamic cell read-only control

## Context
This addresses issue #211 where @pravash901 asked about making individual cells read-only dynamically. The functionality already existed in the codebase but was not documented.

Closes #211
