### PR TITLE
feat: add moveDirection to onBeforeActiveCellChange event

### DIFF
--- a/doc/features/cell-navigation-validation.md
+++ b/doc/features/cell-navigation-validation.md
@@ -44,6 +44,14 @@ class TrinaGridOnBeforeActiveCellChangeEvent {
 
   /// The new row index
   final int newRowIdx;
+
+  /// The direction of movement that triggered this cell change.
+  /// This is `null` when the cell change was triggered by a mouse click
+  /// or programmatic call without direction context.
+  /// When navigating via keyboard (arrow keys, tab, etc.), this will be
+  /// TrinaMoveDirection.left, TrinaMoveDirection.right,
+  /// TrinaMoveDirection.up, or TrinaMoveDirection.down.
+  final TrinaMoveDirection? moveDirection;
 }
 ```
 
@@ -297,6 +305,39 @@ The `onBeforeActiveCellChange` callback works for **all** navigation methods:
 - **Programmatic navigation**: `stateManager.setCurrentCell()`
 
 This ensures consistent validation regardless of how the user navigates.
+
+### Distinguishing Navigation Source
+
+You can use the `moveDirection` property to distinguish between keyboard navigation and mouse clicks:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Check if this is keyboard navigation or mouse click
+    if (event.moveDirection != null) {
+      // Keyboard navigation (arrow keys, tab, etc.)
+      print('Navigating via keyboard: ${event.moveDirection}');
+
+      // Example: Apply stricter validation for keyboard navigation
+      if (event.oldRowIdx != event.newRowIdx) {
+        return validateRowBeforeLeaving(rows[event.oldRowIdx!]);
+      }
+    } else {
+      // Mouse click or programmatic navigation
+      print('Navigation via mouse click or programmatic call');
+
+      // Example: Allow free navigation via mouse
+      return true;
+    }
+
+    return true;
+  },
+)
+```
+
+This is particularly useful for desktop applications where you might want different behavior for keyboard versus mouse navigation.
 
 ## Best Practices
 

