### PR TITLE
fix: visibilityLayout: true breaks left+right frozen columns

### DIFF
--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -58,9 +58,8 @@ class TrinaLeftFrozenRowsState
     _frozenBottomRows = stateManager.refRows.originalList
         .where((row) => row.frozen == TrinaRowFrozen.end)
         .toList();
-    _scrollableRows = _rows
-        .where((row) => row.frozen == TrinaRowFrozen.none)
-        .toList();
+    _scrollableRows =
+        _rows.where((row) => row.frozen == TrinaRowFrozen.none).toList();
   }
 
   Widget _buildRow(BuildContext context, TrinaRow row, int index) {
@@ -70,7 +69,6 @@ class TrinaLeftFrozenRowsState
       row: row,
       columns: _columns,
       stateManager: stateManager,
-      visibilityLayout: true,
     );
 
     return stateManager.rowWrapper?.call(

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -58,9 +58,8 @@ class TrinaRightFrozenRowsState
     _frozenBottomRows = stateManager.refRows.originalList
         .where((row) => row.frozen == TrinaRowFrozen.end)
         .toList();
-    _scrollableRows = _rows
-        .where((row) => row.frozen == TrinaRowFrozen.none)
-        .toList();
+    _scrollableRows =
+        _rows.where((row) => row.frozen == TrinaRowFrozen.none).toList();
   }
 
   Widget _buildRow(BuildContext context, TrinaRow row, int index) {
@@ -70,7 +69,6 @@ class TrinaRightFrozenRowsState
       row: row,
       columns: _columns,
       stateManager: stateManager,
-      visibilityLayout: true,
     );
 
     return stateManager.rowWrapper?.call(


### PR DESCRIPTION
Regressed by: https://github.com/doonfrs/trina_grid/pull/240/commits/c2cf0f144cddfba835746956464475e12504f281

- TrinaBaseRow(visibilityLayout: true) skips paint layer during Android scroll
- Both TrinaLeftFrozenRows & TrinaRightFrozenRows affected
- Remove visibilityLayout → direct render (matches working pattern)
- Git bisect + code diff confirmed exact cause
- Closes #269 >"

- issue:

https://github.com/user-attachments/assets/f74a19b7-0be0-458c-a34f-a678102d7226

