### PR TITLE
feat: add click-to-jump functionality to scrollbars

### DIFF
--- a/lib/src/widgets/trina_horizontal_scroll_bar.dart
+++ b/lib/src/widgets/trina_horizontal_scroll_bar.dart
@@ -186,6 +186,44 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
         });
       },
       child: GestureDetector(
+        onTapUp: (details) {
+          // Handle clicks on the track to jump to that position
+          final scrollController =
+              widget.stateManager.scroll.bodyRowsHorizontal;
+          if (scrollController == null) return;
+
+          final scrollExtent = widget.horizontalScrollExtentNotifier.value;
+          final viewportExtent = widget.horizontalViewportExtentNotifier.value;
+
+          if (scrollExtent <= 0) return;
+
+          final double thumbWidth =
+              (viewportExtent / (viewportExtent + scrollExtent)) * widget.width;
+
+          // Get the local X position of the tap
+          final tapX = details.localPosition.dx;
+
+          // For RTL, we need to adjust the tap position
+          final adjustedTapX = widget.stateManager.isRTL
+              ? widget.width - tapX
+              : tapX;
+
+          // Calculate the scroll position where the center of the thumb should be at tapX
+          // thumbPosition = (scrollOffset / scrollExtent) * (widget.width - thumbWidth)
+          // Solving for scrollOffset when thumbPosition + thumbWidth/2 = tapX:
+          final targetThumbPosition = adjustedTapX - (thumbWidth / 2);
+          final newScrollOffset =
+              (targetThumbPosition / (widget.width - thumbWidth)) *
+              scrollExtent;
+
+          // Clamp to valid range
+          final clampedOffset = newScrollOffset.clamp(
+            0.0,
+            scrollController.position.maxScrollExtent,
+          );
+
+          scrollController.jumpTo(clampedOffset);
+        },
         onPanDown: (_) {
           setState(() {
             _isDragging = true;

--- a/lib/src/widgets/trina_vertical_scroll_bar.dart
+++ b/lib/src/widgets/trina_vertical_scroll_bar.dart
@@ -187,6 +187,39 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
         });
       },
       child: GestureDetector(
+        onTapUp: (details) {
+          // Handle clicks on the track to jump to that position
+          final scrollController = widget.stateManager.scroll.bodyRowsVertical;
+          if (scrollController == null) return;
+
+          final scrollExtent = widget.verticalScrollExtentNotifier.value;
+          final viewportExtent = widget.verticalViewportExtentNotifier.value;
+
+          if (scrollExtent <= 0) return;
+
+          final double thumbHeight =
+              (viewportExtent / (viewportExtent + scrollExtent)) *
+              widget.height;
+
+          // Get the local Y position of the tap
+          final tapY = details.localPosition.dy;
+
+          // Calculate the scroll position where the center of the thumb should be at tapY
+          // thumbPosition = (scrollOffset / scrollExtent) * (widget.height - thumbHeight)
+          // Solving for scrollOffset when thumbPosition + thumbHeight/2 = tapY:
+          final targetThumbPosition = tapY - (thumbHeight / 2);
+          final newScrollOffset =
+              (targetThumbPosition / (widget.height - thumbHeight)) *
+              scrollExtent;
+
+          // Clamp to valid range
+          final clampedOffset = newScrollOffset.clamp(
+            0.0,
+            scrollController.position.maxScrollExtent,
+          );
+
+          scrollController.jumpTo(clampedOffset);
+        },
         onPanDown: (_) {
           setState(() {
             _isDragging = true;


### PR DESCRIPTION
## Summary
- Added click-to-jump functionality to both vertical and horizontal scrollbars
- Clicking anywhere on the scrollbar track now jumps the scroll position to that location
- The thumb centers itself at the clicked position, matching standard platform scrollbar behavior
- RTL (right-to-left) language support included for horizontal scrollbar clicks

## Changes
- Modified `trina_vertical_scroll_bar.dart` to add `onTapUp` handler for click-to-jump
- Modified `trina_horizontal_scroll_bar.dart` to add `onTapUp` handler with RTL support
- Thumb position calculation ensures the center of the thumb aligns with the click point

## Test plan
- [x] Run `dart analyze` - no new errors
- [x] Run `dart format .` - code formatted
- [x] Test clicking on vertical scrollbar track - should jump to clicked position
- [x] Test clicking on horizontal scrollbar track - should jump to clicked position  
- [x] Test with RTL languages - horizontal scrollbar should work correctly
- [x] Verify thumb dragging still works as before