### PR TITLE
feat: add pagination enhancements with global configuration

### DIFF
--- a/demo/lib/screen/feature/row_lazy_pagination_screen.dart
+++ b/demo/lib/screen/feature/row_lazy_pagination_screen.dart
@@ -27,6 +27,9 @@ class _RowLazyPaginationScreenState extends State<RowLazyPaginationScreen> {
 
   final List<TrinaRow> fakeFetchedRows = [];
 
+  bool showTotalRows = true;
+  bool enableGotoPage = true;
+
   @override
   void initState() {
     super.initState();
@@ -121,6 +124,7 @@ class _RowLazyPaginationScreenState extends State<RowLazyPaginationScreen> {
       TrinaLazyPaginationResponse(
         totalPage: totalPage,
         rows: fetchedRows.toList(),
+        totalRecords: tempList.length,
       ),
     );
   }
@@ -130,9 +134,33 @@ class _RowLazyPaginationScreenState extends State<RowLazyPaginationScreen> {
     return TrinaExampleScreen(
       title: 'Row lazy pagination',
       topTitle: 'Row lazy pagination',
-      topContents: const [
-        Text(
+      topContents: [
+        const Text(
           'Implement pagination in the form of fetching data from the server.',
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Checkbox(
+              value: showTotalRows,
+              onChanged: (value) {
+                setState(() {
+                  showTotalRows = value ?? true;
+                });
+              },
+            ),
+            const Text('Show Total Rows'),
+            const SizedBox(width: 24),
+            Checkbox(
+              value: enableGotoPage,
+              onChanged: (value) {
+                setState(() {
+                  enableGotoPage = value ?? true;
+                });
+              },
+            ),
+            const Text('Enable Go to Page'),
+          ],
         ),
       ],
       topButtons: [
@@ -142,6 +170,7 @@ class _RowLazyPaginationScreenState extends State<RowLazyPaginationScreen> {
         ),
       ],
       body: TrinaGrid(
+        key: ValueKey('$showTotalRows-$enableGotoPage'),
         columns: columns,
         rows: rows,
         onLoaded: (TrinaGridOnLoadedEvent event) {
@@ -178,6 +207,8 @@ class _RowLazyPaginationScreenState extends State<RowLazyPaginationScreen> {
             pageSizeToMove: null,
             fetch: fetch,
             stateManager: stateManager,
+            showTotalRows: showTotalRows,
+            enableGotoPage: enableGotoPage,
           );
         },
       ),

--- a/demo/lib/screen/feature/row_pagination_screen.dart
+++ b/demo/lib/screen/feature/row_pagination_screen.dart
@@ -19,6 +19,9 @@ class _RowPaginationScreenState extends State<RowPaginationScreen> {
 
   final List<TrinaRow> rows = [];
 
+  bool showTotalRows = true;
+  bool enableGotoPage = true;
+
   @override
   void initState() {
     super.initState();
@@ -35,12 +38,36 @@ class _RowPaginationScreenState extends State<RowPaginationScreen> {
     return TrinaExampleScreen(
       title: 'Row pagination',
       topTitle: 'Row pagination',
-      topContents: const [
-        Text(
+      topContents: [
+        const Text(
           'If you pass the built-in TrinaPagination widget as the return value of the createFooter callback when creating a grid, pagination is processed.',
         ),
-        Text(
+        const Text(
           'Also, referring to TrinaPagination, you can create a UI in the desired shape and set it as the response value of the createFooter callback.',
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Checkbox(
+              value: showTotalRows,
+              onChanged: (value) {
+                setState(() {
+                  showTotalRows = value ?? true;
+                });
+              },
+            ),
+            const Text('Show Total Rows'),
+            const SizedBox(width: 24),
+            Checkbox(
+              value: enableGotoPage,
+              onChanged: (value) {
+                setState(() {
+                  enableGotoPage = value ?? true;
+                });
+              },
+            ),
+            const Text('Enable Go to Page'),
+          ],
         ),
       ],
       topButtons: [
@@ -50,6 +77,7 @@ class _RowPaginationScreenState extends State<RowPaginationScreen> {
         ),
       ],
       body: TrinaGrid(
+        key: ValueKey('$showTotalRows-$enableGotoPage'),
         columns: columns,
         rows: rows,
         onLoaded: (TrinaGridOnLoadedEvent event) {
@@ -61,7 +89,11 @@ class _RowPaginationScreenState extends State<RowPaginationScreen> {
         configuration: const TrinaGridConfiguration(),
         createFooter: (stateManager) {
           stateManager.setPageSize(100, notify: false); // default 40
-          return TrinaPagination(stateManager);
+          return TrinaPagination(
+            stateManager,
+            showTotalRows: showTotalRows,
+            enableGotoPage: enableGotoPage,
+          );
         },
       ),
     );

--- a/doc/features/pagination.md
+++ b/doc/features/pagination.md
@@ -18,6 +18,51 @@ Trina Grid supports three main types of pagination:
 | **Lazy (Server-Side)** | Large datasets, server APIs with pagination support | Minimal memory usage, handles millions of records, server-side sorting and filtering | Requires server-side implementation, page changes require network requests |
 | **Infinity Scroll** | Continuous data streams, social media-like feeds | Seamless user experience, progressive loading | More complex to implement with sorting and filtering |
 
+## Pagination Features
+
+All pagination types in Trina Grid include these built-in features:
+
+### Total Rows Display
+
+Shows the total number of pages and records in the footer. Enabled by default.
+
+**Format:** `/ TotalPages [TotalRecords]`
+
+Example: `/ 50 [5000]` means 50 pages with 5000 total records.
+
+### Go to Page
+
+Allows users to jump directly to a specific page via a search icon button. Enabled by default.
+
+**How to use:**
+1. Click the search icon in the pagination footer
+2. Enter the desired page number
+3. Press Enter or click "Go"
+
+### Configuration
+
+Control these features globally via `TrinaGridConfiguration`:
+
+```dart
+TrinaGrid(
+  configuration: TrinaGridConfiguration(
+    paginationShowTotalRows: true,    // Show total rows (default: true)
+    paginationEnableGotoPage: true,   // Enable goto page (default: true)
+  ),
+  // ...
+)
+```
+
+Or override per pagination widget:
+
+```dart
+TrinaPagination(
+  stateManager,
+  showTotalRows: false,      // Override config setting
+  enableGotoPage: false,     // Override config setting
+)
+```
+
 ## Implementation Overview
 
 ### Client-Side Pagination
@@ -26,9 +71,7 @@ Trina Grid supports three main types of pagination:
 TrinaGrid(
   // Grid configuration
   createFooter: (stateManager) {
-    return TrinaPagination(
-      stateManager: stateManager,
-    );
+    return TrinaPagination(stateManager);
   },
 )
 ```

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -106,6 +106,19 @@ class TrinaGridConfiguration {
 
   final TrinaGridLocaleText localeText;
 
+  /// Display total number of rows in pagination footer.
+  ///
+  /// Default is true.
+  /// This applies to both [TrinaPagination] and [TrinaLazyPagination].
+  final bool paginationShowTotalRows;
+
+  /// Enable "Go to page" functionality in pagination footer.
+  ///
+  /// Default is true.
+  /// Shows a button to open a dialog for jumping to a specific page.
+  /// This applies to both [TrinaPagination] and [TrinaLazyPagination].
+  final bool paginationEnableGotoPage;
+
   const TrinaGridConfiguration({
     this.enableMoveDownAfterSelecting = false,
     this.enableMoveHorizontalInEditing = false,
@@ -121,6 +134,8 @@ class TrinaGridConfiguration {
     this.columnFilter = const TrinaGridColumnFilterConfig(),
     this.columnSize = const TrinaGridColumnSizeConfig(),
     this.localeText = const TrinaGridLocaleText(),
+    this.paginationShowTotalRows = true,
+    this.paginationEnableGotoPage = true,
   });
 
   const TrinaGridConfiguration.dark({
@@ -138,6 +153,8 @@ class TrinaGridConfiguration {
     this.columnFilter = const TrinaGridColumnFilterConfig(),
     this.columnSize = const TrinaGridColumnSizeConfig(),
     this.localeText = const TrinaGridLocaleText(),
+    this.paginationShowTotalRows = true,
+    this.paginationEnableGotoPage = true,
   });
 
   void updateLocale() {


### PR DESCRIPTION
## Summary
Added two new pagination features that enhance user experience and data visibility:

1. **Total Rows Display** - Shows `/ TotalPages [TotalRecords]` format in pagination footer
2. **Go to Page** - Search icon button opens a dialog to jump directly to any page

## Features

### Configuration
Both features can be controlled globally via `TrinaGridConfiguration`:

```dart
TrinaGrid(
  configuration: TrinaGridConfiguration(
    paginationShowTotalRows: true,    // default: true
    paginationEnableGotoPage: true,   // default: true
  ),
)
```

Or overridden per pagination widget:

```dart
TrinaPagination(
  stateManager,
  showTotalRows: false,      // override config
  enableGotoPage: false,     // override config
)
```

### Total Rows Display
- Format: `/ 50 [5000]` means 50 pages with 5000 total records
- Shows after page numbers in pagination footer
- Works with both client-side and server-side pagination
- Enabled by default

### Go to Page
- Search icon button in pagination footer
- Opens a dialog with page number input
- Validates input (1 to totalPage)
- Shows error snackbar for invalid input
- Supports Enter key to submit
- Enabled by default

## Implementation

### Files Changed
- `lib/src/trina_grid_configuration.dart` - Added global configuration options
- `lib/src/plugin/trina_pagination.dart` - Implemented features for client-side pagination
- `lib/src/plugin/trina_lazy_pagination.dart` - Implemented features for server-side pagination
- `demo/lib/screen/feature/row_pagination_screen.dart` - Added interactive demo with checkboxes
- `demo/lib/screen/feature/row_lazy_pagination_screen.dart` - Added interactive demo with checkboxes
- `doc/features/pagination.md` - Updated documentation with usage examples

### Key Design Decisions
1. **Default to true** - Features are enabled by default for better out-of-box UX
2. **Nullable parameters** - Widget parameters are nullable, falling back to config defaults
3. **Consistent API** - Both `TrinaPagination` and `TrinaLazyPagination` have identical APIs
4. **Backward compatible** - Existing code works unchanged, new features enabled by default

## Demo
Both pagination demo screens now include interactive checkboxes to toggle features on/off for testing:
- Row pagination demo
- Row lazy pagination demo

## Test Plan
- [x] Tested client-side pagination (TrinaPagination)
- [x] Tested server-side pagination (TrinaLazyPagination)
- [x] Tested global configuration
- [x] Tested per-widget override
- [x] Tested goto page dialog validation
- [x] Tested total rows display with filtering
- [x] Tested demo screens with interactive toggles
- [x] Built and ran demo app successfully

Implements #178