### PR TITLE
feat: add Is Empty and Is Not Empty filter types

### DIFF
--- a/lib/src/helper/filter_helper.dart
+++ b/lib/src/helper/filter_helper.dart
@@ -32,6 +32,8 @@ class FilterHelper {
     TrinaFilterTypeLessThan(),
     TrinaFilterTypeLessThanOrEqualTo(),
     TrinaFilterTypeRegex(),
+    TrinaFilterTypeIsEmpty(),
+    TrinaFilterTypeIsNotEmpty(),
   ];
 
   /// Create a row to contain filter information.
@@ -318,6 +320,24 @@ class FilterHelper {
     required TrinaColumn column,
   }) {
     return column.type.compare(base, search) < 1;
+  }
+
+  /// Whether [base] is empty (null, empty string, or whitespace-only).
+  static bool compareIsEmpty({
+    required String? base,
+    required String? search,
+    required TrinaColumn column,
+  }) {
+    return base == null || base.trim().isEmpty;
+  }
+
+  /// Whether [base] is not empty (has actual content).
+  static bool compareIsNotEmpty({
+    required String? base,
+    required String? search,
+    required TrinaColumn column,
+  }) {
+    return base != null && base.trim().isNotEmpty;
   }
 
   static bool _compareWithRegExp(
@@ -741,4 +761,28 @@ class TrinaFilterTypeMultiItems implements TrinaFilterType {
         column: column,
         caseSensitive: caseSensitive,
       );
+}
+
+class TrinaFilterTypeIsEmpty implements TrinaFilterType {
+  static String name = 'Is Empty';
+
+  @override
+  String get title => TrinaFilterTypeIsEmpty.name;
+
+  @override
+  TrinaCompareFunction get compare => FilterHelper.compareIsEmpty;
+
+  const TrinaFilterTypeIsEmpty();
+}
+
+class TrinaFilterTypeIsNotEmpty implements TrinaFilterType {
+  static String name = 'Is Not Empty';
+
+  @override
+  String get title => TrinaFilterTypeIsNotEmpty.name;
+
+  @override
+  TrinaCompareFunction get compare => FilterHelper.compareIsNotEmpty;
+
+  const TrinaFilterTypeIsNotEmpty();
 }

--- a/lib/src/manager/state/filtering_row_state.dart
+++ b/lib/src/manager/state/filtering_row_state.dart
@@ -118,6 +118,12 @@ mixin FilteringRowState implements ITrinaGridState {
   @override
   void setFilterRows(List<TrinaRow> rows) {
     _state._filterRows = rows.where((element) {
+      final filterType = element.cells[FilterHelper.filterFieldType]?.value;
+      // Allow empty filter values for IsEmpty and IsNotEmpty filter types
+      if (filterType is TrinaFilterTypeIsEmpty ||
+          filterType is TrinaFilterTypeIsNotEmpty) {
+        return true;
+      }
       final value = element.cells[FilterHelper.filterFieldValue]!.value;
       return value != null && value.toString().isNotEmpty;
     }).toList();

--- a/test/src/helper/filter_helper_test.dart
+++ b/test/src/helper/filter_helper_test.dart
@@ -898,8 +898,8 @@ void main() {
 
         var columnType = filterColumn.type as TrinaColumnTypeSelect;
 
-        // configuration's filter count should be created. (default 9)
-        expect(configuration.columnFilter.filters.length, 9);
+        // configuration's filter count should be created. (default 11)
+        expect(configuration.columnFilter.filters.length, 11);
         expect(
           columnType.items.length,
           configuration.columnFilter.filters.length,


### PR DESCRIPTION
## Summary
- Add two new filter operators (`Is Empty` and `Is Not Empty`) to allow users to filter for empty/blank values directly through the column filter UI
- `TrinaFilterTypeIsEmpty`: matches cells where value is null, empty string, or whitespace-only
- `TrinaFilterTypeIsNotEmpty`: matches cells that have actual content

Closes #290