### PR TITLE
fix: renderer cache not invalidating when other cells in row change

### DIFF
--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -338,6 +338,7 @@ mixin EditingState implements ITrinaGridState {
 
     currentRow.setState(TrinaRowState.updated);
     cell.value = value;
+    currentRow.incrementVersion();
 
     final changedEvent = TrinaGridOnChangedEvent(
       columnIdx: columnIndex(currentColumn)!,
@@ -464,6 +465,7 @@ mixin EditingState implements ITrinaGridState {
         refRows[rowIdx].setState(TrinaRowState.updated);
 
         currentCell.value = newValue;
+        refRows[rowIdx].incrementVersion();
 
         // Create the event object once to reuse for both callbacks
         final changedEvent = TrinaGridOnChangedEvent(

--- a/lib/src/model/trina_row.dart
+++ b/lib/src/model/trina_row.dart
@@ -49,7 +49,17 @@ class TrinaRow<T> {
 
   TrinaRowState _state;
 
+  /// Version number that increments when any cell value in this row changes.
+  /// Used by cell renderer caching to detect cross-cell dependencies.
+  int _version = 0;
+
   Key get key => _key;
+
+  /// Get the current row version for cache invalidation.
+  int get version => _version;
+
+  /// Increment the row version (called when any cell changes).
+  void incrementVersion() => _version++;
 
   bool get initialized {
     if (cells.isEmpty) {

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -36,6 +36,7 @@ mixin PopupCellState<T extends PopupCell> on State<T>
   // Cache for editCellRenderer callback result
   Widget? _cachedEditCellWidget;
   dynamic _cachedCellValueForEditRenderer;
+  int? _cachedRowVersionForEditRenderer;
 
   KeyEventResult handleOpeningPopupWithKeyboard(
     FocusNode node,
@@ -124,9 +125,12 @@ mixin PopupCellState<T extends PopupCell> on State<T>
         widget.column.editCellRenderer ?? widget.stateManager.editCellRenderer;
     if (customRenderer != null) {
       // Cache the editCellRenderer result to avoid excessive callback executions
+      // Also invalidate when row version changes (cross-cell dependency)
       if (_cachedCellValueForEditRenderer != widget.cell.value ||
+          _cachedRowVersionForEditRenderer != widget.row.version ||
           _cachedEditCellWidget == null) {
         _cachedCellValueForEditRenderer = widget.cell.value;
+        _cachedRowVersionForEditRenderer = widget.row.version;
         _cachedEditCellWidget = customRenderer(
           defaultEditWidget,
           widget.cell,

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -42,10 +42,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
   // Cache for checkReadOnly callback result
   bool? _cachedReadOnly;
   dynamic _cachedCellValueForReadOnly;
+  int? _cachedRowVersionForReadOnly;
 
   // Cache for editCellRenderer callback result
   Widget? _cachedEditCellWidget;
   dynamic _cachedCellValueForEditRenderer;
+  int? _cachedRowVersionForEditRenderer;
 
   @override
   TextInputType get keyboardType => TextInputType.text;
@@ -58,9 +60,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
 
   bool get _readOnly {
     // Cache the checkReadOnly result to avoid excessive callback executions
+    // Also invalidate when row version changes (cross-cell dependency)
     if (_cachedCellValueForReadOnly != widget.cell.value ||
+        _cachedRowVersionForReadOnly != widget.row.version ||
         _cachedReadOnly == null) {
       _cachedCellValueForReadOnly = widget.cell.value;
+      _cachedRowVersionForReadOnly = widget.row.version;
       _cachedReadOnly = widget.column.checkReadOnly(widget.row, widget.cell);
     }
     return _cachedReadOnly!;
@@ -297,9 +302,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
     // Use column-level editCellRenderer if available, otherwise fall back to grid-level
     if (widget.column.editCellRenderer != null) {
       // Cache the editCellRenderer result to avoid excessive callback executions
+      // Also invalidate when row version changes (cross-cell dependency)
       if (_cachedCellValueForEditRenderer != widget.cell.value ||
+          _cachedRowVersionForEditRenderer != widget.row.version ||
           _cachedEditCellWidget == null) {
         _cachedCellValueForEditRenderer = widget.cell.value;
+        _cachedRowVersionForEditRenderer = widget.row.version;
         _cachedEditCellWidget = widget.column.editCellRenderer!(
           w,
           widget.cell,
@@ -311,9 +319,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       return _cachedEditCellWidget!;
     } else if (widget.stateManager.editCellRenderer != null) {
       // Cache the editCellRenderer result to avoid excessive callback executions
+      // Also invalidate when row version changes (cross-cell dependency)
       if (_cachedCellValueForEditRenderer != widget.cell.value ||
+          _cachedRowVersionForEditRenderer != widget.row.version ||
           _cachedEditCellWidget == null) {
         _cachedCellValueForEditRenderer = widget.cell.value;
+        _cachedRowVersionForEditRenderer = widget.row.version;
         _cachedEditCellWidget = widget.stateManager.editCellRenderer!(
           w,
           widget.cell,

--- a/lib/src/ui/cells/trina_default_cell.dart
+++ b/lib/src/ui/cells/trina_default_cell.dart
@@ -474,6 +474,7 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
   bool? _cachedIsCurrentCell;
   bool? _cachedIsSelectedCell;
   Widget? _cachedRendererWidget;
+  int? _cachedRowVersion;
 
   @override
   void didUpdateWidget(_DefaultCellWidget oldWidget) {
@@ -484,6 +485,7 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
       _cachedCellValue = null;
       _cachedIsCurrentCell = null;
       _cachedIsSelectedCell = null;
+      _cachedRowVersion = null;
     }
   }
 
@@ -532,12 +534,14 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
     // Check for cell renderer first
     if (widget.cell.hasRenderer) {
       // Cache the renderer result to avoid excessive callback executions
-      // Invalidate cache if cell value or selection state changes
+      // Invalidate cache if cell value, row version, or selection state changes
       if (_cachedCellValue != widget.cell.value ||
+          _cachedRowVersion != widget.row.version ||
           _cachedIsCurrentCell != isCurrentCell ||
           _cachedIsSelectedCell != isSelectedCell ||
           _cachedRendererWidget == null) {
         _cachedCellValue = widget.cell.value;
+        _cachedRowVersion = widget.row.version;
         _cachedIsCurrentCell = isCurrentCell;
         _cachedIsSelectedCell = isSelectedCell;
         _cachedRendererWidget = widget.cell.renderer!(
@@ -556,12 +560,14 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
     // Fall back to column renderer
     if (widget.column.hasRenderer) {
       // Cache the renderer result to avoid excessive callback executions
-      // Invalidate cache if cell value or selection state changes
+      // Invalidate cache if cell value, row version, or selection state changes
       if (_cachedCellValue != widget.cell.value ||
+          _cachedRowVersion != widget.row.version ||
           _cachedIsCurrentCell != isCurrentCell ||
           _cachedIsSelectedCell != isSelectedCell ||
           _cachedRendererWidget == null) {
         _cachedCellValue = widget.cell.value;
+        _cachedRowVersion = widget.row.version;
         _cachedIsCurrentCell = isCurrentCell;
         _cachedIsSelectedCell = isSelectedCell;
         _cachedRendererWidget = widget.column.renderer!(

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -395,6 +395,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
   // Cache for checkReadOnly callback result
   bool? _cachedReadOnly;
   dynamic _cachedCellValueForReadOnly;
+  int? _cachedRowVersionForReadOnly;
 
   @override
   TrinaGridStateManager get stateManager => widget.stateManager;
@@ -408,9 +409,12 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
 
   bool _getReadOnly() {
     // Cache the checkReadOnly result to avoid excessive callback executions
+    // Also invalidate when row version changes (cross-cell dependency)
     if (_cachedCellValueForReadOnly != widget.cell.value ||
+        _cachedRowVersionForReadOnly != widget.row.version ||
         _cachedReadOnly == null) {
       _cachedCellValueForReadOnly = widget.cell.value;
+      _cachedRowVersionForReadOnly = widget.row.version;
       _cachedReadOnly = widget.column.checkReadOnly(widget.row, widget.cell);
     }
     return _cachedReadOnly!;

--- a/test/src/ui/cells/renderer_callback_cache_test.dart
+++ b/test/src/ui/cells/renderer_callback_cache_test.dart
@@ -5,7 +5,6 @@ import 'package:trina_grid/trina_grid.dart';
 import 'package:trina_grid/src/ui/ui.dart';
 import 'package:rxdart/rxdart.dart';
 
-import '../../../helper/trina_widget_test_helper.dart';
 import '../../../helper/row_helper.dart';
 import '../../../mock/shared_mocks.mocks.dart';
 
@@ -335,6 +334,154 @@ void main() {
         expect(
           find.text('Rendered: test value, Selected: true'),
           findsOneWidget,
+        );
+      },
+    );
+  });
+
+  group('Cross-cell dependency cache invalidation (Issue #268)', () {
+    testWidgets(
+      'renderer cache should invalidate when another cell in the same row changes',
+      (WidgetTester tester) async {
+        int callCount = 0;
+
+        // Renderer that reads ANOTHER cell's value from the same row
+        Widget renderer(TrinaColumnRendererContext context) {
+          callCount++;
+          final status = context.row.cells['status']?.value ?? 'unknown';
+          return Text('Name: ${context.cell.value}, Status: $status');
+        }
+
+        final TrinaColumn nameColumn = TrinaColumn(
+          title: 'Name',
+          field: 'name',
+          type: TrinaColumnType.text(),
+          renderer: renderer,
+        );
+
+        // Create two cells in the same row
+        final TrinaCell statusCell = TrinaCell(value: 'active');
+        final TrinaCell nameCell = TrinaCell(value: 'John');
+        final TrinaRow row = TrinaRow(
+          cells: {'status': statusCell, 'name': nameCell},
+        );
+
+        when(stateManager.isCurrentCell(any)).thenReturn(false);
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: nameCell,
+                column: nameColumn,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Initial render
+        expect(callCount, 1);
+        expect(find.text('Name: John, Status: active'), findsOneWidget);
+
+        // Change the OTHER cell (status) - this simulates what changeCellValue does
+        statusCell.value = 'inactive';
+        row.incrementVersion();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: nameCell,
+                column: nameColumn,
+                row: row,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Renderer should be called again because row version changed
+        expect(
+          callCount,
+          2,
+          reason:
+              'Renderer should be called again when another cell in the row changes',
+        );
+        expect(find.text('Name: John, Status: inactive'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renderer cache should NOT invalidate when cell in different row changes',
+      (WidgetTester tester) async {
+        int callCount = 0;
+
+        Widget renderer(TrinaColumnRendererContext context) {
+          callCount++;
+          return Text('Value: ${context.cell.value}');
+        }
+
+        final TrinaColumn column = TrinaColumn(
+          title: 'Name',
+          field: 'name',
+          type: TrinaColumnType.text(),
+          renderer: renderer,
+        );
+
+        // Create two separate rows
+        final TrinaCell cell1 = TrinaCell(value: 'Row 1');
+        final TrinaRow row1 = TrinaRow(cells: {'name': cell1});
+
+        final TrinaCell cell2 = TrinaCell(value: 'Row 2');
+        final TrinaRow row2 = TrinaRow(cells: {'name': cell2});
+
+        when(stateManager.isCurrentCell(any)).thenReturn(false);
+        when(stateManager.isSelectedCell(any, any, any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell1,
+                column: column,
+                row: row1,
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        expect(callCount, 1);
+
+        // Change cell in DIFFERENT row
+        cell2.value = 'Row 2 Changed';
+        row2.incrementVersion();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TrinaDefaultCell(
+                cell: cell1,
+                column: column,
+                row: row1, // Still row1
+                rowIdx: 0,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+
+        // Renderer should NOT be called again (different row)
+        expect(
+          callCount,
+          1,
+          reason: 'Renderer should not be called when a different row changes',
         );
       },
     );


### PR DESCRIPTION
## Summary
- Fixes custom column renderer background color not updating when dependent cells change
- Added row version tracking to invalidate renderer cache when any cell in a row changes
- Added tests for cross-cell dependency scenarios

## Details
When a custom renderer reads another cell's value from the same row (e.g., `rendererContext.row.cells['legStatus']?.value`), changing that cell's value now correctly invalidates the cache and re-renders all dependent cells.

The fix adds a version counter to `TrinaRow` that increments when any cell changes. Cell widgets track this version and invalidate their renderer cache when it changes.

Closes #268