### PR TITLE
fix: row moving now works with multiple selected rows

### DIFF
--- a/lib/src/manager/state/dragging_row_state.dart
+++ b/lib/src/manager/state/dragging_row_state.dart
@@ -57,7 +57,12 @@ mixin DraggingRowState implements ITrinaGridState {
 
     _state._isDraggingRow = flag;
 
-    _clearDraggingState();
+    // Only clear drag state when ending a drag (flag = false).
+    // Don't clear when starting - dragRows will be set immediately after.
+    // This ensures dragRows is still available when onAccept is called.
+    if (!flag) {
+      _state._dragTargetRowIdx = null;
+    }
 
     notifyListeners(notify, setIsDraggingRow.hashCode);
   }
@@ -108,11 +113,5 @@ mixin DraggingRowState implements ITrinaGridState {
     return rowKey != null &&
         isDraggingRow == true &&
         dragRows.firstWhereOrNull((element) => element.key == rowKey) != null;
-  }
-
-  void _clearDraggingState() {
-    _state._dragRows = [];
-
-    _state._dragTargetRowIdx = null;
   }
 }

--- a/lib/src/ui/cells/trina_default_cell.dart
+++ b/lib/src/ui/cells/trina_default_cell.dart
@@ -278,10 +278,9 @@ class _RowDragIconWidget extends StatelessWidget {
   }
 
   void _handleOnPointerMove(PointerMoveEvent event) {
-    // Do not drag while rows are selected.
-    if (stateManager.isSelecting) {
-      stateManager.setIsDraggingRow(false);
-
+    // Do not start drag while actively selecting rows.
+    // Allow drag to continue if it was already initiated via the drag handle.
+    if (stateManager.isSelecting && !stateManager.isDraggingRow) {
       return;
     }
 

--- a/test/src/manager/state/dragging_row_state_test.dart
+++ b/test/src/manager/state/dragging_row_state_test.dart
@@ -72,6 +72,46 @@ void main() {
       expect(stateManager.isDraggingRow, isTrue);
       verifyNever(listener!.noParamReturnVoid());
     });
+
+    test(
+      'When setIsDraggingRow(false) is called, dragRows should NOT be cleared '
+      'so they remain available for onAccept handlers (issue #225)',
+      () {
+        // given - simulate starting a drag with multiple rows selected
+        stateManager.setIsDraggingRow(true, notify: false);
+        stateManager.setDragRows([rows[1], rows[2]], notify: false);
+
+        expect(stateManager.isDraggingRow, isTrue);
+        expect(stateManager.dragRows.length, 2);
+
+        // when - drag ends (pointer up)
+        stateManager.setIsDraggingRow(false);
+
+        // then - dragRows should still be available for onAccept to use
+        expect(stateManager.isDraggingRow, isFalse);
+        expect(stateManager.dragRows.length, 2);
+        expect(stateManager.dragRows[0].key, rows[1].key);
+        expect(stateManager.dragRows[1].key, rows[2].key);
+      },
+    );
+
+    test(
+      'When setIsDraggingRow(false) is called, dragTargetRowIdx should be cleared',
+      () {
+        // given
+        stateManager.setIsDraggingRow(true, notify: false);
+        stateManager.setDragTargetRowIdx(3, notify: false);
+
+        expect(stateManager.isDraggingRow, isTrue);
+        expect(stateManager.dragTargetRowIdx, 3);
+
+        // when
+        stateManager.setIsDraggingRow(false);
+
+        // then - dragTargetRowIdx should be cleared
+        expect(stateManager.dragTargetRowIdx, isNull);
+      },
+    );
   });
 
   group('setDragRows', () {


### PR DESCRIPTION
## Summary
- Fixes #225 - Row moving now correctly moves all selected rows instead of just one
- The issue was that `dragRows` was being cleared when `setIsDraggingRow(false)` was called (on pointer up), before `_handleOnAccept` could use them
- Now `dragRows` persists after drag ends so the move operation receives all selected rows

## Changes
- `dragging_row_state.dart`: Only clear `dragTargetRowIdx` when ending drag, preserve `dragRows`
- `trina_default_cell.dart`: Refine guard condition to allow drag when already initiated
- Added unit tests for the fix