### PR TITLE
fix: auto-scaling accounts for vertical scrollbar

### DIFF
--- a/lib/src/manager/state/visibility_layout_state.dart
+++ b/lib/src/manager/state/visibility_layout_state.dart
@@ -44,6 +44,15 @@ mixin VisibilityLayoutState implements ITrinaGridState {
       }
     }
 
+    // Subtract vertical scrollbar width from available column space.
+    //
+    // The scrollbar overlays content but still occupies visual space on the
+    // right edge, so columns must be sized to (viewport width - scrollbar width).
+    // Scrollbar uses thickness + 4px padding (see trina_vertical_scroll_bar.dart:273)
+    if (configuration.scrollbar.showVertical) {
+      offset += configuration.scrollbar.thickness + 4;
+    }
+
     getColumnsAutoSizeHelper(
       columns: refColumns,
       maxWidth: maxWidth! - offset,


### PR DESCRIPTION
Column auto-sizing algorithm sized columns to full widget width without subtracting vertical scrollbar width (thickness + 4px padding), causing 12px horizontal overflow (typically 8px + 4px).

Simple fix here to subtract scrollbar width (thickness + 4px padding) from available width when calculating column sizes.

## Detailed bug

The `_updateColumnSize()` method in `VisibilityLayoutState` was calculating column widths using the full widget width without accounting for the vertical scrollbar width. Since the scrollbar overlays content but still occupies visual space on the right edge (thickness + 4px padding), columns were being sized larger than the available viewport, causing horizontal overflow.

## Minimal example

Here's a minimal example showing the bug.

```dart
import 'package:flutter/material.dart';
import 'package:trina_grid/trina_grid.dart';

/// Minimal reproduction case for Trina Grid horizontal scrollbar bug
///
/// SYMPTOMS:
/// - Horizontal scrollbar appears even though column widths should fit
/// - Overflow width equals scrollbar thickness (8px in this example)
/// - Only occurs with TrinaAutoSizeMode.scale + overlay scrollbar
///
/// TO RUN:
/// 1. Create a new Flutter project
/// 2. Add trina_grid: ^2.1.0 to pubspec.yaml
/// 3. Replace main.dart with this file
/// 4. Run the app
/// 5. Observe horizontal scrollbar at bottom of grid
void main() => runApp(const MaterialApp(home: TrinaGridScrollbarBug()));

class TrinaGridScrollbarBug extends StatelessWidget {
  const TrinaGridScrollbarBug({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Trina Grid Scrollbar Bug Reproduction'),
      ),
      body: Center(
        child: Container(
          width: 800, // Fixed width container
          height: 600,
          color: Colors.grey[200],
          padding: const EdgeInsets.all(16),
          child: Column(
            crossAxisAlignment: CrossAxisAlignment.start,
            children: [
              const Text(
                'Bug: Horizontal scrollbar appears even though columns fit in 800px',
                style: TextStyle(fontWeight: FontWeight.bold),
              ),
              const Text(
                'Columns: 200px + 200px + 400px = 800px (should fit exactly)',
              ),
              const Text(
                'Overflow: Exactly 8px (scrollbar thickness)',
                style: TextStyle(color: Colors.red),
              ),
              const SizedBox(height: 16),
              Expanded(
                child: TrinaGrid(
                  columns: [
                    TrinaColumn(
                      title: 'Column 1 (200px)',
                      field: 'col1',
                      type: TrinaColumnTypeText(),
                      width: 200,
                    ),
                    TrinaColumn(
                      title: 'Column 2 (200px)',
                      field: 'col2',
                      type: TrinaColumnTypeText(),
                      width: 200,
                    ),
                    TrinaColumn(
                      title: 'Column 3 (400px)',
                      field: 'col3',
                      type: TrinaColumnTypeText(),
                      width: 400, // Total: 800px
                    ),
                  ],
                  rows: List.generate(
                    50,
                    (i) => TrinaRow(
                      cells: {
                        'col1': TrinaCell(value: 'Row $i Col 1'),
                        'col2': TrinaCell(value: 'Row $i Col 2'),
                        'col3': TrinaCell(value: 'Row $i Col 3'),
                      },
                    ),
                  ),
                  configuration: TrinaGridConfiguration(
                    columnSize: const TrinaGridColumnSizeConfig(
                      // Auto-scaling enabled - columns should scale to fit container
                      autoSizeMode: TrinaAutoSizeMode.scale,
                    ),
                    scrollbar: const TrinaGridScrollbarConfig(
                      thickness: 8.0,
                    ),
                  ),
                ),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```


