### PR TITLE
feat: add Mac Cmd key support for cell selection

### DIFF
--- a/doc/features/cell-selection.md
+++ b/doc/features/cell-selection.md
@@ -356,9 +356,9 @@ Recommended delays:
 - **200ms**: Balanced (default) - good distinction from scroll gestures
 - **300ms**: Clear separation, less chance of accidental activation
 
-### Ctrl+Click Multi-Select
+### Ctrl+Click Multi-Select (Cmd+Click on Mac)
 
-Enable selecting individual cells with Ctrl+Click:
+Enable selecting individual cells with Ctrl+Click (or Cmd+Click on Mac):
 
 ```dart
 TrinaGrid(
@@ -366,15 +366,15 @@ TrinaGrid(
   rows: rows,
   configuration: TrinaGridConfiguration(
     selectingMode: TrinaGridSelectingMode.cell,
-    enableCtrlClickMultiSelect: true,  // Enable Ctrl+Click
+    enableCtrlClickMultiSelect: true,  // Enable Ctrl+Click (Cmd+Click on Mac)
   ),
 )
 ```
 
 With this enabled:
-- Ctrl+Click adds/removes individual cells
+- Ctrl+Click (Cmd+Click on Mac) adds/removes individual cells
 - Build non-contiguous selections
-- Click without Ctrl clears individual selections
+- Click without Ctrl/Cmd clears individual selections
 - Shift+Click still works for range selection
 - All individually selected cells are included in `currentSelectingPositionList`
 
@@ -401,9 +401,9 @@ The following keyboard combinations work with selection:
 | Shortcut | Behavior |
 |----------|----------|
 | Long Press + Drag | Select range (when enableDragSelection is true) |
-| Ctrl + Click | Toggle individual cell (when enableCtrlClickMultiSelect is true) |
+| Ctrl + Click (Cmd + Click on Mac) | Toggle individual cell (when enableCtrlClickMultiSelect is true) |
 | Shift + Click | Extend selection to clicked cell |
-| Ctrl + A | Select all cells |
+| Ctrl + A (Cmd + A on Mac) | Select all cells |
 | Click (no modifier) | Clear individual selections and select single cell |
 
 ## Configuration Reference
@@ -434,9 +434,10 @@ TrinaGridConfiguration(
 **enableCtrlClickMultiSelect**:
 - Type: `bool`
 - Default: `false`
-- When `true`: Ctrl+Click toggles individual cells in/out of selection
+- When `true`: Ctrl+Click (Cmd+Click on Mac) toggles individual cells in/out of selection
 - When `false`: Ctrl+Click has no special behavior in cell mode
 - Only works when `selectingMode` is `TrinaGridSelectingMode.cell`
+- Cross-platform: Automatically uses Ctrl on Windows/Linux and Cmd on Mac
 
 **dragSelectionDelayDuration**:
 - Type: `Duration`

--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -629,8 +629,11 @@ class TrinaGridKeyPressed {
   bool get ctrl {
     final keysPressed = HardwareKeyboard.instance.logicalKeysPressed;
 
+    // Support both Ctrl (Windows/Linux) and Cmd (Mac) for cross-platform compatibility
     return !(!keysPressed.contains(LogicalKeyboardKey.controlLeft) &&
-        !keysPressed.contains(LogicalKeyboardKey.controlRight));
+        !keysPressed.contains(LogicalKeyboardKey.controlRight) &&
+        !keysPressed.contains(LogicalKeyboardKey.metaLeft) &&
+        !keysPressed.contains(LogicalKeyboardKey.metaRight));
   }
 }
 


### PR DESCRIPTION
## Summary

This PR adds Mac Cmd key support for all cell selection features, ensuring cross-platform compatibility.

## Changes

### Code Changes

**TrinaGridKeyPressed.ctrl getter** ([trina_grid_state_manager.dart:629-637](lib/src/manager/trina_grid_state_manager.dart#L629-L637))

Updated to check for both Ctrl and Meta (Cmd) keys:

```dart
bool get ctrl {
  final keysPressed = HardwareKeyboard.instance.logicalKeysPressed;

  // Support both Ctrl (Windows/Linux) and Cmd (Mac) for cross-platform compatibility
  return !(!keysPressed.contains(LogicalKeyboardKey.controlLeft) &&
      !keysPressed.contains(LogicalKeyboardKey.controlRight) &&
      !keysPressed.contains(LogicalKeyboardKey.metaLeft) &&
      !keysPressed.contains(LogicalKeyboardKey.metaRight));
}
```

Now checks for:
- `LogicalKeyboardKey.controlLeft/Right` (Windows/Linux)
- `LogicalKeyboardKey.metaLeft/Right` (Mac Cmd key)

### Documentation Updates

Updated [cell-selection.md](doc/features/cell-selection.md) to reflect Mac support:

1. **Section title**: "Ctrl+Click Multi-Select" → "Ctrl+Click Multi-Select (Cmd+Click on Mac)"
2. **Keyboard shortcuts table**: Added Mac equivalents (Cmd+Click, Cmd+A)
3. **Configuration reference**: Added note about cross-platform support

## Impact

All Excel-like selection features now work on Mac:
- ✅ Cmd+Click for individual cell toggle
- ✅ Cmd+A for select all
- ✅ All other Ctrl-based operations

## Testing

The change is transparent and automatic:
- Windows/Linux users continue using Ctrl
- Mac users can now use Cmd (their native modifier key)
- No breaking changes or configuration required

## Related

This complements PR #243 (Excel-like cell selection features) by ensuring full cross-platform support.