### PR TITLE
feat: add AI instructions syncer configuration and related files

### DIFF
--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,0 +1,5 @@
+---
+alwaysApply: true
+---
+# Format
+- Kindly run dart format . after finishing your changes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,2 @@
+# Format
+- Kindly run dart format . after finishing your changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+# Format
+- Kindly run dart format . after finishing your changes

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,2 @@
+# Format
+- Kindly run dart format . after finishing your changes

--- a/ai-rules.config.yaml
+++ b/ai-rules.config.yaml
@@ -1,0 +1,25 @@
+# AI Instructions Syncer Configuration Template
+# This file controls which files get synced when you save your AI instructions
+
+# Source file that triggers the sync (default: ai-rules.md)
+# This is the file you edit that will be synced to all target files
+sourceFile: ai-rules.md
+
+# Target files to sync to (supports both files and folder paths)
+# Folders will be created automatically if they don't exist
+# Uncomment or add the files you want to sync to
+
+targetFiles:
+  - CLAUDE.md                             # Claude Code
+  - .cursor/rules/rules.mdc               # Cursor rules file
+  - .github/copilot-instructions.md       # GitHub Copilot repository-wide instructions
+  #- .windsurf/rules/rules.md              # Windsurf rules directory (recommended)
+  - CODEX.md                              # Codex rules file
+
+
+# Enable automatic syncing on save
+autoSync: true
+
+# Default value for alwaysApply in Cursor MDC files (true/false)
+# This will be added to .mdc files if they don't already have YAML frontmatter
+cursorMdcAlwaysApply: true

--- a/ai-rules.md
+++ b/ai-rules.md
@@ -1,0 +1,2 @@
+# Format
+- Kindly run dart format . after finishing your changes


### PR DESCRIPTION
- Introduced ai-rules.config.yaml to manage syncing of AI instructions across multiple target files.
- Created ai-rules.md, CLAUDE.md, CODEX.md, and .github/copilot-instructions.md with formatting guidelines.
- Added rules.mdc file in .cursor/rules/ with default settings for automatic syncing.

This setup streamlines the process of maintaining consistent AI instructions across various platforms.