### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.1.1] - 2025. 11. 17
+
+* Feature: Added scroll physics configuration to TrinaGrid (#262). @doonfrs
+* Feature: Added configurable platform-specific separators for copy/paste (#261). @doonfrs
+* Feature: Added Mac Cmd key support for cell selection. @doonfrs
+* Feature: Added Excel-like cell selection features. @doonfrs
+* Feature: Added cancellable onBeforeActiveCellChange event. @doonfrs
+* Feature: Added smooth scrolling and scrollbar click-to-jump enhancements. @doonfrs
+* Feature: Added click-to-jump functionality to scrollbars. @doonfrs
+* Fix: Optimized callback executions with caching (#252) (#265). @doonfrs
+* Fix: Account for scrollbar width in column auto-sizing (#266). @doonfrs
+* Fix: Initialize all columns when inserting rows to prevent assertion error. @doonfrs
+* Fix: Ensure frozen column divider renders correctly in RTL mode. @doonfrs
+* Fix: Exit edit mode before selection to enable copy operations. @doonfrs
+* Fix: Update outdated test mocks and fix flaky date-time test. @doonfrs
+* Fix: Copy/paste with Ctrl+Click multi-select and Mac support. @doonfrs
+* Fix: Enable custom renderers for group header cells in row grouping. @doonfrs
+* Fix: Apply rowWrapper to frozen column rows. @doonfrs
+* Test: Fix outdated test expectations for time cell and pagination. @doonfrs
+* Docs: Add comprehensive scrollPhysics documentation and tests (#263). @doonfrs
+
 ## [2.1.0] - 2025. 09. 30
 
 * Feature: Added comprehensive translations for pagination and time picker. @doonfrs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: trina_grid
 description: A data grid that can be controlled by the keyboard on desktop and web. Of course, it works well on Android and IOS. (DataGrid, DataTable, Data Grid, Data Table, Sticky)
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/doonfrs/trina_grid
 issue_tracker: https://github.com/doonfrs/trina_grid/issues
 


### PR DESCRIPTION
## Summary

This PR prepares the release for version **2.1.1** of TrinaGrid.

### Changes Included

This release contains **37 commits** since v2.1.0 with the following improvements:

#### ✨ Features (7)
* Added scroll physics configuration to TrinaGrid (#262)
* Added configurable platform-specific separators for copy/paste (#261)
* Added Mac Cmd key support for cell selection
* Added Excel-like cell selection features
* Added cancellable onBeforeActiveCellChange event
* Added smooth scrolling and scrollbar click-to-jump enhancements
* Added click-to-jump functionality to scrollbars

#### 🐛 Fixes (9)
* Optimized callback executions with caching (#252) (#265)
* Account for scrollbar width in column auto-sizing (#266)
* Initialize all columns when inserting rows to prevent assertion error
* Ensure frozen column divider renders correctly in RTL mode
* Exit edit mode before selection to enable copy operations
* Update outdated test mocks and fix flaky date-time test
* Copy/paste with Ctrl+Click multi-select and Mac support
* Enable custom renderers for group header cells in row grouping
* Apply rowWrapper to frozen column rows

#### 🧪 Tests & 📚 Docs
* Fix outdated test expectations for time cell and pagination
* Add comprehensive scrollPhysics documentation and tests (#263)

### Breaking Changes

✅ **No breaking changes** - This is a backward-compatible patch release.

### Version Bump

- **From:** 2.1.0
- **To:** 2.1.1

### Files Modified

- `CHANGELOG.md` - Added v2.1.1 section with all changes
- `pubspec.yaml` - Bumped version to 2.1.1

### Quality Checks

- ✅ `dart analyze` - No errors or warnings
- ✅ `dart format .` - All files properly formatted

### Next Steps

After merging this PR:
1. Tag the release with `v2.1.1`
2. Publish to pub.dev using `dart pub publish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares v2.1.1 by bumping package version and adding a changelog with key features, fixes, tests, and docs.
> 
> - **Release**:
>   - Bump version in `pubspec.yaml` to `2.1.1`.
>   - Add `2.1.1` entry to `CHANGELOG.md` summarizing:
>     - Features: scroll physics config, platform-specific copy/paste separators, Mac Cmd support, Excel-like selection, cancellable `onBeforeActiveCellChange`, smooth scrolling and scrollbar click-to-jump.
>     - Fixes: callback caching, account for scrollbar width in auto-sizing, initialize columns on row insert, RTL frozen divider, exit edit before selection for copy, updated test mocks, copy/paste multi-select and Mac support, group header renderer in row grouping, apply `rowWrapper` to frozen rows.
>     - Tests/Docs: time cell/pagination test updates; scrollPhysics docs and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e4f168b44c867030d8afc8c9662466ac5614dc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->