### PR TITLE
fix: initialize all columns when inserting rows to prevent assertion error (#258)

### DIFF
--- a/lib/src/manager/state/row_state.dart
+++ b/lib/src/manager/state/row_state.dart
@@ -554,7 +554,7 @@ mixin RowState implements ITrinaGridState {
       refRows.insertAll(safetyIndex, rows);
 
       TrinaGridStateManager.initializeRows(
-        refColumns,
+        refColumns.originalList,
         rows,
         forceApplySortIdx: false,
       );


### PR DESCRIPTION
## Summary
Fixes #258 - Resolved assertion error when calling `setCurrentCell()` after `prependNewRows()`

## Problem
When migrating from PlutoGrid_plus to TrinaGrid, users encountered an assertion error: `"TrinaCell is not initialized"` at `trina_cell.dart:207` when executing:

```dart
_trinaGridStateManager.prependNewRows();
final cell = _trinaGridStateManager.rows.first.cells.entries.elementAt(0).value;
_trinaGridStateManager.setCurrentCell(cell, 0);
```

## Root Cause
The bug was caused by a mismatch in column handling during row insertion:
- `getNewRow()` creates cells for **all columns** using `refColumns.originalList` (including hidden/filtered columns)
- `_insertRows()` was only initializing cells for **visible columns** using `refColumns`

This left cells in hidden/filtered columns uninitialized, causing the assertion error when accessed.

## Solution
Changed `_insertRows()` in `row_state.dart:557` to use `refColumns.originalList` instead of `refColumns` when calling `initializeRows()`. This ensures all cells are properly initialized regardless of column visibility state.

## Test Plan
- [x] Verified dart analyze passes with no errors
- [x] Confirmed the fix aligns with existing code patterns (row_group_state.dart already uses the same approach)
- [ ] Waiting for reporter to test with the git version and provide feedback

@Alyssonpp Please test this fix by using the git version of trina_grid and let us know if it resolves your issue.