### PR TITLE
fix: include hidden columns when creating new rows

### DIFF
--- a/lib/src/manager/state/row_state.dart
+++ b/lib/src/manager/state/row_state.dart
@@ -195,7 +195,7 @@ mixin RowState implements ITrinaGridState {
   TrinaRow getNewRow() {
     final cells = <String, TrinaCell>{};
 
-    for (var column in refColumns) {
+    for (var column in refColumns.originalList) {
       cells[column.field] = TrinaCell(value: column.type.defaultValue);
     }
 

--- a/test/src/manager/state/row_state_test.dart
+++ b/test/src/manager/state/row_state_test.dart
@@ -1244,6 +1244,61 @@ void main() {
         expect(newRow.cells['time']!.value, '23:59');
       },
     );
+
+    testWidgets(
+      'Should include hidden columns in the new row',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          TrinaColumn(
+            title: 'visible',
+            field: 'visible',
+            type: TrinaColumnType.text(defaultValue: 'visible value'),
+          ),
+          TrinaColumn(
+            title: 'hiddenId',
+            field: 'hiddenId',
+            type: TrinaColumnType.number(defaultValue: 999),
+            hide: true,
+          ),
+          TrinaColumn(
+            title: 'anotherVisible',
+            field: 'anotherVisible',
+            type: TrinaColumnType.text(defaultValue: 'another'),
+          ),
+          TrinaColumn(
+            title: 'hiddenCode',
+            field: 'hiddenCode',
+            type: TrinaColumnType.text(defaultValue: 'CODE123'),
+            hide: true,
+          ),
+        ];
+
+        List<TrinaRow> rows = [];
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: null,
+          scroll: null,
+        );
+
+        // when
+        TrinaRow newRow = stateManager.getNewRow();
+
+        // then
+        // Verify visible columns are included
+        expect(newRow.cells['visible']!.value, 'visible value');
+        expect(newRow.cells['anotherVisible']!.value, 'another');
+
+        // Verify hidden columns are also included
+        expect(newRow.cells['hiddenId']!.value, 999);
+        expect(newRow.cells['hiddenCode']!.value, 'CODE123');
+
+        // Verify all 4 columns are present
+        expect(newRow.cells.length, 4);
+      },
+    );
   });
 
   group('getNewRows', () {


### PR DESCRIPTION
## Summary
- Fixed `getNewRow()` to include hidden columns when creating new rows
- Added unit test to verify hidden columns are properly included

## Problem
Previously, `getNewRow()` only created cells for visible columns by iterating over `refColumns` (a filtered list). This caused issues when hidden columns were needed for calculations or internal state, as reported in #203.

## Solution
Changed line 198 in `row_state.dart` to use `refColumns.originalList` instead of `refColumns`, ensuring all columns (both visible and hidden) are included when creating new rows.

## Test Plan
- Added comprehensive unit test that verifies hidden columns are included in new rows
- Test creates a grid with 2 visible and 2 hidden columns
- Verifies all 4 columns are present in the new row with correct default values

Fixes #203