### PR TITLE
fix: Ensure frozen column divider renders correctly in RTL mode

### DIFF
--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -840,6 +840,7 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
                       axis: Axis.vertical,
                       color: style.gridBorderColor,
                       shadow: style.enableGridBorderShadow,
+                      reverse: _stateManager.isRTL,
                     ),
                   ),
                   if (showColumnFooter)
@@ -865,7 +866,7 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
                       axis: Axis.vertical,
                       color: style.gridBorderColor,
                       shadow: style.enableGridBorderShadow,
-                      reverse: true,
+                      reverse: !_stateManager.isRTL,
                     ),
                   ),
                   if (showColumnFooter)


### PR DESCRIPTION
This commit corrects the rendering of divider for frozen column when the layout is in Right-To-Left (RTL) mode.

The `reverse` property of the `TrinaShadowLine` widget was being set incorrectly, causing the shadow/divider to appear on the wrong side of the frozen panes in RTL layouts. The logic has been updated to correctly account for the `isRTL` state.

- For leading frozen columns, the divider is now reversed only in RTL mode (`reverse: _stateManager.isRTL`).
- For trailing frozen columns, the divider is now reversed only in LTR mode (`reverse: !_stateManager.isRTL`).