### PR TITLE
feat: add lazy pagination functionality for TrinaGrid.

### DIFF
--- a/lib/src/plugin/trina_lazy_pagination.dart
+++ b/lib/src/plugin/trina_lazy_pagination.dart
@@ -360,6 +360,7 @@ class TrinaLazyPaginationState extends State<TrinaLazyPagination> {
           }
         })
         .catchError((error) {
+          debugPrint('TrinaLazyPagination fetch error: $error');
           // Only handle error if this is still the current fetch
           if (thisVersion != _fetchVersion || !mounted) return;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Logging enhancement**
> 
> - Adds `debugPrint` in `TrinaLazyPagination.setPage` `catchError` to log fetch errors (`TrinaLazyPagination fetch error: $error`).
> - No functional changes to pagination flow; loading indicator still hidden on error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9728ecb81587d29c56c3b8d462c6b5e45a4eeba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->