### PR TITLE
fix: frozen columns vertical misalignment while scrolling

### DIFF
--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -58,8 +58,9 @@ class TrinaLeftFrozenRowsState
     _frozenBottomRows = stateManager.refRows.originalList
         .where((row) => row.frozen == TrinaRowFrozen.end)
         .toList();
-    _scrollableRows =
-        _rows.where((row) => row.frozen == TrinaRowFrozen.none).toList();
+    _scrollableRows = _rows
+        .where((row) => row.frozen == TrinaRowFrozen.none)
+        .toList();
   }
 
   Widget _buildRow(BuildContext context, TrinaRow row, int index) {
@@ -100,7 +101,11 @@ class TrinaLeftFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            // Remove fixed itemExtent for variable heights
+            itemExtent:
+                (stateManager.rowWrapper != null &&
+                    !stateManager.configuration.rowWrapperIsConstantHeight)
+                ? null
+                : stateManager.rowTotalHeight,
             itemBuilder: (ctx, i) =>
                 _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -58,8 +58,9 @@ class TrinaRightFrozenRowsState
     _frozenBottomRows = stateManager.refRows.originalList
         .where((row) => row.frozen == TrinaRowFrozen.end)
         .toList();
-    _scrollableRows =
-        _rows.where((row) => row.frozen == TrinaRowFrozen.none).toList();
+    _scrollableRows = _rows
+        .where((row) => row.frozen == TrinaRowFrozen.none)
+        .toList();
   }
 
   Widget _buildRow(BuildContext context, TrinaRow row, int index) {
@@ -100,7 +101,11 @@ class TrinaRightFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            // Remove fixed itemExtent for variable heights
+            itemExtent:
+                (stateManager.rowWrapper != null &&
+                    !stateManager.configuration.rowWrapperIsConstantHeight)
+                ? null
+                : stateManager.rowTotalHeight,
             itemBuilder: (ctx, i) =>
                 _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),


### PR DESCRIPTION
## Summary
- Add `itemExtent` to frozen rows ListView to match body rows behavior
- Without `itemExtent`, frozen rows calculated their own heights which differed slightly from `rowTotalHeight`, causing cumulative vertical drift while scrolling

Closes #289