### PR TITLE
test: fix outdated test expectations for time cell and pagination

### DIFF
--- a/test/src/plugin/trina_pagination_test.dart
+++ b/test/src/plugin/trina_pagination_test.dart
@@ -22,6 +22,8 @@ void main() {
     when(stateManager.footerHeight).thenReturn(45);
 
     when(stateManager.streamNotifier).thenAnswer((_) => subject);
+
+    when(stateManager.refRows).thenReturn(FilteredList<TrinaRow>());
   });
 
   tearDown(() {
@@ -52,9 +54,9 @@ void main() {
     });
 
     buildWidget().test(
-      'Four IconButton should be rendered. (First, Previous, Next, Last buttons)',
+      'Five IconButton should be rendered. (First, Previous, Next, Last, Go to page buttons)',
       (tester) async {
-        expect(find.byType(IconButton), findsNWidgets(4));
+        expect(find.byType(IconButton), findsNWidgets(5));
       },
     );
 

--- a/test/src/ui/cells/trina_time_cell_test.dart
+++ b/test/src/ui/cells/trina_time_cell_test.dart
@@ -118,7 +118,7 @@ void main() {
   });
 
   group('when popup is opened', () {
-    final okTextButtonFinder = find.widgetWithText(TextButton, 'OK');
+    final okTextButtonFinder = find.widgetWithText(TextButton, 'Ok');
     final hourFieldFinder = find.byWidgetPredicate(
       (widget) =>
           widget is TextField && widget.decoration?.helperText == 'Hour',
@@ -300,7 +300,7 @@ void main() {
 
         // act
 
-        await tester.tap(find.text('OK'));
+        await tester.tap(find.text('Ok'));
         await tester.pumpAndSettle();
         // assert
         expect(find.byType(TrinaTimePicker), findsNothing);


### PR DESCRIPTION
## Summary
Fixed 18 failing tests by updating outdated test expectations to match current implementation.

## Changes

### 1. TrinaTimeCell Tests (5 failures fixed)
- **Root cause**: Tests were checking for 'OK' button, but the default locale text uses 'Ok'
- **Fix**: Updated button text finder from `'OK'` to `'Ok'` to match `multiLineFilterOkButton = 'Ok'` in locale configuration
- **Files changed**: `test/src/ui/cells/trina_time_cell_test.dart`

### 2. TrinaPagination Tests (13 failures fixed)
- **Root cause 1**: Missing mock stub for `stateManager.refRows` which is now accessed by the pagination widget
- **Fix 1**: Added `when(stateManager.refRows).thenReturn(FilteredList<TrinaRow>())` to test setup
- **Root cause 2**: Test expected 4 IconButtons but pagination now has 5 (added "Go to page" button)
- **Fix 2**: Updated expectation from 4 to 5 IconButtons to account for `paginationEnableGotoPage` feature
- **Files changed**: `test/src/plugin/trina_pagination_test.dart`

## Test Results
- **Before**: 1,479 passed, 18 failed
- **After**: 1,497 passed, 0 failed ✅