--- a/lib/src/manager/state/cell_state.dart
+++ b/lib/src/manager/state/cell_state.dart
@@ -26,7 +26,16 @@ abstract class ICellState {
   void clearCurrentCell({bool notify = true});
 
   /// Change the selected cell.
-  void setCurrentCell(TrinaCell? cell, int? rowIdx, {bool notify = true});
+  ///
+  /// [direction] is the movement direction that triggered this cell change.
+  /// Pass this when navigating via keyboard to allow callbacks to distinguish
+  /// between keyboard navigation and mouse clicks.
+  void setCurrentCell(
+    TrinaCell? cell,
+    int? rowIdx, {
+    bool notify = true,
+    TrinaMoveDirection? direction,
+  });
 
   /// Whether it is possible to move in the [direction] from [cellPosition].
   bool canMoveCell(
@@ -180,7 +189,12 @@ mixin CellState implements ITrinaGridState {
   }
 
   @override
-  void setCurrentCell(TrinaCell? cell, int? rowIdx, {bool notify = true}) {
+  void setCurrentCell(
+    TrinaCell? cell,
+    int? rowIdx, {
+    bool notify = true,
+    TrinaMoveDirection? direction,
+  }) {
     debugPrint(
       '[Selection] setCurrentCell called - rowIdx: $rowIdx, notify: $notify, ctrl: ${keyPressed.ctrl}, shift: ${keyPressed.shift}',
     );
@@ -209,6 +223,7 @@ mixin CellState implements ITrinaGridState {
           oldRowIdx: currentCellPosition?.rowIdx,
           newCell: cell,
           newRowIdx: rowIdx,
+          moveDirection: direction,
         ),
       );
 

--- a/lib/src/manager/state/keyboard_state.dart
+++ b/lib/src/manager/state/keyboard_state.dart
@@ -145,6 +145,7 @@ mixin KeyboardState implements ITrinaGridState {
       refRows[toMove.rowIdx!].cells[refColumns[toMove.columnIdx!].field],
       toMove.rowIdx,
       notify: notify,
+      direction: direction,
     );
 
     if (direction.horizontal) {
@@ -183,7 +184,12 @@ mixin KeyboardState implements ITrinaGridState {
 
     final cellToMove = currentRow!.cells[column.field];
 
-    setCurrentCell(cellToMove, currentRowIdx, notify: notify);
+    setCurrentCell(
+      cellToMove,
+      currentRowIdx,
+      notify: notify,
+      direction: direction,
+    );
 
     if (!showFrozenColumn || column.frozen.isFrozen != true) {
       direction.isLeft
@@ -212,7 +218,7 @@ mixin KeyboardState implements ITrinaGridState {
 
     final cellToMove = refRows[rowIdx].cells[field];
 
-    setCurrentCell(cellToMove, rowIdx, notify: notify);
+    setCurrentCell(cellToMove, rowIdx, notify: notify, direction: direction);
 
     direction.isUp
         ? scroll.vertical!.jumpTo(0)
@@ -241,7 +247,7 @@ mixin KeyboardState implements ITrinaGridState {
 
     final cellToMove = refRows[rowIdx].cells[field];
 
-    setCurrentCell(cellToMove, rowIdx, notify: notify);
+    setCurrentCell(cellToMove, rowIdx, notify: notify, direction: direction);
 
     moveScrollByRow(direction, rowIdx - direction.offset);
   }

--- a/lib/src/trina_grid_events.dart
+++ b/lib/src/trina_grid_events.dart
@@ -237,17 +237,29 @@ class TrinaGridOnBeforeActiveCellChangeEvent {
   /// The new row index
   final int newRowIdx;
 
+  /// The direction of movement that triggered this cell change.
+  /// This is `null` when the cell change was triggered by a mouse click
+  /// or programmatic call without direction context.
+  /// When navigating via keyboard (arrow keys, tab, etc.), this will be
+  /// [TrinaMoveDirection.left], [TrinaMoveDirection.right],
+  /// [TrinaMoveDirection.up], or [TrinaMoveDirection.down].
+  final TrinaMoveDirection? moveDirection;
+
   const TrinaGridOnBeforeActiveCellChangeEvent({
     required this.oldCell,
     required this.oldRowIdx,
     required this.newCell,
     required this.newRowIdx,
+    this.moveDirection,
   });
 
   @override
   String toString() {
     String out = '[TrinaGridOnBeforeActiveCellChangeEvent] ';
     out += 'OldRowIdx: $oldRowIdx, NewRowIdx: $newRowIdx';
+    if (moveDirection != null) {
+      out += ', MoveDirection: $moveDirection';
+    }
     return out;
   }
 }

--- a/test/mock/shared_mocks.mocks.dart
+++ b/test/mock/shared_mocks.mocks.dart
@@ -1620,8 +1620,13 @@ class MockTrinaGridStateManager extends _i1.Mock
     _i2.TrinaCell? cell,
     int? rowIdx, {
     bool? notify = true,
+    _i2.TrinaMoveDirection? direction,
   }) => super.noSuchMethod(
-    Invocation.method(#setCurrentCell, [cell, rowIdx], {#notify: notify}),
+    Invocation.method(
+      #setCurrentCell,
+      [cell, rowIdx],
+      {#notify: notify, #direction: direction},
+    ),
     returnValueForMissingStub: null,
   );
 


### PR DESCRIPTION
## Summary
- Add `TrinaMoveDirection? moveDirection` parameter to `TrinaGridOnBeforeActiveCellChangeEvent`
- Add optional `direction` parameter to `setCurrentCell()` method
- Pass direction from keyboard navigation (arrow keys, tab, etc.)
- Mouse clicks and programmatic calls will have `null` direction

This allows developers to distinguish between keyboard navigation and mouse clicks in the `onBeforeActiveCellChange` callback.

Closes #280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds moveDirection to the before-active-cell-change event and passes keyboard navigation direction through a new optional direction param in setCurrentCell; updates docs and mocks.
> 
> - **Events/Core**:
>   - `TrinaGridOnBeforeActiveCellChangeEvent`: add `moveDirection` (nullable) and include in `toString()`.
> - **State/Navigation**:
>   - `ICellState.setCurrentCell(...)`: add optional `TrinaMoveDirection? direction` and forward it to the event.
>   - `KeyboardState`: pass `direction` to `setCurrentCell` in `moveCurrentCell`, `moveCurrentCellToEdgeOfColumns`, `moveCurrentCellToEdgeOfRows`, and `moveCurrentCellByRowIdx`.
> - **Docs**:
>   - Update `doc/features/cell-navigation-validation.md` to document `moveDirection` and add usage example distinguishing keyboard vs mouse navigation.
> - **Tests/Mocks**:
>   - Update `test/mock/shared_mocks.mocks.dart` to reflect new `setCurrentCell` signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d78efdb51b98e4d881932db772bbcad53b2b0fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->