### PR TITLE
fix: account for scrollbar width in column auto-sizing

### DIFF
--- a/lib/src/manager/state/visibility_layout_state.dart
+++ b/lib/src/manager/state/visibility_layout_state.dart
@@ -49,7 +49,10 @@ mixin VisibilityLayoutState implements ITrinaGridState {
     // The scrollbar overlays content but still occupies visual space on the
     // right edge, so columns must be sized to (viewport width - scrollbar width).
     // Scrollbar uses thickness + 4px padding (see trina_vertical_scroll_bar.dart:273)
-    if (configuration.scrollbar.showVertical) {
+    // Only subtract when columnShowScrollWidth is enabled (matching behavior in
+    // trina_body_columns.dart and trina_body_columns_footer.dart)
+    if (configuration.scrollbar.showVertical &&
+        configuration.scrollbar.columnShowScrollWidth) {
       offset += configuration.scrollbar.thickness + 4;
     }
 

--- a/lib/src/manager/state/visibility_layout_state.dart
+++ b/lib/src/manager/state/visibility_layout_state.dart
@@ -44,6 +44,15 @@ mixin VisibilityLayoutState implements ITrinaGridState {
       }
     }
 
+    // Subtract vertical scrollbar width from available column space.
+    //
+    // The scrollbar overlays content but still occupies visual space on the
+    // right edge, so columns must be sized to (viewport width - scrollbar width).
+    // Scrollbar uses thickness + 4px padding (see trina_vertical_scroll_bar.dart:273)
+    if (configuration.scrollbar.showVertical) {
+      offset += configuration.scrollbar.thickness + 4;
+    }
+
     getColumnsAutoSizeHelper(
       columns: refColumns,
       maxWidth: maxWidth! - offset,


### PR DESCRIPTION
## Summary

Fixes horizontal overflow issue when using column auto-sizing with vertical scrollbar enabled.

## Problem

The column auto-sizing algorithm (`_updateColumnSize()`) was not accounting for vertical scrollbar width when calculating available space for columns. This caused unwanted horizontal overflow (typically 12px = 8px scrollbar + 4px padding) when using `TrinaAutoSizeMode.scale` or `TrinaAutoSizeMode.equal`.

## Solution

Added proper check to subtract vertical scrollbar width from available column space:

```dart
if (configuration.scrollbar.showVertical &&
    configuration.scrollbar.columnShowScrollWidth) {
  offset += configuration.scrollbar.thickness + 4;
}
```

This matches the existing pattern already used in:
- `lib/src/ui/trina_body_columns.dart:56`
- `lib/src/ui/trina_body_columns_footer.dart:53`

## Key Points

- ✅ Only subtracts scrollbar width when `columnShowScrollWidth` is enabled (respects existing configuration)
- ✅ Prevents horizontal scrollbar from appearing when columns should fit exactly
- ✅ All existing tests pass
- ✅ No new analyzer errors

## Credits

Thanks to @davidlrichmond for discovering this bug and providing the initial fix in PR #264. This PR builds on that work by adding the missing `columnShowScrollWidth` check to ensure consistency with the rest of the codebase.

Closes #264
Related to #50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Subtract vertical scrollbar thickness + padding from column auto-size width when configured to prevent overflow.
> 
> - **Column auto-sizing** (`lib/src/manager/state/visibility_layout_state.dart`):
>   - In `_updateColumnSize()`, subtract vertical scrollbar width from available column space when `configuration.scrollbar.showVertical` and `configuration.scrollbar.columnShowScrollWidth` are true.
>   - Offset adds `configuration.scrollbar.thickness + 4` before computing `maxWidth` for `getColumnsAutoSizeHelper(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1029c5429abcdcf9e244b7ceb18d27c8cb9c76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->