### PR TITLE
fix: exit edit mode before selection to enable copy operations

### DIFF
--- a/lib/src/manager/state/selecting_state.dart
+++ b/lib/src/manager/state/selecting_state.dart
@@ -323,6 +323,12 @@ mixin SelectingState implements ITrinaGridState {
       return;
     }
 
+    // Exit editing mode when creating a range selection
+    // This ensures copy/paste operations work correctly
+    if (isEditing && cellPosition != null) {
+      setEditing(false, notify: false);
+    }
+
     _state._currentSelectingPosition = isInvalidCellPosition(cellPosition)
         ? null
         : cellPosition;
@@ -521,6 +527,12 @@ mixin SelectingState implements ITrinaGridState {
         '[Selection] toggleSelectingCell - Not in cell mode, returning',
       );
       return;
+    }
+
+    // Exit editing mode when selecting individual cells
+    // This ensures copy/paste operations work correctly
+    if (isEditing) {
+      setEditing(false, notify: false);
     }
 
     if (_state._individuallySelectedCells.contains(cellPosition)) {


### PR DESCRIPTION
## Summary
- Fixes copy operations (Ctrl+C) not working when cells are selected
- Automatically exits edit mode before creating range selections (drag selection)
- Automatically exits edit mode before selecting individual cells (Ctrl+Click)

## Problem
When in edit mode, keyboard shortcuts like Ctrl+C would target the text input field rather than the grid selection, preventing users from copying selected cell values.

## Solution
Added logic to exit edit mode (with `notify: false` for performance) before establishing selections in both:
- Range selection flow (`setCurrentSelectingPosition`)
- Individual cell selection flow (`toggleSelectingCell`)

This implements Excel-like behavior where starting a selection automatically exits edit mode.

## Test plan
- [x] Verify Ctrl+C works after selecting cells with drag
- [x] Verify Ctrl+C works after selecting cells with Ctrl+Click
- [ ] Test with keyboard-based selections (Shift+Arrow keys)
- [ ] Verify no regression in other selection behaviors