### PR TITLE
fix: optimize callback executions with caching (closes #252)

### DIFF
--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -33,6 +33,10 @@ mixin PopupCellState<T extends PopupCell> on State<T>
   late final TextEditingController textController;
   late final FocusNode textFocus;
 
+  // Cache for editCellRenderer callback result
+  Widget? _cachedEditCellWidget;
+  dynamic _cachedCellValueForEditRenderer;
+
   KeyEventResult handleOpeningPopupWithKeyboard(
     FocusNode node,
     KeyEvent event,
@@ -119,13 +123,19 @@ mixin PopupCellState<T extends PopupCell> on State<T>
     final customRenderer =
         widget.column.editCellRenderer ?? widget.stateManager.editCellRenderer;
     if (customRenderer != null) {
-      return customRenderer(
-        defaultEditWidget,
-        widget.cell,
-        textController,
-        textFocus,
-        handleSelected,
-      );
+      // Cache the editCellRenderer result to avoid excessive callback executions
+      if (_cachedCellValueForEditRenderer != widget.cell.value ||
+          _cachedEditCellWidget == null) {
+        _cachedCellValueForEditRenderer = widget.cell.value;
+        _cachedEditCellWidget = customRenderer(
+          defaultEditWidget,
+          widget.cell,
+          textController,
+          textFocus,
+          handleSelected,
+        );
+      }
+      return _cachedEditCellWidget!;
     }
     return defaultEditWidget;
   }

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -392,6 +392,10 @@ class _CellContainer extends TrinaStatefulWidget {
 class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
   BoxDecoration _decoration = const BoxDecoration();
 
+  // Cache for checkReadOnly callback result
+  bool? _cachedReadOnly;
+  dynamic _cachedCellValueForReadOnly;
+
   @override
   TrinaGridStateManager get stateManager => widget.stateManager;
 
@@ -400,6 +404,16 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
     super.initState();
 
     updateState(TrinaNotifierEventForceUpdate.instance);
+  }
+
+  bool _getReadOnly() {
+    // Cache the checkReadOnly result to avoid excessive callback executions
+    if (_cachedCellValueForReadOnly != widget.cell.value ||
+        _cachedReadOnly == null) {
+      _cachedCellValueForReadOnly = widget.cell.value;
+      _cachedReadOnly = widget.column.checkReadOnly(widget.row, widget.cell);
+    }
+    return _cachedReadOnly!;
   }
 
   @override
@@ -412,7 +426,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
       _decoration,
       _boxDecoration(
         hasFocus: stateManager.hasFocus,
-        readOnly: widget.column.checkReadOnly(widget.row, widget.cell),
+        readOnly: _getReadOnly(),
         isEditing: stateManager.isEditing,
         isCurrentCell: isCurrentCell,
         isSelectedCell: stateManager.isSelectedCell(

--- a/lib/src/ui/widgets/trina_dropdown_menu.dart
+++ b/lib/src/ui/widgets/trina_dropdown_menu.dart
@@ -75,8 +75,9 @@ class TrinaDropdownMenu<T> extends StatefulWidget {
 
   /// {@template TrinaDropdownMenu.initialValue}
   /// The initially selected value, which will be highlighted in the list.
+  /// If null, no item will be initially selected.
   /// {@endtemplate}
-  final T initialValue;
+  final T? initialValue;
 
   /// {@template TrinaDropdownMenu.itemBuilder}
   /// A builder function to create a custom widget for each item in the list.
@@ -159,7 +160,7 @@ class TrinaDropdownMenu<T> extends StatefulWidget {
     required List<T> items,
     required void Function(T item) onItemSelected,
     required double width,
-    required T initialValue,
+    required T? initialValue,
     required double itemHeight,
     required double maxHeight,
     required List<TrinaDropdownMenuFilter> filters,
@@ -229,7 +230,7 @@ class TrinaDropdownMenu<T> extends StatefulWidget {
     required String Function(T item) itemToString,
     required void Function(T item) onItemSelected,
     required double width,
-    required T initialValue,
+    required T? initialValue,
     required double itemHeight,
     required double maxHeight,
     Key? key,
@@ -246,7 +247,7 @@ class TrinaDropdownMenu<T> extends StatefulWidget {
     required void Function(T item) onItemSelected,
     required List<TrinaDropdownMenuFilter> filters,
     required double width,
-    required T initialValue,
+    required T? initialValue,
     required double itemHeight,
     required double maxHeight,
     required bool filtersInitiallyExpanded,
@@ -296,8 +297,10 @@ base class TrinaDropdownMenuState<T> extends State<TrinaDropdownMenu<T>> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (!scrollController.hasClients) return;
+      final initialValue = widget.initialValue;
+      if (initialValue == null) return;
 
-      final initialValueComparable = getComparableValue(widget.initialValue);
+      final initialValueComparable = getComparableValue(initialValue);
       final initialItemIndex = itemsNotifier.value.indexWhere(
         (element) => getComparableValue(element) == initialValueComparable,
       );
@@ -1120,9 +1123,11 @@ class _ItemListView<T> extends StatelessWidget {
             itemCount: filteredItems.length,
             itemBuilder: (context, index) {
               final item = filteredItems[index];
+              final initialValue = menuWidget.initialValue;
               final isSelected =
+                  initialValue != null &&
                   menuState.getComparableValue(item) ==
-                  menuState.getComparableValue(menuWidget.initialValue);
+                      menuState.getComparableValue(initialValue);
               return _EnterKeyListener(
                 onEnter: () {
                   menuWidget.onItemSelected(item);

--- a/test/src/ui/cells/renderer_callback_cache_test.dart
+++ b/test/src/ui/cells/renderer_callback_cache_test.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:trina_grid/src/ui/ui.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../../../helper/trina_widget_test_helper.dart';
+import '../../../helper/row_helper.dart';
+import '../../../mock/shared_mocks.mocks.dart';
+
+void main() {
+  late MockTrinaGridStateManager stateManager;
+  late MockTrinaGridScrollController scroll;
+  late MockLinkedScrollControllerGroup horizontalScroll;
+  late MockScrollController horizontalScrollController;
+  late MockScrollController verticalScrollController;
+  MockTrinaGridEventManager? eventManager;
+  PublishSubject<TrinaNotifierEvent> streamNotifier;
+
+  setUp(() {
+    stateManager = MockTrinaGridStateManager();
+    scroll = MockTrinaGridScrollController();
+    horizontalScroll = MockLinkedScrollControllerGroup();
+    horizontalScrollController = MockScrollController();
+    verticalScrollController = MockScrollController();
+    eventManager = MockTrinaGridEventManager();
+    streamNotifier = PublishSubject<TrinaNotifierEvent>();
+    when(stateManager.isRTL).thenReturn(false);
+    when(stateManager.textDirection).thenReturn(TextDirection.ltr);
+    when(stateManager.eventManager).thenReturn(eventManager);
+    when(stateManager.streamNotifier).thenAnswer((_) => streamNotifier);
+    when(stateManager.configuration).thenReturn(const TrinaGridConfiguration());
+    when(stateManager.keyPressed).thenReturn(TrinaGridKeyPressed());
+    when(stateManager.rowTotalHeight).thenReturn(
+      RowHelper.resolveRowTotalHeight(stateManager.configuration.style),
+    );
+    when(stateManager.localeText).thenReturn(const TrinaGridLocaleText());
+    when(stateManager.keepFocus).thenReturn(true);
+    when(stateManager.hasFocus).thenReturn(true);
+    when(stateManager.canRowDrag).thenReturn(true);
+    when(stateManager.rowHeight).thenReturn(0);
+    when(stateManager.currentSelectingRows).thenReturn([]);
+    when(stateManager.scroll).thenReturn(scroll);
+    when(scroll.maxScrollHorizontal).thenReturn(0);
+    when(scroll.horizontal).thenReturn(horizontalScroll);
+    when(scroll.bodyRowsHorizontal).thenReturn(horizontalScrollController);
+    when(scroll.bodyRowsVertical).thenReturn(verticalScrollController);
+    when(horizontalScrollController.offset).thenReturn(0);
+    when(verticalScrollController.offset).thenReturn(0);
+    when(stateManager.enabledRowGroups).thenReturn(false);
+    when(stateManager.rowGroupDelegate).thenReturn(null);
+  });
+
+  group('Renderer callback caching (Issue #252)', () {
+    testWidgets(
+      'renderer callback should be cached and not called excessively on rebuilds',
+      (WidgetTester tester) async {
+        int callCount = 0;
+
+        Widget renderer(TrinaColumnRendererContext context) {
+          callCount++;
+          return Text('Rendered: ${context.cell.value}');
+        }
+
+        final TrinaColumn column = TrinaColumn(
+          title: 'column title',
+          field: 'column_field_name',
+          type: TrinaColumnType.text(),
+          renderer: renderer,
+        );
+
+        final TrinaCell cell = TrinaCell(value: 'test value');
+        final TrinaRow row = TrinaRow(cells: {'column_field_name': cell});
+
+        // Set up mock to return false for isCurrentCell and isSelectedCell
+        when(stateManager.isCurrentCell(any)).thenReturn(false);
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Initial render should call the renderer once
+        expect(callCount, 1);
+        expect(find.text('Rendered: test value'), findsOneWidget);
+
+        // Rebuild without changing cell value or selection state
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Should not call renderer again (cached)
+        expect(callCount, 1, reason: 'Renderer should be cached on rebuild');
+      },
+    );
+
+    testWidgets('renderer cache should invalidate when cell value changes', (
+      WidgetTester tester,
+    ) async {
+      int callCount = 0;
+
+      Widget renderer(TrinaColumnRendererContext context) {
+        callCount++;
+        return Text('Rendered: ${context.cell.value}');
+      }
+
+      final TrinaColumn column = TrinaColumn(
+        title: 'column title',
+        field: 'column_field_name',
+        type: TrinaColumnType.text(),
+        renderer: renderer,
+      );
+
+      final TrinaCell cell = TrinaCell(value: 'initial value');
+      final TrinaRow row = TrinaRow(cells: {'column_field_name': cell});
+
+      when(stateManager.isCurrentCell(any)).thenReturn(false);
+      when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TrinaDefaultCell(
+              cell: cell,
+              column: column,
+              row: row,
+              rowIdx: 0,
+              stateManager: stateManager,
+            ),
+          ),
+        ),
+      );
+
+      expect(callCount, 1);
+      expect(find.text('Rendered: initial value'), findsOneWidget);
+
+      // Change cell value
+      cell.value = 'changed value';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TrinaDefaultCell(
+              cell: cell,
+              column: column,
+              row: row,
+              rowIdx: 0,
+              stateManager: stateManager,
+            ),
+          ),
+        ),
+      );
+
+      // Should call renderer again because value changed
+      expect(
+        callCount,
+        2,
+        reason: 'Renderer should be called again when cell value changes',
+      );
+      expect(find.text('Rendered: changed value'), findsOneWidget);
+    });
+
+    testWidgets(
+      'renderer cache should invalidate when isCurrentCell state changes',
+      (WidgetTester tester) async {
+        int callCount = 0;
+
+        Widget renderer(TrinaColumnRendererContext context) {
+          callCount++;
+          final isCurrentCell = context.stateManager.isCurrentCell(
+            context.cell,
+          );
+          return Text(
+            'Rendered: ${context.cell.value}, Current: $isCurrentCell',
+          );
+        }
+
+        final TrinaColumn column = TrinaColumn(
+          title: 'column title',
+          field: 'column_field_name',
+          type: TrinaColumnType.text(),
+          renderer: renderer,
+        );
+
+        final TrinaCell cell = TrinaCell(value: 'test value');
+        final TrinaRow row = TrinaRow(cells: {'column_field_name': cell});
+
+        // Initially not current cell
+        when(stateManager.isCurrentCell(any)).thenReturn(false);
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        expect(callCount, 1);
+        expect(
+          find.text('Rendered: test value, Current: false'),
+          findsOneWidget,
+        );
+
+        // Change to current cell
+        when(stateManager.isCurrentCell(any)).thenReturn(true);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Should call renderer again because isCurrentCell state changed
+        expect(
+          callCount,
+          2,
+          reason: 'Renderer should be called again when isCurrentCell changes',
+        );
+        expect(
+          find.text('Rendered: test value, Current: true'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'renderer cache should invalidate when isSelectedCell state changes',
+      (WidgetTester tester) async {
+        int callCount = 0;
+
+        Widget renderer(TrinaColumnRendererContext context) {
+          callCount++;
+          final isSelected = context.stateManager.isSelectedCell(
+            context.cell,
+            context.column,
+            context.rowIdx,
+          );
+          return Text('Rendered: ${context.cell.value}, Selected: $isSelected');
+        }
+
+        final TrinaColumn column = TrinaColumn(
+          title: 'column title',
+          field: 'column_field_name',
+          type: TrinaColumnType.text(),
+          renderer: renderer,
+        );
+
+        final TrinaCell cell = TrinaCell(value: 'test value');
+        final TrinaRow row = TrinaRow(cells: {'column_field_name': cell});
+
+        // Initially not selected
+        when(stateManager.isCurrentCell(any)).thenReturn(false);
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        expect(callCount, 1);
+        expect(
+          find.text('Rendered: test value, Selected: false'),
+          findsOneWidget,
+        );
+
+        // Change to selected
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(true);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell,
+                column: column,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Should call renderer again because isSelectedCell state changed
+        expect(
+          callCount,
+          2,
+          reason: 'Renderer should be called again when isSelectedCell changes',
+        );
+        expect(
+          find.text('Rendered: test value, Selected: true'),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+}

--- a/test/src/ui/widgets/trina_dropdown_menu_test.dart
+++ b/test/src/ui/widgets/trina_dropdown_menu_test.dart
@@ -22,7 +22,7 @@ void main() {
     Future<void> buildMenu<T>(
       WidgetTester tester, {
       required List<T> items,
-      required T initialValue,
+      required T? initialValue,
       String Function(T item)? itemToString,
       dynamic Function(T item)? itemToValue,
       TrinaDropdownMenuVariant variant = TrinaDropdownMenuVariant.select,
@@ -458,6 +458,63 @@ void main() {
         expect(find.text('Item 15'), findsOneWidget);
         // Top items should be scrolled off-screen
         expect(find.text('Item 0'), findsNothing);
+      });
+
+      testWidgets('should handle null initialValue without crashing', (
+        tester,
+      ) async {
+        // This test ensures issue with null select cell values is fixed
+        await buildMenu<String>(
+          tester,
+          items: ['Apple', 'Banana', 'Cherry'],
+          initialValue: null,
+          itemToString: (item) => item,
+        );
+
+        // Should render all items
+        expect(find.text('Apple'), findsOneWidget);
+        expect(find.text('Banana'), findsOneWidget);
+        expect(find.text('Cherry'), findsOneWidget);
+
+        // Should not crash when initialValue is null
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('should not scroll when initialValue is null', (
+        tester,
+      ) async {
+        await buildStringMenu(
+          tester,
+          items: List.generate(20, (i) => 'Item $i'),
+          initialValue: null,
+          itemHeight: 40,
+          maxHeight: 200,
+        );
+
+        final scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+        // When initialValue is null, scroll offset should be 0 (no scrolling)
+        expect(scrollable.controller?.offset, 0);
+
+        // First items should be visible
+        expect(find.text('Item 0'), findsOneWidget);
+      });
+
+      testWidgets('should not highlight any item when initialValue is null', (
+        tester,
+      ) async {
+        await buildStringMenu(
+          tester,
+          items: ['Apple', 'Banana', 'Cherry'],
+          initialValue: null,
+        );
+
+        // Find all MenuItemButton widgets
+        final menuItems = find.byType(MenuItemButton);
+        expect(menuItems, findsNWidgets(3));
+
+        // When initialValue is null, no item should be marked as selected
+        // This is tested implicitly - the menu should render without errors
+        expect(tester.takeException(), isNull);
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR fixes issue #252 by implementing intelligent caching for callback properties (`renderer`, `checkReadOnly`, `editCellRenderer`) to prevent excessive executions during rebuilds, scrolling, and state updates.

Additionally, this PR fixes a related bug where clicking on a select cell with a `null` value would crash the application.

## Problem

The callbacks were being invoked on every widget rebuild, causing:
- **Performance degradation** - callbacks executed hundreds of times during scrolling
- **Debug console clutter** - excessive print() statements from user callbacks
- **Unnecessary computations** - complex logic in callbacks ran repeatedly without value changes

## Solution

### 1. Callback Caching
Implemented smart caching that only re-executes callbacks when relevant state actually changes:

- **Renderer callbacks** (`TrinaDefaultCell`):
  - Cache invalidates when cell value changes
  - Cache invalidates when `isCurrentCell` state changes
  - Cache invalidates when `isSelectedCell` state changes
  - Prevents execution on unrelated rebuilds

- **checkReadOnly callbacks** (`_CellContainerState`, `TextCellState`):
  - Cache invalidates only when cell value changes
  - Reduces repeated checks during state updates

- **editCellRenderer callbacks** (`TextCellState`, `PopupCellState`):
  - Cache invalidates only when cell value changes
  - Prevents re-execution on every edit widget rebuild

### 2. Null Value Handling
- Made `TrinaDropdownMenu.initialValue` nullable
- Prevents crash when opening select cells with null values
- Properly handles cases where no initial selection exists

## Files Changed

- `lib/src/ui/cells/trina_default_cell.dart` - Renderer caching
- `lib/src/ui/trina_base_cell.dart` - checkReadOnly caching
- `lib/src/ui/cells/text_cell.dart` - checkReadOnly & editCellRenderer caching
- `lib/src/ui/cells/popup_cell.dart` - editCellRenderer caching
- `lib/src/ui/widgets/trina_dropdown_menu.dart` - Nullable initialValue
- `test/src/ui/cells/renderer_callback_cache_test.dart` - New comprehensive tests
- `test/src/ui/widgets/trina_dropdown_menu_test.dart` - Null value tests

## Tests

- ✅ Added 7 new tests for callback caching behavior
- ✅ Tests verify cache invalidation on value and state changes
- ✅ Tests verify null initialValue handling
- ✅ All 1516 tests pass
- ✅ No regressions detected

## Closes

Closes #252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches cell renderer/readOnly/edit widgets to avoid excessive callback executions and makes `TrinaDropdownMenu.initialValue` nullable with proper no-selection handling.
> 
> - **Cells (performance optimizations)**:
>   - **Renderer caching**: Convert `_DefaultCellWidget` to `StatefulWidget` and cache `renderer` outputs; invalidate on changes to `cell.value`, `isCurrentCell`, or `isSelectedCell` (`lib/src/ui/cells/trina_default_cell.dart`).
>   - **editCellRenderer caching**: Cache edit widget for `TextCell` and `PopupCell`; re-run only when `cell.value` changes (`lib/src/ui/cells/text_cell.dart`, `lib/src/ui/cells/popup_cell.dart`).
>   - **readOnly caching**: Cache `checkReadOnly` results in `TextCell` and `_CellContainerState` (`lib/src/ui/cells/text_cell.dart`, `lib/src/ui/trina_base_cell.dart`).
> - **Dropdown**:
>   - Make `TrinaDropdownMenu.initialValue` nullable and handle null by skipping initial scroll/highlight and avoiding selection checks on null (`lib/src/ui/widgets/trina_dropdown_menu.dart`).
> - **Tests**:
>   - Add renderer caching tests and dropdown null-handling tests (`test/src/ui/cells/renderer_callback_cache_test.dart`, `test/src/ui/widgets/trina_dropdown_menu_test.dart`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a3f209f10d372f63acd686d70805ed244cefccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->