### PR TITLE
feat: accept any Widget as sort icons

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -717,12 +717,12 @@ class TrinaGridStyleConfig {
   /// Ascending icon when sorting a column.
   ///
   /// If no value is specified, the default icon is set.
-  final Icon? columnAscendingIcon;
+  final Widget? columnAscendingIcon;
 
   /// Descending icon when sorting a column.
   ///
   /// If no value is specified, the default icon is set.
-  final Icon? columnDescendingIcon;
+  final Widget? columnDescendingIcon;
 
   /// Icon when RowGroup is expanded.
   final IconData rowGroupExpandedIcon;
@@ -807,8 +807,8 @@ class TrinaGridStyleConfig {
     TextStyle? cellTextStyle,
     IconData? columnContextIcon,
     IconData? columnResizeIcon,
-    TrinaOptional<Icon?>? columnAscendingIcon,
-    TrinaOptional<Icon?>? columnDescendingIcon,
+    TrinaOptional<Widget?>? columnAscendingIcon,
+    TrinaOptional<Widget?>? columnDescendingIcon,
     IconData? rowGroupExpandedIcon,
     IconData? rowGroupCollapsedIcon,
     IconData? rowGroupEmptyIcon,

--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -272,9 +272,9 @@ class TrinaGridColumnIcon extends StatelessWidget {
 
   final IconData icon;
 
-  final Icon? ascendingIcon;
+  final Widget? ascendingIcon;
 
-  final Icon? descendingIcon;
+  final Widget? descendingIcon;
 
   const TrinaGridColumnIcon({
     this.sort,

--- a/test/src/ui/columns/trina_column_title_test.dart
+++ b/test/src/ui/columns/trina_column_title_test.dart
@@ -537,6 +537,59 @@ void main() {
       expect(icon.icon, Icons.arrow_upward);
       expect(icon.color, Colors.cyan);
     });
+
+    testWidgets('columnAscendingIcon should accept any Widget, not just Icon', (
+      tester,
+    ) async {
+      final column = buildColumn(sort: TrinaColumnSort.ascending);
+
+      await buildGrid(
+        tester,
+        columns: [column],
+        configuration: const TrinaGridConfiguration(
+          style: TrinaGridStyleConfig(
+            columnAscendingIcon: Text(
+              '↑',
+              style: TextStyle(color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+
+      final target = find.descendant(
+        of: find.byType(TrinaColumnTitle),
+        matching: find.text('↑'),
+      );
+
+      expect(target, findsOneWidget);
+    });
+
+    testWidgets(
+      'columnDescendingIcon should accept any Widget, not just Icon',
+      (tester) async {
+        final column = buildColumn(sort: TrinaColumnSort.descending);
+
+        await buildGrid(
+          tester,
+          columns: [column],
+          configuration: const TrinaGridConfiguration(
+            style: TrinaGridStyleConfig(
+              columnDescendingIcon: Text(
+                '↓',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ),
+        );
+
+        final target = find.descendant(
+          of: find.byType(TrinaColumnTitle),
+          matching: find.text('↓'),
+        );
+
+        expect(target, findsOneWidget);
+      },
+    );
   });
 
   group('with titleRenderer', () {


### PR DESCRIPTION
## Summary
- Change `columnAscendingIcon` and `columnDescendingIcon` from `Icon?` to `Widget?` type
- Allows any widget (Text, Image, FaIcon, etc.) as sort indicators
- Non-breaking change since `Icon` extends `Widget`

Closes #279

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change sort icon APIs to accept any Widget (not just Icon) and add tests verifying Text-based indicators work.
> 
> - **Style/API**:
>   - `TrinaGridStyleConfig`: change `columnAscendingIcon`/`columnDescendingIcon` from `Icon?` to `Widget?`; update `copyWith` to `TrinaOptional<Widget?>`.
> - **UI**:
>   - `TrinaGridColumnIcon`: props `ascendingIcon`/`descendingIcon` now `Widget?`; rendering supports arbitrary widgets.
> - **Tests**:
>   - Add widget tests ensuring `columnAscendingIcon`/`columnDescendingIcon` accept non-Icon widgets (e.g., `Text`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 060231ca246e08d227fa4541152d24db649a11c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->