### PR TITLE
feat: add cancellable onBeforeActiveCellChange event

### DIFF
--- a/doc/features/cell-navigation-validation.md
+++ b/doc/features/cell-navigation-validation.md
@@ -1,0 +1,486 @@
+# Cell Navigation Validation
+
+TrinaGrid provides a powerful callback mechanism to validate and control cell navigation. This feature allows you to prevent users from navigating away from a cell or row until certain conditions are met, such as data validation.
+
+## Overview
+
+The `onBeforeActiveCellChange` callback fires **before** the active cell changes, allowing you to:
+
+- Validate data in the current cell/row
+- Prevent navigation if validation fails
+- Implement custom navigation rules
+- Show validation errors without visual flicker
+
+This is particularly useful for building data entry forms where strict validation rules are required before proceeding.
+
+## Basic Usage
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Return true to allow the change
+    // Return false to cancel the change
+    return true;
+  },
+)
+```
+
+## Event Object
+
+The `TrinaGridOnBeforeActiveCellChangeEvent` provides complete context about the navigation:
+
+```dart
+class TrinaGridOnBeforeActiveCellChangeEvent {
+  /// The current (old) cell that is active
+  final TrinaCell? oldCell;
+
+  /// The current (old) row index
+  final int? oldRowIdx;
+
+  /// The new cell that will become active
+  final TrinaCell newCell;
+
+  /// The new row index
+  final int newRowIdx;
+}
+```
+
+## Common Use Cases
+
+### 1. Row-Level Validation
+
+Prevent navigation to a different row until the current row is valid:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Check if user is trying to change rows
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      // Validate the current row
+      final currentRow = rows[event.oldRowIdx!];
+      final isValid = validateRow(currentRow);
+
+      if (!isValid) {
+        // Show error message
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Please fix errors in the current row before proceeding'),
+            backgroundColor: Colors.red,
+          ),
+        );
+
+        // Cancel navigation
+        return false;
+      }
+    }
+
+    // Allow navigation
+    return true;
+  },
+)
+```
+
+### 2. Required Field Validation
+
+Ensure required fields are filled before navigating away:
+
+```dart
+bool validateRow(TrinaRow row) {
+  // Check if name field is not empty
+  final name = row.cells['name']?.value;
+  if (name == null || name.toString().trim().isEmpty) {
+    return false;
+  }
+
+  // Check if email field is not empty
+  final email = row.cells['email']?.value;
+  if (email == null || email.toString().trim().isEmpty) {
+    return false;
+  }
+
+  return true;
+}
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+      if (!validateRow(currentRow)) {
+        return false; // Cancel navigation
+      }
+    }
+    return true;
+  },
+)
+```
+
+### 3. Async Validation
+
+Perform asynchronous validation before allowing navigation:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+
+      // Show loading indicator
+      final loadingDialog = showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => Center(child: CircularProgressIndicator()),
+      );
+
+      // Perform async validation
+      validateRowAsync(currentRow).then((isValid) {
+        // Hide loading indicator
+        Navigator.of(context).pop();
+
+        if (!isValid) {
+          showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: Text('Validation Error'),
+              content: Text('Please fix errors before proceeding'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: Text('OK'),
+                ),
+              ],
+            ),
+          );
+        }
+      });
+
+      // Note: For async validation, you might need to store state
+      // and prevent navigation in the sync callback
+      return false; // Cancel for now
+    }
+    return true;
+  },
+)
+```
+
+**Note**: The callback is synchronous. For async validation, you may need to implement a two-step approach:
+1. Cancel navigation in the callback
+2. Perform async validation
+3. If valid, programmatically trigger navigation using `stateManager.setCurrentCell()`
+
+### 4. Conditional Navigation Rules
+
+Allow or prevent navigation based on specific conditions:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Allow same-row navigation
+    if (event.oldRowIdx == event.newRowIdx) {
+      return true;
+    }
+
+    // Allow navigation from the last row
+    if (event.oldRowIdx == rows.length - 1) {
+      return true;
+    }
+
+    // For other cases, validate the current row
+    if (event.oldRowIdx != null) {
+      final currentRow = rows[event.oldRowIdx!];
+      return validateRow(currentRow);
+    }
+
+    return true;
+  },
+)
+```
+
+### 5. Field-Specific Validation
+
+Prevent navigation based on specific field validation:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+
+      // Validate specific fields
+      final email = currentRow.cells['email']?.value?.toString() ?? '';
+      final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+
+      if (email.isNotEmpty && !emailRegex.hasMatch(email)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Please enter a valid email address'),
+            backgroundColor: Colors.red,
+          ),
+        );
+        return false;
+      }
+    }
+
+    return true;
+  },
+)
+```
+
+## Integration with Other Callbacks
+
+The `onBeforeActiveCellChange` callback works seamlessly with other cell-related callbacks:
+
+### Combining with onActiveCellChanged
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Validate before navigation
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final isValid = validateRow(rows[event.oldRowIdx!]);
+      if (!isValid) {
+        return false; // Cancel navigation
+      }
+    }
+    return true;
+  },
+  onActiveCellChanged: (event) {
+    // This only fires if navigation was allowed
+    print('Active cell changed to row ${event.idx}');
+
+    // You can perform actions after successful navigation
+    loadAdditionalDataForRow(event.idx);
+  },
+)
+```
+
+### Combining with onValidationFailed
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Prevent row navigation until validation passes
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+      return validateAllFieldsInRow(currentRow);
+    }
+    return true;
+  },
+  onValidationFailed: (event) {
+    // This fires when individual cell validation fails
+    print('Field ${event.column.title} validation failed: ${event.errorMessage}');
+  },
+)
+```
+
+## Keyboard and Mouse Navigation
+
+The `onBeforeActiveCellChange` callback works for **all** navigation methods:
+
+- **Keyboard navigation**: Arrow keys, Tab, Enter
+- **Mouse clicks**: Clicking on cells
+- **Programmatic navigation**: `stateManager.setCurrentCell()`
+
+This ensures consistent validation regardless of how the user navigates.
+
+## Best Practices
+
+1. **Provide Clear Feedback**: Always show clear error messages when preventing navigation
+   ```dart
+   if (!isValid) {
+     ScaffoldMessenger.of(context).showSnackBar(
+       SnackBar(content: Text('Please complete all required fields')),
+     );
+     return false;
+   }
+   ```
+
+2. **Allow Same-Row Navigation**: Let users move between cells in the same row
+   ```dart
+   if (event.oldRowIdx == event.newRowIdx) {
+     return true; // Allow cell navigation within same row
+   }
+   ```
+
+3. **Handle First Selection**: Check if `oldRowIdx` is null (first cell selection)
+   ```dart
+   if (event.oldRowIdx == null) {
+     return true; // Always allow first cell selection
+   }
+   ```
+
+4. **Keep Validation Logic Fast**: The callback is synchronous and blocks navigation
+   ```dart
+   // Good: Fast validation
+   return row.cells['name']?.value != null;
+
+   // Avoid: Slow operations that block UI
+   // return await fetchValidationFromServer(row);
+   ```
+
+5. **Use with Cell Validation**: Combine with column-level validators for comprehensive validation
+   ```dart
+   TrinaColumn(
+     field: 'email',
+     validator: (value, context) {
+       // Cell-level validation
+       if (!isValidEmail(value)) {
+         return 'Invalid email';
+       }
+       return null;
+     },
+   ),
+   ```
+
+6. **Visual Indicators**: Highlight invalid cells to guide users
+   ```dart
+   cellColorCallback: (cellContext) {
+     if (!isValidCell(cellContext.cell)) {
+       return Colors.red.shade50;
+     }
+     return Colors.white;
+   },
+   ```
+
+## Differences from onActiveCellChanged
+
+| Feature | onBeforeActiveCellChange | onActiveCellChanged |
+|---------|-------------------------|---------------------|
+| **Timing** | Before state changes | After state changes |
+| **Can cancel** | Yes (return false) | No |
+| **Return type** | bool | void |
+| **Use case** | Validation, prevention | Tracking, logging |
+| **Old cell info** | Yes (provided in event) | No |
+
+## Example: Complete Validation Form
+
+```dart
+class ValidatedGrid extends StatelessWidget {
+  final List<TrinaColumn> columns = [
+    TrinaColumn(
+      title: 'Name',
+      field: 'name',
+      type: TrinaColumnType.text(),
+      validator: (value, context) {
+        if (value == null || value.toString().trim().isEmpty) {
+          return 'Name is required';
+        }
+        return null;
+      },
+    ),
+    TrinaColumn(
+      title: 'Email',
+      field: 'email',
+      type: TrinaColumnType.text(),
+      validator: (value, context) {
+        if (value == null || value.toString().trim().isEmpty) {
+          return 'Email is required';
+        }
+        final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+        if (!emailRegex.hasMatch(value.toString())) {
+          return 'Invalid email format';
+        }
+        return null;
+      },
+    ),
+  ];
+
+  bool validateRow(TrinaRow row) {
+    // Check all cells in the row
+    for (final column in columns) {
+      final cell = row.cells[column.field];
+      if (column.validator != null) {
+        final error = column.validator!(
+          cell?.value,
+          TrinaValidationContext(
+            column: column,
+            row: row,
+            rowIdx: 0,
+            oldValue: cell?.value,
+          ),
+        );
+        if (error != null) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      columns: columns,
+      rows: rows,
+      onBeforeActiveCellChange: (event) {
+        // Prevent row navigation if current row is invalid
+        if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+          final currentRow = rows[event.oldRowIdx!];
+          final isValid = validateRow(currentRow);
+
+          if (!isValid) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Please fix validation errors before proceeding'),
+                backgroundColor: Colors.red,
+              ),
+            );
+            return false;
+          }
+        }
+
+        return true;
+      },
+      onValidationFailed: (event) {
+        // Show specific field validation errors
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${event.column.title}: ${event.errorMessage}'),
+            backgroundColor: Colors.orange,
+          ),
+        );
+      },
+      cellColorCallback: (cellContext) {
+        // Highlight invalid cells
+        if (cellContext.column.validator != null) {
+          final error = cellContext.column.validator!(
+            cellContext.cell.value,
+            TrinaValidationContext(
+              column: cellContext.column,
+              row: cellContext.row,
+              rowIdx: cellContext.rowIdx,
+              oldValue: cellContext.cell.value,
+            ),
+          );
+          if (error != null) {
+            return Colors.red.shade50;
+          }
+        }
+        return Colors.white;
+      },
+    );
+  }
+}
+```
+
+## Related Features
+
+- [Cell Validation](cell-validation.md) - For column-level and cell-level validation
+- [Cell Editing](cell-editing.md) - For controlling cell editing behavior
+- [Cell Selection](cell-selection.md) - For understanding cell selection and navigation
+- [Cell Value Change Handling](cell_value_change_handling.md) - For handling value changes

--- a/doc/features/cell-validation.md
+++ b/doc/features/cell-validation.md
@@ -309,6 +309,7 @@ TrinaColumn(
 
 ## Related Features
 
+- [Cell Navigation Validation](cell-navigation-validation.md) - For preventing navigation away from invalid cells/rows
 - [Column Types](column-types.md) - For details on built-in column types and their validation
 - [Cell Editing](cell-editing.md) - For more details on cell editing behavior
 - [Cell Value Change Handling](cell_value_change_handling.md) - For handling cell value changes

--- a/doc/index.md
+++ b/doc/index.md
@@ -47,6 +47,7 @@ Welcome to the official documentation for TrinaGrid, a powerful data grid for Fl
 
 - [Cell Selection](features/cell-selection.md)
 - [Cell Editing](features/cell-editing.md)
+- [Cell Navigation Validation](features/cell-navigation-validation.md)
 - [Cell Renderers](features/cell-renderer.md)
 - [Cell Validation](features/cell-validation.md)
 - [Cell Value Change Handling](features/cell_value_change_handling.md)

--- a/lib/src/manager/state/cell_state.dart
+++ b/lib/src/manager/state/cell_state.dart
@@ -193,6 +193,23 @@ mixin CellState implements ITrinaGridState {
       return;
     }
 
+    // Call onBeforeActiveCellChange callback before changing state
+    if (onBeforeActiveCellChange != null) {
+      final shouldProceed = onBeforeActiveCellChange!(
+        TrinaGridOnBeforeActiveCellChangeEvent(
+          oldCell: currentCell,
+          oldRowIdx: currentCellPosition?.rowIdx,
+          newCell: cell,
+          newRowIdx: rowIdx,
+        ),
+      );
+
+      // If callback returns false, cancel the cell change
+      if (!shouldProceed) {
+        return;
+      }
+    }
+
     _state._currentCell = cell;
 
     _state._currentCellPosition = TrinaGridCellPosition(

--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -30,6 +30,8 @@ abstract class IGridState {
 
   TrinaOnRowsMovedEventCallback? get onRowsMoved;
 
+  TrinaOnBeforeActiveCellChangeEventCallback? get onBeforeActiveCellChange;
+
   TrinaOnActiveCellChangedEventCallback? get onActiveCellChanged;
 
   TrinaOnColumnsMovedEventCallback? get onColumnsMoved;

--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -85,6 +85,7 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
     this.onRowEnter,
     this.onRowExit,
     this.onRowsMoved,
+    this.onBeforeActiveCellChange,
     this.onActiveCellChanged,
     this.onColumnsMoved,
     this.rowColorCallback,
@@ -171,6 +172,9 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
 
   @override
   final TrinaOnRowsMovedEventCallback? onRowsMoved;
+
+  @override
+  final TrinaOnBeforeActiveCellChangeEventCallback? onBeforeActiveCellChange;
 
   @override
   final TrinaOnActiveCellChangedEventCallback? onActiveCellChanged;
@@ -324,6 +328,7 @@ class TrinaGridStateManager extends TrinaGridStateChangeNotifier {
     super.onRowEnter,
     super.onRowExit,
     super.onRowsMoved,
+    super.onBeforeActiveCellChange,
     super.onActiveCellChanged,
     super.onColumnsMoved,
     super.rowColorCallback,

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -61,6 +61,9 @@ typedef TrinaCellColorCallback =
 typedef TrinaSelectDateCallBack =
     Future<DateTime?> Function(TrinaCell dateCell, TrinaColumn column);
 
+typedef TrinaOnBeforeActiveCellChangeEventCallback =
+    bool Function(TrinaGridOnBeforeActiveCellChangeEvent event);
+
 typedef TrinaOnActiveCellChangedEventCallback =
     void Function(TrinaGridOnActiveCellChangedEvent event);
 
@@ -105,6 +108,7 @@ class TrinaGrid extends TrinaStatefulWidget {
     this.onRowEnter,
     this.onRowExit,
     this.onRowsMoved,
+    this.onBeforeActiveCellChange,
     this.onActiveCellChanged,
     this.onColumnsMoved,
     this.createHeader,
@@ -261,6 +265,27 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// if [TrinaColumn.enableRowDrag] is enabled.
   /// {@endtemplate}
   final TrinaOnRowsMovedEventCallback? onRowsMoved;
+
+  /// {@template trina_grid_property_onBeforeActiveCellChange}
+  /// Callback for receiving events before the active cell changes.
+  /// Return true to allow the change, false to cancel it.
+  /// This allows implementing validation logic that can prevent navigation.
+  ///
+  /// Example:
+  /// ```dart
+  /// onBeforeActiveCellChange: (event) {
+  ///   // Validate current row before allowing navigation
+  ///   if (event.oldRowIdx != event.newRowIdx) {
+  ///     final isValid = validateRow(event.oldRowIdx);
+  ///     if (!isValid) {
+  ///       return false; // Cancel navigation
+  ///     }
+  ///   }
+  ///   return true; // Allow navigation
+  /// },
+  /// ```
+  /// {@endtemplate}
+  final TrinaOnBeforeActiveCellChangeEventCallback? onBeforeActiveCellChange;
 
   /// {@template trina_grid_property_onActiveCellChanged}
   /// Callback for receiving events
