### PR TITLE
fix: apply rowWrapper to frozen column rows (#238)

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -59,6 +59,7 @@ import 'screen/feature/pages_list_screen.dart';
 import 'screen/feature/frozen_rows_screen.dart';
 import 'screen/feature/scrollbars.dart';
 import 'screen/feature/row_wrapper_screen.dart';
+import 'screen/feature/row_wrapper_frozen_screen.dart';
 import 'screen/feature/multiitems_delegate_demo_screen.dart';
 import 'screen/feature/custom_footer_screen.dart';
 import 'screen/feature/dynamic_row_height_demo.dart';
@@ -162,6 +163,8 @@ class MyApp extends StatelessWidget {
         LoadingOptionsScreen.routeName: (context) =>
             const LoadingOptionsScreen(),
         RowWrapperScreen.routeName: (context) => const RowWrapperScreen(),
+        RowWrapperFrozenScreen.routeName: (context) =>
+            const RowWrapperFrozenScreen(),
         MultiItemsDelegateDemoScreen.routeName: (context) =>
             const MultiItemsDelegateDemoScreen(),
         DynamicRowHeightDemo.routeName: (context) =>

--- a/demo/lib/screen/feature/row_wrapper_frozen_screen.dart
+++ b/demo/lib/screen/feature/row_wrapper_frozen_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../dummy_data/development.dart';
+import '../../widget/trina_example_button.dart';
+import '../../widget/trina_example_screen.dart';
+
+class RowWrapperFrozenScreen extends StatefulWidget {
+  static const routeName = 'feature/row-wrapper-frozen';
+
+  const RowWrapperFrozenScreen({super.key});
+
+  @override
+  State<RowWrapperFrozenScreen> createState() => _RowWrapperFrozenScreenState();
+}
+
+class _RowWrapperFrozenScreenState extends State<RowWrapperFrozenScreen> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final dummyData = DummyData(10, 30);
+
+    // Create columns with some frozen left and right
+    for (int i = 0; i < dummyData.columns.length; i++) {
+      final column = dummyData.columns[i];
+      if (i < 2) {
+        // First 2 columns frozen left
+        column.frozen = TrinaColumnFrozen.start;
+      } else if (i >= dummyData.columns.length - 2) {
+        // Last 2 columns frozen right
+        column.frozen = TrinaColumnFrozen.end;
+      }
+      columns.add(column);
+    }
+
+    rows.addAll(dummyData.rows);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaExampleScreen(
+      title: 'Row Wrapper with Frozen Columns',
+      topTitle: 'Row Wrapper with Frozen Columns',
+      topContents: const [
+        Text('Demonstrates rowWrapper working with frozen columns.'),
+        Text(
+          'Notice how the wrapper styling is applied to ALL rows, including those in frozen columns.',
+        ),
+        Text(
+          'The first 2 columns are frozen left, and the last 2 columns are frozen right.',
+        ),
+      ],
+      topButtons: [
+        TrinaExampleButton(
+          url:
+              'https://github.com/doonfrs/trina_grid/blob/master/doc/features/row-wrapper.md',
+        ),
+      ],
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        createFooter: (stateManager) {
+          return Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.deepPurple.shade50,
+              border: Border(
+                top: BorderSide(color: Colors.deepPurple.shade200, width: 2),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.info_outline, color: Colors.deepPurple.shade700),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'The purple borders and shadows are applied via rowWrapper to all rows, including frozen columns',
+                    style: TextStyle(
+                      color: Colors.deepPurple.shade700,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        rowWrapper: (context, rowWidget, rowData, stateManager) {
+          return Container(
+            margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.deepPurple, width: 2),
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.deepPurple.withAlpha(8),
+                  blurRadius: 6,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+              color: Colors.white,
+            ),
+            child: rowWidget,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -66,6 +66,7 @@ import 'feature/pages_list_screen.dart';
 import 'feature/scrollbars.dart';
 import 'feature/date_time_column_screen.dart';
 import 'feature/row_wrapper_screen.dart';
+import 'feature/row_wrapper_frozen_screen.dart';
 import 'feature/multiitems_delegate_demo_screen.dart';
 import 'feature/custom_footer_screen.dart';
 import 'feature/dynamic_row_height_demo.dart';
@@ -650,6 +651,15 @@ class _TrinaFeaturesState extends State<TrinaFeatures> {
             'Wrap each row with your own widget for custom styling or interactivity.',
         onTapLiveDemo: () {
           Navigator.pushNamed(context, RowWrapperScreen.routeName);
+        },
+        trailing: newIcon,
+      ),
+      TrinaListTile(
+        title: 'Row Wrapper with Frozen Columns',
+        description:
+            'Demonstrates rowWrapper working with frozen columns - styling is applied to all rows including frozen ones.',
+        onTapLiveDemo: () {
+          Navigator.pushNamed(context, RowWrapperFrozenScreen.routeName);
         },
         trailing: newIcon,
       ),

--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -63,14 +63,23 @@ class TrinaLeftFrozenRowsState
         .toList();
   }
 
-  Widget _buildRow(TrinaRow row, int index) {
-    return TrinaBaseRow(
+  Widget _buildRow(BuildContext context, TrinaRow row, int index) {
+    Widget rowWidget = TrinaBaseRow(
       key: ValueKey('left_frozen_row_${row.key}'),
       rowIdx: index,
       row: row,
       columns: _columns,
       stateManager: stateManager,
+      visibilityLayout: true,
     );
+
+    return stateManager.rowWrapper?.call(
+          context,
+          rowWidget,
+          row,
+          stateManager,
+        ) ??
+        rowWidget;
   }
 
   @override
@@ -83,7 +92,7 @@ class TrinaLeftFrozenRowsState
             children: _frozenTopRows
                 .asMap()
                 .entries
-                .map((e) => _buildRow(e.value, e.key))
+                .map((e) => _buildRow(context, e.value, e.key))
                 .toList(),
           ),
         // Scrollable rows
@@ -95,7 +104,7 @@ class TrinaLeftFrozenRowsState
             itemCount: _scrollableRows.length,
             // Remove fixed itemExtent for variable heights
             itemBuilder: (ctx, i) =>
-                _buildRow(_scrollableRows[i], i + _frozenTopRows.length),
+                _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),
         ),
         // Frozen bottom rows
@@ -106,6 +115,7 @@ class TrinaLeftFrozenRowsState
                 .entries
                 .map(
                   (e) => _buildRow(
+                    context,
                     e.value,
                     e.key + _frozenTopRows.length + _scrollableRows.length,
                   ),

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -63,14 +63,23 @@ class TrinaRightFrozenRowsState
         .toList();
   }
 
-  Widget _buildRow(TrinaRow row, int index) {
-    return TrinaBaseRow(
+  Widget _buildRow(BuildContext context, TrinaRow row, int index) {
+    Widget rowWidget = TrinaBaseRow(
       key: ValueKey('right_frozen_row_${row.key}'),
       rowIdx: index,
       row: row,
       columns: _columns,
       stateManager: stateManager,
+      visibilityLayout: true,
     );
+
+    return stateManager.rowWrapper?.call(
+          context,
+          rowWidget,
+          row,
+          stateManager,
+        ) ??
+        rowWidget;
   }
 
   @override
@@ -83,7 +92,7 @@ class TrinaRightFrozenRowsState
             children: _frozenTopRows
                 .asMap()
                 .entries
-                .map((e) => _buildRow(e.value, e.key))
+                .map((e) => _buildRow(context, e.value, e.key))
                 .toList(),
           ),
         // Scrollable rows
@@ -95,7 +104,7 @@ class TrinaRightFrozenRowsState
             itemCount: _scrollableRows.length,
             // Remove fixed itemExtent for variable heights
             itemBuilder: (ctx, i) =>
-                _buildRow(_scrollableRows[i], i + _frozenTopRows.length),
+                _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),
         ),
         // Frozen bottom rows
@@ -106,6 +115,7 @@ class TrinaRightFrozenRowsState
                 .entries
                 .map(
                   (e) => _buildRow(
+                    context,
                     e.value,
                     e.key + _frozenTopRows.length + _scrollableRows.length,
                   ),


### PR DESCRIPTION
## Summary
Fixes the issue where `rowWrapper` was not being applied to rows in frozen columns (left and right). This ensures consistent row styling and behavior across all column types.

## Changes Made

### Core Fix
- **[lib/src/ui/trina_left_frozen_rows.dart](lib/src/ui/trina_left_frozen_rows.dart)**:
  - Updated `_buildRow` method to accept `BuildContext` parameter
  - Applied `rowWrapper` callback if defined
  - Added `visibilityLayout: true` to `TrinaBaseRow`
  - Updated all `_buildRow` calls to pass context
  
- **[lib/src/ui/trina_right_frozen_rows.dart](lib/src/ui/trina_right_frozen_rows.dart)**:
  - Applied the same changes as left frozen rows

### Demo
- **[demo/lib/screen/feature/row_wrapper_frozen_screen.dart](demo/lib/screen/feature/row_wrapper_frozen_screen.dart)** (new):
  - Created demo showcasing rowWrapper with frozen columns
  - 10 columns: first 2 frozen left, last 2 frozen right
  - Custom row styling (purple borders, shadows, rounded corners)
  - Informative footer explaining the feature

- **[demo/lib/main.dart](demo/lib/main.dart)** & **[demo/lib/screen/home_screen.dart](demo/lib/screen/home_screen.dart)**:
  - Registered new demo screen in routes and menu

## Implementation Details

The fix implements the same pattern used in `trina_body_rows.dart`:

```dart
Widget _buildRow(BuildContext context, TrinaRow row, int index) {
  Widget rowWidget = TrinaBaseRow(
    key: ValueKey('left_frozen_row_\${row.key}'),
    rowIdx: index,
    row: row,
    columns: _columns,
    stateManager: stateManager,
    visibilityLayout: true,
  );

  return stateManager.rowWrapper?.call(
        context,
        rowWidget,
        row,
        stateManager,
      ) ??
      rowWidget;
}
```

