### PR TITLE
fix: prevent crash when TrinaDualGrid onSelected is null

### DIFF
--- a/lib/src/trina_dual_grid.dart
+++ b/lib/src/trina_dual_grid.dart
@@ -175,6 +175,8 @@ class TrinaDualGridState extends State<TrinaDualGrid> {
         },
         onChanged: props.onChanged,
         onSelected: (TrinaGridOnSelectedEvent onSelectedEvent) {
+          if (widget.onSelected == null) return;
+
           if (onSelectedEvent.row == null || onSelectedEvent.cell == null) {
             widget.onSelected!(
               TrinaDualOnSelectedEvent(gridA: null, gridB: null),


### PR DESCRIPTION
## Summary
- Add null check guard for `onSelected` callback in `TrinaDualGrid` widget
- Prevents runtime crash when users don't provide an `onSelected` callback

Closes #283