### PR TITLE
feat: Add rowWrapperIsConstantHeight configuration option

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -167,6 +167,17 @@ class TrinaGridConfiguration {
   /// Can be customized to use a specific separator.
   final String? copyPasteLineSeparator;
 
+  /// When true, enables itemExtent optimization even when rowWrapper is used.
+  ///
+  /// By default, using [rowWrapper] disables ListView's itemExtent optimization
+  /// to allow for variable row heights. However, if your rowWrapper only adds
+  /// visual styling without affecting row height, setting this to true will
+  /// restore O(1) scroll performance and allow accurate calculation of scroll
+  /// position.
+  ///
+  /// Default is false for backward compatibility.
+  final bool rowWrapperIsConstantHeight;
+
   const TrinaGridConfiguration({
     this.enableMoveDownAfterSelecting = false,
     this.enableMoveHorizontalInEditing = false,
@@ -189,6 +200,7 @@ class TrinaGridConfiguration {
     this.dragSelectionDelayDuration = const Duration(milliseconds: 200),
     this.copyPasteCellSeparator,
     this.copyPasteLineSeparator,
+    this.rowWrapperIsConstantHeight = false,
   });
 
   const TrinaGridConfiguration.dark({
@@ -213,6 +225,7 @@ class TrinaGridConfiguration {
     this.dragSelectionDelayDuration = const Duration(milliseconds: 200),
     this.copyPasteCellSeparator,
     this.copyPasteLineSeparator,
+    this.rowWrapperIsConstantHeight = false,
   });
 
   void updateLocale() {
@@ -261,6 +274,7 @@ class TrinaGridConfiguration {
     Duration? dragSelectionDelayDuration,
     String? copyPasteCellSeparator,
     String? copyPasteLineSeparator,
+    bool? rowWrapperIsConstantHeight,
   }) {
     return TrinaGridConfiguration(
       enableMoveDownAfterSelecting:
@@ -289,6 +303,8 @@ class TrinaGridConfiguration {
           copyPasteCellSeparator ?? this.copyPasteCellSeparator,
       copyPasteLineSeparator:
           copyPasteLineSeparator ?? this.copyPasteLineSeparator,
+      rowWrapperIsConstantHeight:
+          rowWrapperIsConstantHeight ?? this.rowWrapperIsConstantHeight,
     );
   }
 
@@ -317,7 +333,8 @@ class TrinaGridConfiguration {
             enableCtrlClickMultiSelect == other.enableCtrlClickMultiSelect &&
             dragSelectionDelayDuration == other.dragSelectionDelayDuration &&
             copyPasteCellSeparator == other.copyPasteCellSeparator &&
-            copyPasteLineSeparator == other.copyPasteLineSeparator;
+            copyPasteLineSeparator == other.copyPasteLineSeparator &&
+            rowWrapperIsConstantHeight == other.rowWrapperIsConstantHeight;
   }
 
   @override
@@ -341,6 +358,7 @@ class TrinaGridConfiguration {
       dragSelectionDelayDuration,
       copyPasteCellSeparator,
       copyPasteLineSeparator,
+      rowWrapperIsConstantHeight,
     ),
   );
 }

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -246,7 +246,10 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                                       physics: const ClampingScrollPhysics(),
                                       itemCount: _scrollableRows.length,
                                       itemExtent:
-                                          stateManager.rowWrapper != null
+                                          (stateManager.rowWrapper != null &&
+                                              !stateManager
+                                                  .configuration
+                                                  .rowWrapperIsConstantHeight)
                                           ? null
                                           : stateManager.rowTotalHeight,
                                       addRepaintBoundaries: false,


### PR DESCRIPTION
### Summary

- Adds `rowWrapperIsConstantHeight` configuration option to `TrinaGridConfiguration`
- When `true`, enables `itemExtent` ListView performance optimization even when `rowWrapper` is used
- Allows reliable scroll position calculations for grids with constant-height row wrappers

### Problem

As of **v2.1.1**, when `rowWrapper` is used, `itemExtent` is disabled conditionally to support variable row heights and enabled when `rowWrapper` is `null`. However, this causes two issues for grid implementations where one is willing to guarantee that the wrapper only adds visual styling (colors, borders) without affecting height:

1. **Unreliable scroll calculations**: Without `itemExtent`, Flutter estimates content height from visible rows only. When row heights change (e.g., user toggles between compact/comfortable modes), scroll position maintenance becomes unpredictable.

2. **O(n) scroll performance**: Without `itemExtent`, scroll offset calculations scale linearly with row count instead of O(1).

### Minimal reproduction

See below.

### Solution

Add `rowWrapperIsConstantHeight` (default: `false`) that, when `true`, keeps `itemExtent` enabled even with `rowWrapper`:

```dart
itemExtent:
    (stateManager.rowWrapper != null &&
        !stateManager
                .configuration
                .rowWrapperIsConstantHeight)
    ? null
    : stateManager.rowTotalHeight,
```

### Scope

This configuration option only affects one line in trina_body_rows.dart. The frozen row files (trina_left_frozen_rows.dart, trina_right_frozen_rows.dart) have itemExtent unconditionally removed with comments indicating this was intentional for variable heights support. I chose to leave those unchanged to avoid unintended side effects.

- Existing tests pass
- Grid with `rowWrapper` and `rowWrapperIsConstantHeight: false` behaves as before
- Grid with `rowWrapper` and `rowWrapperIsConstantHeight: true` maintains scroll position when row height changes and has smoother scroll

### Working Example of Undesired Behavior

With the new `rowWrapperIsConstantHeight: true` parameter added, behavior works identically with and without this constant-height row wrapper applies.

```dart
// trina_scroll_bug.dart 
//
// Demonstrates scroll position maintenance during row height changes
//
// Run: flutter run trina_scroll_bug.dart
//
// PROBLEM: When row heights change, scroll offset stays constant but a different
// row appears at viewport top. trina_grid has no API for this - must use jumpTo().
//
// SOLUTION (without rowWrapper):
//   topRowIndex = currentOffset / oldRowTotal
//   targetOffset = topRowIndex * newRowTotal
//   controller.jumpTo(targetOffset)
//
// LIMITATION (with rowWrapper):
//   rowWrapper disables itemExtent, so ListView estimates content height from
//   visible rows only. This makes scroll calculations unreliable:
//   - "No Adjustment": close but off by ~10 rows
//   - "Adjust Scroll" or "Jump to": oscillates wildly
//
// EDGE CASE: At scroll bottom, detect wasAtEnd and recalculate new maxScrollExtent.
//
// TEST: Jump to row 500, toggle row sizes (keep rowWrapper OFF for accurate test)

import 'package:flutter/material.dart';
import 'package:trina_grid/trina_grid.dart';

void main() {
  WidgetsFlutterBinding.ensureInitialized();
  runApp(const ScrollBugTestApp());
}

class ScrollBugTestApp extends StatelessWidget {
  const ScrollBugTestApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Trina Grid Scroll Bug Test',
      theme: ThemeData(useMaterial3: false),
      home: const ScrollBugTestScreen(),
    );
  }
}

enum RowSize { small, medium, large }

class ScrollBugTestScreen extends StatefulWidget {
  const ScrollBugTestScreen({super.key});

  @override
  State<ScrollBugTestScreen> createState() => _ScrollBugTestScreenState();
}

class _ScrollBugTestScreenState extends State<ScrollBugTestScreen> {
  // Test controls
  bool _useRowWrapper = false;
  bool _useCustomScrollLogic = true; // false = no adjustment
  RowSize _rowSize = RowSize.medium;
  RowSize? _previousRowSize;

  // Grid state
  TrinaGridStateManager? _stateManager;

  // Row count
  static const int _rowCount = 1000;

  // Row heights
  static const double _smallRowHeight = 24.0;
  static const double _mediumRowHeight = 36.0;
  static const double _largeRowHeight = 56.0;

  double _getRowHeight(RowSize size) {
    switch (size) {
      case RowSize.small:
        return _smallRowHeight;
      case RowSize.medium:
        return _mediumRowHeight;
      case RowSize.large:
        return _largeRowHeight;
    }
  }

  List<TrinaColumn> _buildColumns() {
    return [
      TrinaColumn(
        title: 'Index',
        field: 'index',
        width: 80,
        type: TrinaColumnType.number(),
      ),
      TrinaColumn(
        title: 'Description',
        field: 'description',
        width: 300,
        type: TrinaColumnType.text(),
      ),
      TrinaColumn(
        title: 'Amount',
        field: 'amount',
        width: 120,
        type: TrinaColumnType.number(),
      ),
    ];
  }

  List<TrinaRow> _buildRows() {
    return List.generate(_rowCount, (index) {
      return TrinaRow(
        cells: {
          'index': TrinaCell(value: index),
          'description': TrinaCell(value: 'Row $index - Test data for scroll behavior'),
          'amount': TrinaCell(value: (index * 10.5).toStringAsFixed(2)),
        },
      );
    });
  }

  TrinaGridConfiguration _buildConfig() {
    final rowHeight = _getRowHeight(_rowSize);

    return TrinaGridConfiguration(
      style: TrinaGridStyleConfig(
        rowHeight: rowHeight,
        columnHeight: 36,
        cellHorizontalBorderWidth: 1,
        cellVerticalBorderWidth: 1,
        borderColor: Colors.grey.shade300,
        gridBorderRadius: BorderRadius.circular(4),
      ),
      scrollbar: const TrinaGridScrollbarConfig(
        showHorizontal: true,
        showVertical: true,
      ),
      // PROPOSED FIX: When true, keeps itemExtent enabled even with rowWrapper
      // rowWrapperIsConstantHeight: true,
    );
  }

  // Row wrapper with color pattern
  Widget _wrapRow(
    BuildContext context,
    Widget rowWidget,
    TrinaRow row,
    TrinaGridStateManager stateManager,
  ) {
    final index = row.cells['index']?.value as int? ?? 0;
    final isEven = index % 2 == 0;

    return Container(
      color: isEven ? Colors.yellow.shade100 : Colors.cyan.shade100,
      child: rowWidget,
    );
  }

  Color _getRowColor(TrinaRowColorContext context) {
    return Colors.transparent; // Handled by wrapper
  }

  void _scrollToRow(int rowIndex) {
    if (_stateManager == null) return;

    final controller = _stateManager!.scroll.bodyRowsVertical;
    if (controller == null || !controller.hasClients) return;

    final rowHeight = _getRowHeight(_rowSize);
    const borderWidth = 1.0;
    final targetOffset = rowIndex * (rowHeight + borderWidth);
    controller.jumpTo(targetOffset);
  }

  void _changeRowSize(RowSize newSize) {
    if (newSize == _rowSize) return;

    setState(() {
      _previousRowSize = _rowSize;
      _rowSize = newSize;
    });
  }

  @override
  Widget build(BuildContext context) {
    // Handle row size change - maintain scroll position
    if (_previousRowSize != null && _stateManager != null) {
      if (_useCustomScrollLogic) {
        // Custom logic using jumpTo
        final scrollController = _stateManager!.scroll.bodyRowsVertical;
        if (scrollController != null && scrollController.hasClients) {
          final currentOffset = scrollController.offset;
          final oldMaxExtent = scrollController.position.maxScrollExtent;
          final oldRowHeight = _getRowHeight(_previousRowSize!);
          final newRowHeight = _getRowHeight(_rowSize);

          // Include border width (1px) in row height for accurate calculation
          const borderWidth = 1.0;
          final oldRowTotal = oldRowHeight + borderWidth;
          final newRowTotal = newRowHeight + borderWidth;

          // Check if we were at or near scroll end (within one row height)
          final wasAtEnd = (oldMaxExtent - currentOffset) < oldRowTotal;

          final double targetOffset;
          if (wasAtEnd) {
            // At scroll end - calculate new max extent and stay there
            final viewportHeight = scrollController.position.viewportDimension;
            final newContentHeight = _rowCount * newRowTotal;
            targetOffset = (newContentHeight - viewportHeight).clamp(0.0, newContentHeight);
          } else {
            // Not at end - maintain top row position
            final topRowIndex = (currentOffset / oldRowTotal).floor();
            final calculatedOffset = topRowIndex * newRowTotal;

            // Only clamp when going to smaller rows
            if (newRowHeight < oldRowHeight) {
              final viewportHeight = scrollController.position.viewportDimension;
              final newContentHeight = _rowCount * newRowTotal;
              final newMaxExtent = (newContentHeight - viewportHeight).clamp(0.0, newContentHeight);
              targetOffset = calculatedOffset.clamp(0.0, newMaxExtent);
            } else {
              targetOffset = calculatedOffset;
            }
          }

          scrollController.jumpTo(targetOffset);
        }
      } else {
        // No adjustment - offset stays same, different row appears at top
      }
      _previousRowSize = null;
    }

    final rowHeight = _getRowHeight(_rowSize);

    // Status bar
    final statusText = 'Row Height: ${rowHeight.toInt()}px | '
        'rowWrapper: ${_useRowWrapper ? "ON" : "OFF"}';

    return Scaffold(
      appBar: AppBar(
        title: const Text('Trina Grid Scroll Bug Test'),
      ),
      body: Column(
        children: [
          // Controls row
          Container(
            padding: const EdgeInsets.all(8),
            color: Colors.grey.shade200,
            child: Row(
              children: [
                // Row size buttons
                const Text('Row Size: '),
                const SizedBox(width: 8),
                _buildSizeButton(RowSize.small, 'Small (24px)'),
                const SizedBox(width: 4),
                _buildSizeButton(RowSize.medium, 'Medium (36px)'),
                const SizedBox(width: 4),
                _buildSizeButton(RowSize.large, 'Large (56px)'),
                const Spacer(),
                // rowWrapper toggle
                const Text('rowWrapper: '),
                Switch(
                  value: _useRowWrapper,
                  onChanged: (value) {
                    setState(() {
                      _useRowWrapper = value;
                    });
                  },
                ),
                const SizedBox(width: 16),
                // Scroll logic toggle
                Text(
                  _useCustomScrollLogic ? 'Adjust Scroll' : 'No Adjustment',
                  style: TextStyle(
                    color: _useCustomScrollLogic ? Colors.green : Colors.red,
                    fontWeight: FontWeight.bold,
                  ),
                ),
                Switch(
                  value: _useCustomScrollLogic,
                  activeTrackColor: Colors.green.shade200,
                  inactiveTrackColor: Colors.red.shade200,
                  onChanged: (value) {
                    setState(() {
                      _useCustomScrollLogic = value;
                    });
                  },
                ),
              ],
            ),
          ),

          // Jump buttons row
          Container(
            padding: const EdgeInsets.all(8),
            color: Colors.blue.shade50,
            child: Row(
              children: [
                ElevatedButton(
                  onPressed: () => _scrollToRow(0),
                  child: const Text('Jump to Top'),
                ),
                const SizedBox(width: 8),
                ElevatedButton(
                  onPressed: () => _scrollToRow(500),
                  child: const Text('Jump to 500'),
                ),
                const SizedBox(width: 8),
                ElevatedButton(
                  onPressed: () => _scrollToRow(999),
                  child: const Text('Jump to End'),
                ),
                const Spacer(),
                Text(statusText),
              ],
            ),
          ),

          // Instructions
          Container(
            padding: const EdgeInsets.all(8),
            color: Colors.amber.shade50,
            child: const Text(
              'Test: Jump to 500, toggle row sizes. '
              'No Adjustment: row at top changes (500->740->500...). '
              'Adjust Scroll: same row stays at top.',
              style: TextStyle(fontSize: 12),
            ),
          ),

          // Grid
          Expanded(
            child: TrinaGrid(
              key: ValueKey('grid_$_useRowWrapper'), // Only rebuild on rowWrapper change
              columns: _buildColumns(),
              rows: _buildRows(),
              configuration: _buildConfig(),
              rowWrapper: _useRowWrapper ? _wrapRow : null,
              rowColorCallback: _useRowWrapper ? _getRowColor : null,
              onLoaded: (event) {
                _stateManager = event.stateManager;
              },
            ),
          ),
        ],
      ),
    );
  }

  Widget _buildSizeButton(RowSize size, String label) {
    final isSelected = _rowSize == size;
    return ElevatedButton(
      onPressed: () => _changeRowSize(size),
      style: ElevatedButton.styleFrom(
        backgroundColor: isSelected ? Colors.blue : Colors.grey.shade300,
        foregroundColor: isSelected ? Colors.white : Colors.black,
      ),
      child: Text(label),
    );
  }
}
```