@@ -626,6 +651,7 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       onRowEnter: widget.onRowEnter,
       onRowExit: widget.onRowExit,
       onRowsMoved: widget.onRowsMoved,
+      onBeforeActiveCellChange: widget.onBeforeActiveCellChange,
       onActiveCellChanged: widget.onActiveCellChanged,
       onColumnsMoved: widget.onColumnsMoved,
       rowColorCallback: widget.rowColorCallback,

--- a/lib/src/trina_grid_events.dart
+++ b/lib/src/trina_grid_events.dart
@@ -222,6 +222,36 @@ class TrinaGridOnColumnsMovedEvent {
   }
 }
 
+/// Event triggered before the active cell changes.
+/// Return true to allow the change, false to cancel it.
+class TrinaGridOnBeforeActiveCellChangeEvent {
+  /// The current (old) cell that is active
+  final TrinaCell? oldCell;
+
+  /// The current (old) row index
+  final int? oldRowIdx;
+
+  /// The new cell that will become active
+  final TrinaCell newCell;
+
+  /// The new row index
+  final int newRowIdx;
+
+  const TrinaGridOnBeforeActiveCellChangeEvent({
+    required this.oldCell,
+    required this.oldRowIdx,
+    required this.newCell,
+    required this.newRowIdx,
+  });
+
+  @override
+  String toString() {
+    String out = '[TrinaGridOnBeforeActiveCellChangeEvent] ';
+    out += 'OldRowIdx: $oldRowIdx, NewRowIdx: $newRowIdx';
+    return out;
+  }
+}
+
 /// When the active cell changes this callback is called
 class TrinaGridOnActiveCellChangedEvent {
   final int idx;

--- a/test/src/manager/state/cell_state_before_change_test.dart
+++ b/test/src/manager/state/cell_state_before_change_test.dart
@@ -1,0 +1,458 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../../helper/column_helper.dart';
+import '../../../helper/row_helper.dart';
+import '../../../mock/shared_mocks.mocks.dart';
+
+void main() {
+  TrinaGridStateManager createStateManager({
+    required List<TrinaColumn> columns,
+    required List<TrinaRow> rows,
+    FocusNode? gridFocusNode,
+    TrinaGridScrollController? scroll,
+    BoxConstraints? layout,
+    TrinaGridConfiguration configuration = const TrinaGridConfiguration(),
+    TrinaGridMode? mode,
+    bool isRTL = false,
+    TrinaOnBeforeActiveCellChangeEventCallback? onBeforeActiveCellChange,
+    TrinaOnActiveCellChangedEventCallback? onActiveCellChanged,
+  }) {
+    final stateManager = TrinaGridStateManager(
+      columns: columns,
+      rows: rows,
+      gridFocusNode: gridFocusNode ?? MockFocusNode(),
+      scroll: scroll ?? MockTrinaGridScrollController(),
+      configuration: configuration,
+      mode: mode,
+      onBeforeActiveCellChange: onBeforeActiveCellChange,
+      onActiveCellChanged: onActiveCellChanged,
+    );
+
+    stateManager.setEventManager(MockTrinaGridEventManager());
+    stateManager.setTextDirection(
+      isRTL ? TextDirection.rtl : TextDirection.ltr,
+    );
+    if (layout != null) {
+      stateManager.setLayout(layout);
+    }
+
+    return stateManager;
+  }
+
+  group('onBeforeActiveCellChange callback', () {
+    testWidgets(
+      'When onBeforeActiveCellChange returns true, cell change should proceed',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        bool callbackCalled = false;
+        TrinaGridOnBeforeActiveCellChangeEvent? capturedEvent;
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: (event) {
+            callbackCalled = true;
+            capturedEvent = event;
+            return true; // Allow the change
+          },
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+        expect(stateManager.currentCellPosition!.rowIdx, 0);
+
+        // Try to change to a different cell
+        callbackCalled = false;
+        stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+        // then
+        expect(callbackCalled, isTrue);
+        expect(capturedEvent, isNotNull);
+        expect(capturedEvent!.oldCell, rows[0].cells['col0']);
+        expect(capturedEvent!.oldRowIdx, 0);
+        expect(capturedEvent!.newCell, rows[2].cells['col1']);
+        expect(capturedEvent!.newRowIdx, 2);
+        expect(stateManager.currentCell, rows[2].cells['col1']);
+        expect(stateManager.currentCellPosition!.rowIdx, 2);
+      },
+    );
+
+    testWidgets(
+      'When onBeforeActiveCellChange returns false, cell change should be cancelled',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        bool callbackCalled = false;
+        bool blockChanges = false;
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: (event) {
+            callbackCalled = true;
+            return !blockChanges; // Cancel only when blockChanges is true
+          },
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        // First, set the initial cell (should succeed)
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+        expect(stateManager.currentCellPosition!.rowIdx, 0);
+
+        // Now enable blocking
+        blockChanges = true;
+        callbackCalled = false;
+
+        // Try to change to a different cell (should be blocked)
+        stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+        // then
+        expect(callbackCalled, isTrue);
+        // Cell should not have changed
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+        expect(stateManager.currentCellPosition!.rowIdx, 0);
+      },
+    );
+
+    testWidgets(
+      'When onBeforeActiveCellChange is not set, cell change should proceed normally',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: null, // No callback
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+
+        stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+        // then
+        expect(stateManager.currentCell, rows[2].cells['col1']);
+        expect(stateManager.currentCellPosition!.rowIdx, 2);
+      },
+    );
+
+    testWidgets('Validation scenario: prevent row change if validation fails', (
+      WidgetTester tester,
+    ) async {
+      // given
+      List<TrinaColumn> columns = [
+        ...ColumnHelper.textColumn('col', count: 3, width: 150),
+      ];
+
+      List<TrinaRow> rows = RowHelper.count(5, columns);
+
+      // Simulate validation: only allow navigation from row 0 to row 1
+      TrinaGridStateManager stateManager = createStateManager(
+        columns: columns,
+        rows: rows,
+        onBeforeActiveCellChange: (event) {
+          // Allow initial cell selection
+          if (event.oldRowIdx == null) {
+            return true;
+          }
+
+          // Allow navigation from row 0 to row 1
+          if (event.oldRowIdx == 0 && event.newRowIdx == 1) {
+            return true; // Allow
+          }
+
+          // Prevent other row changes
+          if (event.oldRowIdx != event.newRowIdx) {
+            return false; // Cancel row changes except 0->1
+          }
+
+          return true; // Allow same-row navigation
+        },
+      );
+
+      stateManager.setLayout(
+        const BoxConstraints(maxWidth: 500, maxHeight: 500),
+      );
+
+      // when
+      stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+      expect(stateManager.currentCellPosition!.rowIdx, 0);
+
+      // Try to navigate to row 1 (should succeed)
+      stateManager.setCurrentCell(rows[1].cells['col0'], 1);
+      expect(stateManager.currentCellPosition!.rowIdx, 1);
+
+      // Try to navigate to row 2 (should fail)
+      stateManager.setCurrentCell(rows[2].cells['col0'], 2);
+      expect(stateManager.currentCellPosition!.rowIdx, 1); // Still at row 1
+
+      // Try to navigate to a different cell in same row (should succeed)
+      stateManager.setCurrentCell(rows[1].cells['col1'], 1);
+      expect(stateManager.currentCellPosition!.rowIdx, 1);
+      expect(stateManager.currentCellPosition!.columnIdx, 1);
+    });
+
+    testWidgets(
+      'When onBeforeActiveCellChange cancels change, onActiveCellChanged should not be called',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        bool beforeCallbackCalled = false;
+        bool afterCallbackCalled = false;
+        bool blockChanges = false;
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: (event) {
+            beforeCallbackCalled = true;
+            return !blockChanges; // Cancel only when blockChanges is true
+          },
+          onActiveCellChanged: (event) {
+            afterCallbackCalled = true;
+          },
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        // First, set initial cell
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+
+        // Reset flags and enable blocking
+        beforeCallbackCalled = false;
+        afterCallbackCalled = false;
+        blockChanges = true;
+
+        // Try to change to a different cell (should be blocked)
+        stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+        // then
+        expect(beforeCallbackCalled, isTrue);
+        expect(afterCallbackCalled, isFalse); // Should not be called
+        expect(stateManager.currentCell, rows[0].cells['col0']); // No change
+      },
+    );
+
+    testWidgets(
+      'When onBeforeActiveCellChange allows change, onActiveCellChanged should be called',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        bool beforeCallbackCalled = false;
+        bool afterCallbackCalled = false;
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: (event) {
+            beforeCallbackCalled = true;
+            return true; // Allow the change
+          },
+          onActiveCellChanged: (event) {
+            afterCallbackCalled = true;
+          },
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(stateManager.currentCell, rows[0].cells['col0']);
+
+        // Reset flags
+        beforeCallbackCalled = false;
+        afterCallbackCalled = false;
+
+        // Try to change to a different cell
+        stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+        // then
+        expect(beforeCallbackCalled, isTrue);
+        expect(afterCallbackCalled, isTrue); // Should be called
+        expect(stateManager.currentCell, rows[2].cells['col1']); // Changed
+      },
+    );
+
+    testWidgets('Event should contain correct old and new cell information', (
+      WidgetTester tester,
+    ) async {
+      // given
+      List<TrinaColumn> columns = [
+        ...ColumnHelper.textColumn('col', count: 3, width: 150),
+      ];
+
+      List<TrinaRow> rows = RowHelper.count(5, columns);
+
+      TrinaGridOnBeforeActiveCellChangeEvent? firstEvent;
+      TrinaGridOnBeforeActiveCellChangeEvent? secondEvent;
+
+      TrinaGridStateManager stateManager = createStateManager(
+        columns: columns,
+        rows: rows,
+        onBeforeActiveCellChange: (event) {
+          if (firstEvent == null) {
+            firstEvent = event;
+          } else {
+            secondEvent = event;
+          }
+          return true;
+        },
+      );
+
+      stateManager.setLayout(
+        const BoxConstraints(maxWidth: 500, maxHeight: 500),
+      );
+
+      // when
+      // First cell selection (no previous cell)
+      stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+
+      // Second cell selection (previous cell exists)
+      stateManager.setCurrentCell(rows[2].cells['col1'], 2);
+
+      // then
+      expect(firstEvent, isNotNull);
+      expect(firstEvent!.oldCell, isNull); // No previous cell
+      expect(firstEvent!.oldRowIdx, isNull); // No previous row
+      expect(firstEvent!.newCell, rows[0].cells['col0']);
+      expect(firstEvent!.newRowIdx, 0);
+
+      expect(secondEvent, isNotNull);
+      expect(secondEvent!.oldCell, rows[0].cells['col0']);
+      expect(secondEvent!.oldRowIdx, 0);
+      expect(secondEvent!.newCell, rows[2].cells['col1']);
+      expect(secondEvent!.newRowIdx, 2);
+    });
+
+    testWidgets(
+      'Callback should not be invoked when trying to set the same cell',
+      (WidgetTester tester) async {
+        // given
+        List<TrinaColumn> columns = [
+          ...ColumnHelper.textColumn('col', count: 3, width: 150),
+        ];
+
+        List<TrinaRow> rows = RowHelper.count(5, columns);
+
+        int callbackCount = 0;
+
+        TrinaGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          onBeforeActiveCellChange: (event) {
+            callbackCount++;
+            return true;
+          },
+        );
+
+        stateManager.setLayout(
+          const BoxConstraints(maxWidth: 500, maxHeight: 500),
+        );
+
+        // when
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+        expect(callbackCount, 1);
+
+        // Try to set the same cell again
+        stateManager.setCurrentCell(rows[0].cells['col0'], 0);
+
+        // then
+        expect(callbackCount, 1); // Should not be called again
+      },
+    );
+
+    testWidgets('Callback should not be invoked for invalid cell parameters', (
+      WidgetTester tester,
+    ) async {
+      // given
+      List<TrinaColumn> columns = [
+        ...ColumnHelper.textColumn('col', count: 3, width: 150),
+      ];
+
+      List<TrinaRow> rows = RowHelper.count(5, columns);
+
+      int callbackCount = 0;
+
+      TrinaGridStateManager stateManager = createStateManager(
+        columns: columns,
+        rows: rows,
+        onBeforeActiveCellChange: (event) {
+          callbackCount++;
+          return true;
+        },
+      );
+
+      stateManager.setLayout(
+        const BoxConstraints(maxWidth: 500, maxHeight: 500),
+      );
+
+      // when
+      // Try to set with null cell
+      stateManager.setCurrentCell(null, 0);
+      expect(callbackCount, 0);
+
+      // Try to set with null rowIdx
+      stateManager.setCurrentCell(rows[0].cells['col0'], null);
+      expect(callbackCount, 0);
+
+      // Try to set with invalid rowIdx
+      stateManager.setCurrentCell(rows[0].cells['col0'], -1);
+      expect(callbackCount, 0);
+
+      stateManager.setCurrentCell(rows[0].cells['col0'], 999);
+      expect(callbackCount, 0);
+
+      // then
+      expect(callbackCount, 0); // Should never be called for invalid params
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds a new `onBeforeActiveCellChange` callback that fires **before** the active cell changes, allowing developers to validate data and prevent navigation if needed. This solves the visual flicker issue that occurs when using `onActiveCellChanged` to revert navigation.

## Changes

### 1. New Event Class
- Added `TrinaGridOnBeforeActiveCellChangeEvent` with complete context:
  - `oldCell` - The current active cell
  - `oldRowIdx` - The current row index  
  - `newCell` - The cell that will become active
  - `newRowIdx` - The new row index

### 2. Callback Integration
- Added `onBeforeActiveCellChange` callback to `TrinaGrid`
- Returns `bool`: `true` to allow navigation, `false` to cancel
- Works for all navigation types: keyboard, mouse, and programmatic

### 3. Core Implementation
Modified `setCurrentCell()` in `CellState` mixin to:
1. Invoke `onBeforeActiveCellChange` before state changes
2. Cancel navigation if callback returns `false`
3. Only trigger `onActiveCellChanged` if navigation succeeds

## Example Usage

```dart
TrinaGrid(
  columns: columns,
  rows: rows,
  onBeforeActiveCellChange: (event) {
    // Prevent row navigation until current row is valid
    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
      final currentRow = rows[event.oldRowIdx!];
      if (!validateRow(currentRow)) {
        ScaffoldMessenger.of(context).showSnackBar(
          SnackBar(
            content: Text('Please fix errors before proceeding'),
            backgroundColor: Colors.red,
          ),
        );
        return false; // Cancel navigation
      }
    }
    return true; // Allow navigation
  },
)
```

## Benefits

✅ **No visual flicker** - Navigation is prevented before state changes, not reverted after  
✅ **Works everywhere** - Keyboard, mouse, and programmatic navigation all respect the callback  
✅ **Full context** - Access to both old and new cell/row information for validation  
✅ **Backwards compatible** - Optional callback, existing code works unchanged  

## Testing

- ✅ 9 comprehensive unit tests covering:
  - Allow/cancel navigation scenarios
  - Row-level validation
  - Callback interaction with `onActiveCellChanged`
  - Event data validation
  - Edge cases (null checks, invalid parameters)

## Documentation

- ✅ Complete feature guide: [Cell Navigation Validation](doc/features/cell-navigation-validation.md)
  - Overview and basic usage
  - Common use cases with examples
  - Best practices
  - Integration with other callbacks
- ✅ Updated documentation index
- ✅ Cross-linked with related features

---

This PR provides a clean, well-tested solution that addresses the exact use case described in the issue without breaking changes.

Closes #237