### PR TITLE
feat: add customizable column resize widget support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,12 @@ class TrinaGridExamplePage extends StatefulWidget {
 
 class _TrinaGridExamplePageState extends State<TrinaGridExamplePage> {
   final List<TrinaColumn> columns = <TrinaColumn>[
-    TrinaColumn(title: 'Id', field: 'id', type: TrinaColumnType.text()),
+    TrinaColumn(
+      enableContextMenu: false,
+      title: 'Id',
+      field: 'id',
+      type: TrinaColumnType.text(),
+    ),
     TrinaColumn(title: 'Name', field: 'name', type: TrinaColumnType.text()),
     TrinaColumn(title: 'Age', field: 'age', type: TrinaColumnType.number()),
     TrinaColumn(
@@ -161,7 +166,17 @@ class _TrinaGridExamplePageState extends State<TrinaGridExamplePage> {
           onChanged: (TrinaGridOnChangedEvent event) {
             print(event);
           },
-          configuration: const TrinaGridConfiguration(),
+          configuration: TrinaGridConfiguration(
+            style: TrinaGridStyleConfig(
+              columnResizeWidget: Container(
+                height: 20,
+                color: Colors.red,
+                width: 10,
+              ),
+
+              columnResizeIcon: Icons.drag_handle,
+            ),
+          ),
           selectDateCallback: (TrinaCell cell, TrinaColumn column) async {
             return showDatePicker(
               context: context,

--- a/lib/src/model/trina_column.dart
+++ b/lib/src/model/trina_column.dart
@@ -3,15 +3,15 @@ import 'package:trina_grid/trina_grid.dart';
 
 typedef TrinaColumnValueFormatter = String Function(dynamic value);
 
-typedef TrinaColumnRenderer =
-    Widget Function(TrinaColumnRendererContext rendererContext);
+typedef TrinaColumnRenderer = Widget Function(
+    TrinaColumnRendererContext rendererContext);
 
-typedef TrinaColumnFooterRenderer =
-    Widget Function(TrinaColumnFooterRendererContext context);
+typedef TrinaColumnFooterRenderer = Widget Function(
+    TrinaColumnFooterRendererContext context);
 
 /// Renderer for customizing the column title widget
-typedef TrinaColumnTitleRenderer =
-    Widget Function(TrinaColumnTitleRendererContext rendererContext);
+typedef TrinaColumnTitleRenderer = Widget Function(
+    TrinaColumnTitleRendererContext rendererContext);
 
 /// It dynamically determines whether the cells of the column are in the edit state.
 ///
@@ -178,6 +178,8 @@ class TrinaColumn {
   ///
   /// If [enableContextMenu] is enabled, the contextMenu icon appears.
   /// In this case, dragging the context menu icon adjusts the column width.
+  /// If [enableContextMenu] is disabled and [columnResizeWidget] is provided,
+  /// the custom widget will be used instead of [columnResizeIcon].
   bool enableDropToResize;
 
   /// Displays filter-related menus in the column context menu.
@@ -206,7 +208,7 @@ class TrinaColumn {
   /// Optional validator function that returns an error message string if validation fails,
   /// or null if validation passes. This is called before the cell value is updated.
   final String? Function(dynamic value, TrinaValidationContext context)?
-  validator;
+      validator;
 
   /// Custom renderer for the edit cell widget.
   /// This allows customizing the edit cell UI for this specific column.
@@ -217,8 +219,7 @@ class TrinaColumn {
     TextEditingController controller,
     FocusNode focusNode,
     Function(dynamic value)? handleSelected,
-  )?
-  editCellRenderer;
+  )? editCellRenderer;
 
   /// Custom renderer for the column title.
   /// This allows complete customization of the column title UI.
@@ -326,8 +327,8 @@ class TrinaColumn {
     this.validator,
     this.editCellRenderer,
     this.filterEnterKeyAction,
-  }) : _key = UniqueKey(),
-       _checkReadOnly = checkReadOnly;
+  })  : _key = UniqueKey(),
+        _checkReadOnly = checkReadOnly;
 
   final Key _key;
 
@@ -426,12 +427,12 @@ class TrinaColumn {
   String formattedValueForDisplayInEditing(dynamic value) {
     if (type is TrinaColumnTypeWithNumberFormat) {
       return value.toString().replaceFirst(
-        '.',
-        (type as TrinaColumnTypeWithNumberFormat)
-            .numberFormat
-            .symbols
-            .DECIMAL_SEP,
-      );
+            '.',
+            (type as TrinaColumnTypeWithNumberFormat)
+                .numberFormat
+                .symbols
+                .DECIMAL_SEP,
+          );
     } else if (type is TrinaColumnTypeBoolean) {
       switch (value) {
         case true:
@@ -464,29 +465,29 @@ class TrinaFilterColumnWidgetDelegate {
     this.onFilterSuffixTap,
     this.clearIcon = const Icon(Icons.clear),
     this.onClear,
-  }) : filterWidgetBuilder = null,
-       caseSensitive = null,
-       isMultiItems = false;
+  })  : filterWidgetBuilder = null,
+        caseSensitive = null,
+        isMultiItems = false;
 
   const TrinaFilterColumnWidgetDelegate.builder({this.filterWidgetBuilder})
-    : filterSuffixIcon = null,
-      onFilterSuffixTap = null,
-      filterHintText = null,
-      filterHintTextColor = null,
-      clearIcon = const Icon(Icons.clear),
-      onClear = null,
-      caseSensitive = null,
-      isMultiItems = false;
+      : filterSuffixIcon = null,
+        onFilterSuffixTap = null,
+        filterHintText = null,
+        filterHintTextColor = null,
+        clearIcon = const Icon(Icons.clear),
+        onClear = null,
+        caseSensitive = null,
+        isMultiItems = false;
 
   const TrinaFilterColumnWidgetDelegate.multiItems({this.caseSensitive = true})
-    : filterSuffixIcon = null,
-      onFilterSuffixTap = null,
-      filterHintText = null,
-      filterHintTextColor = null,
-      filterWidgetBuilder = null,
-      clearIcon = const Icon(Icons.clear),
-      onClear = null,
-      isMultiItems = true;
+      : filterSuffixIcon = null,
+        onFilterSuffixTap = null,
+        filterHintText = null,
+        filterHintTextColor = null,
+        filterWidgetBuilder = null,
+        clearIcon = const Icon(Icons.clear),
+        onClear = null,
+        isMultiItems = true;
 
   ///Set hint text for filter field
   final String? filterHintText;
@@ -510,8 +511,7 @@ class TrinaFilterColumnWidgetDelegate {
     bool enabled,
     void Function(dynamic changed) handleOnChanged,
     TrinaGridStateManager stateManager,
-  )?
-  onFilterSuffixTap;
+  )? onFilterSuffixTap;
 
   final Widget Function(
     FocusNode focusNode,
@@ -519,8 +519,7 @@ class TrinaFilterColumnWidgetDelegate {
     bool enabled,
     void Function(dynamic changed) handleOnChanged,
     TrinaGridStateManager stateManager,
-  )?
-  filterWidgetBuilder;
+  )? filterWidgetBuilder;
 
   final bool? isMultiItems;
 

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -339,28 +339,28 @@ class TrinaGridConfiguration {
 
   @override
   int get hashCode => Object.hash(
-    enableMoveDownAfterSelecting,
-    enableMoveHorizontalInEditing,
-    enableAutoSelectFirstRow,
-    rowSelectionCheckBoxBehavior,
-    enterKeyAction,
-    tabKeyAction,
-    selectingMode,
-    shortcut,
-    style,
-    scrollbar,
-    columnFilter,
-    columnSize,
-    localeText,
-    enableDragSelection,
-    enableCtrlClickMultiSelect,
-    Object.hash(
-      dragSelectionDelayDuration,
-      copyPasteCellSeparator,
-      copyPasteLineSeparator,
-      rowWrapperIsConstantHeight,
-    ),
-  );
+        enableMoveDownAfterSelecting,
+        enableMoveHorizontalInEditing,
+        enableAutoSelectFirstRow,
+        rowSelectionCheckBoxBehavior,
+        enterKeyAction,
+        tabKeyAction,
+        selectingMode,
+        shortcut,
+        style,
+        scrollbar,
+        columnFilter,
+        columnSize,
+        localeText,
+        enableDragSelection,
+        enableCtrlClickMultiSelect,
+        Object.hash(
+          dragSelectionDelayDuration,
+          copyPasteCellSeparator,
+          copyPasteLineSeparator,
+          rowWrapperIsConstantHeight,
+        ),
+      );
 }
 
 class TrinaGridStyleConfig {
@@ -430,6 +430,7 @@ class TrinaGridStyleConfig {
     this.cellTextStyle = defaultLightCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
+    this.columnResizeWidget,
     this.columnAscendingIcon,
     this.columnDescendingIcon,
     this.rowGroupExpandedIcon = Icons.keyboard_arrow_down,
@@ -449,13 +450,13 @@ class TrinaGridStyleConfig {
     this.filterHeaderColor,
     this.filterPopupHeaderColor,
     this.filterHeaderIconColor,
-  }) : columnCheckedColor = (columnCheckedColor ?? activatedColor),
-       cellCheckedColor = (cellCheckedColor ?? activatedColor),
-       columnUnselectedColor = (columnUnselectedColor ?? iconColor),
-       columnActiveColor = (columnActiveColor ?? activatedBorderColor),
-       cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-       cellActiveColor = (cellActiveColor ?? activatedBorderColor),
-       isDarkStyle = false;
+  })  : columnCheckedColor = (columnCheckedColor ?? activatedColor),
+        cellCheckedColor = (cellCheckedColor ?? activatedColor),
+        columnUnselectedColor = (columnUnselectedColor ?? iconColor),
+        columnActiveColor = (columnActiveColor ?? activatedBorderColor),
+        cellUnselectedColor = (cellUnselectedColor ?? iconColor),
+        cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+        isDarkStyle = false;
 
   const TrinaGridStyleConfig.dark({
     this.enableGridBorderShadow = false,
@@ -513,6 +514,7 @@ class TrinaGridStyleConfig {
     this.cellTextStyle = defaultDarkCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
+    this.columnResizeWidget,
     this.columnAscendingIcon,
     this.columnDescendingIcon,
     this.rowGroupExpandedIcon = Icons.keyboard_arrow_down,
@@ -532,13 +534,13 @@ class TrinaGridStyleConfig {
     this.filterHeaderColor,
     this.filterPopupHeaderColor,
     this.filterHeaderIconColor,
-  }) : columnCheckedColor = (columnCheckedColor ?? activatedColor),
-       cellCheckedColor = (cellCheckedColor ?? activatedColor),
-       columnUnselectedColor = (columnUnselectedColor ?? iconColor),
-       columnActiveColor = (columnActiveColor ?? activatedBorderColor),
-       cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-       cellActiveColor = (cellActiveColor ?? activatedBorderColor),
-       isDarkStyle = true;
+  })  : columnCheckedColor = (columnCheckedColor ?? activatedColor),
+        cellCheckedColor = (cellCheckedColor ?? activatedColor),
+        columnUnselectedColor = (columnUnselectedColor ?? iconColor),
+        columnActiveColor = (columnActiveColor ?? activatedBorderColor),
+        cellUnselectedColor = (cellUnselectedColor ?? iconColor),
+        cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+        isDarkStyle = true;
 
   /// Enable borderShadow in [TrinaGrid].
   final bool enableGridBorderShadow;
@@ -714,6 +716,10 @@ class TrinaGridStyleConfig {
   /// only the width of the column can be adjusted.
   final IconData columnResizeIcon;
 
+  /// If enableContextMenu of TrinaColumn is false and columnResizeWidget is not null,
+  /// this widget will be used for resizing instead of [columnResizeIcon].
+  final Widget? columnResizeWidget;
+
   /// Ascending icon when sorting a column.
   ///
   /// If no value is specified, the default icon is set.
@@ -807,6 +813,7 @@ class TrinaGridStyleConfig {
     TextStyle? cellTextStyle,
     IconData? columnContextIcon,
     IconData? columnResizeIcon,
+    Widget? columnResizeWidget,
     TrinaOptional<Widget?>? columnAscendingIcon,
     TrinaOptional<Widget?>? columnDescendingIcon,
     IconData? rowGroupExpandedIcon,
@@ -845,9 +852,8 @@ class TrinaGridStyleConfig {
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
-        evenRowColor: evenRowColor == null
-            ? this.evenRowColor
-            : evenRowColor.value,
+        evenRowColor:
+            evenRowColor == null ? this.evenRowColor : evenRowColor.value,
         activatedColor: activatedColor ?? this.activatedColor,
         columnCheckedColor: columnCheckedColor ?? this.columnCheckedColor,
         columnCheckedSide: columnCheckedSide ?? this.columnCheckedSide,
@@ -888,6 +894,7 @@ class TrinaGridStyleConfig {
         cellTextStyle: cellTextStyle ?? this.cellTextStyle,
         columnContextIcon: columnContextIcon ?? this.columnContextIcon,
         columnResizeIcon: columnResizeIcon ?? this.columnResizeIcon,
+        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
         columnAscendingIcon: columnAscendingIcon == null
             ? this.columnAscendingIcon
             : columnAscendingIcon.value,
@@ -931,9 +938,8 @@ class TrinaGridStyleConfig {
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
-        evenRowColor: evenRowColor == null
-            ? this.evenRowColor
-            : evenRowColor.value,
+        evenRowColor:
+            evenRowColor == null ? this.evenRowColor : evenRowColor.value,
         activatedColor: activatedColor ?? this.activatedColor,
         columnCheckedColor: columnCheckedColor ?? this.columnCheckedColor,
         columnCheckedSide: columnCheckedSide ?? this.columnCheckedSide,
@@ -974,6 +980,7 @@ class TrinaGridStyleConfig {
         cellTextStyle: cellTextStyle ?? this.cellTextStyle,
         columnContextIcon: columnContextIcon ?? this.columnContextIcon,
         columnResizeIcon: columnResizeIcon ?? this.columnResizeIcon,
+        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
         columnAscendingIcon: columnAscendingIcon == null
             ? this.columnAscendingIcon
             : columnAscendingIcon.value,
@@ -1047,6 +1054,7 @@ class TrinaGridStyleConfig {
             cellTextStyle == other.cellTextStyle &&
             columnContextIcon == other.columnContextIcon &&
             columnResizeIcon == other.columnResizeIcon &&
+            columnResizeWidget == other.columnResizeWidget &&
             columnAscendingIcon == other.columnAscendingIcon &&
             columnDescendingIcon == other.columnDescendingIcon &&
             rowGroupExpandedIcon == other.rowGroupExpandedIcon &&
@@ -1066,65 +1074,66 @@ class TrinaGridStyleConfig {
 
   @override
   int get hashCode => Object.hashAll([
-    enableGridBorderShadow,
-    enableColumnBorderVertical,
-    enableColumnBorderHorizontal,
-    enableCellBorderVertical,
-    enableCellBorderHorizontal,
-    enableRowColorAnimation,
-    filterIcon,
-    gridBackgroundColor,
-    rowColor,
-    oddRowColor,
-    evenRowColor,
-    activatedColor,
-    columnCheckedColor,
-    columnCheckedSide,
-    cellCheckedColor,
-    cellCheckedSide,
-    cellColorInEditState,
-    cellColorInReadOnlyState,
-    cellReadonlyColor,
-    cellColorGroupedRow,
-    dragTargetColumnColor,
-    iconColor,
-    disabledIconColor,
-    menuBackgroundColor,
-    gridBorderColor,
-    borderColor,
-    activatedBorderColor,
-    inactivatedBorderColor,
-    iconSize,
-    rowHeight,
-    columnHeight,
-    columnFilterHeight,
-    defaultColumnTitlePadding,
-    defaultColumnFilterPadding,
-    defaultCellPadding,
-    columnTextStyle,
-    columnUnselectedColor,
-    columnActiveColor,
-    cellUnselectedColor,
-    cellActiveColor,
-    cellTextStyle,
-    columnContextIcon,
-    columnResizeIcon,
-    columnAscendingIcon,
-    columnDescendingIcon,
-    rowGroupExpandedIcon,
-    rowGroupCollapsedIcon,
-    rowGroupEmptyIcon,
-    gridBorderRadius,
-    gridPopupBorderRadius,
-    gridPadding,
-    gridBorderWidth,
-    cellVerticalBorderWidth,
-    cellHorizontalBorderWidth,
-    filterPopupHeaderColor,
-    filterHeaderColor,
-    filterHeaderIconColor,
-    isDarkStyle,
-  ]);
+        enableGridBorderShadow,
+        enableColumnBorderVertical,
+        enableColumnBorderHorizontal,
+        enableCellBorderVertical,
+        enableCellBorderHorizontal,
+        enableRowColorAnimation,
+        filterIcon,
+        gridBackgroundColor,
+        rowColor,
+        oddRowColor,
+        evenRowColor,
+        activatedColor,
+        columnCheckedColor,
+        columnCheckedSide,
+        cellCheckedColor,
+        cellCheckedSide,
+        cellColorInEditState,
+        cellColorInReadOnlyState,
+        cellReadonlyColor,
+        cellColorGroupedRow,
+        dragTargetColumnColor,
+        iconColor,
+        disabledIconColor,
+        menuBackgroundColor,
+        gridBorderColor,
+        borderColor,
+        activatedBorderColor,
+        inactivatedBorderColor,
+        iconSize,
+        rowHeight,
+        columnHeight,
+        columnFilterHeight,
+        defaultColumnTitlePadding,
+        defaultColumnFilterPadding,
+        defaultCellPadding,
+        columnTextStyle,
+        columnUnselectedColor,
+        columnActiveColor,
+        cellUnselectedColor,
+        cellActiveColor,
+        cellTextStyle,
+        columnContextIcon,
+        columnResizeIcon,
+        columnResizeWidget,
+        columnAscendingIcon,
+        columnDescendingIcon,
+        rowGroupExpandedIcon,
+        rowGroupCollapsedIcon,
+        rowGroupEmptyIcon,
+        gridBorderRadius,
+        gridPopupBorderRadius,
+        gridPadding,
+        gridBorderWidth,
+        cellVerticalBorderWidth,
+        cellHorizontalBorderWidth,
+        filterPopupHeaderColor,
+        filterHeaderColor,
+        filterHeaderIconColor,
+        isDarkStyle,
+      ]);
 }
 
 /// Allows to customise scrollbars "look and feel"
@@ -1271,23 +1280,23 @@ class TrinaGridScrollbarConfig {
 
   @override
   int get hashCode => Object.hashAll([
-    isAlwaysShown,
-    dragDevices,
-    isDraggable,
-    smoothScrolling,
-    thumbVisible,
-    showTrack,
-    showHorizontal,
-    showVertical,
-    thickness,
-    minThumbLength,
-    radius,
-    thumbColor,
-    trackColor,
-    thumbHoverColor,
-    trackHoverColor,
-    columnShowScrollWidth,
-  ]);
+        isAlwaysShown,
+        dragDevices,
+        isDraggable,
+        smoothScrolling,
+        thumbVisible,
+        showTrack,
+        showHorizontal,
+        showVertical,
+        thickness,
+        minThumbLength,
+        radius,
+        thumbColor,
+        trackColor,
+        thumbHoverColor,
+        trackHoverColor,
+        columnShowScrollWidth,
+      ]);
 }
 
 extension TrinaGridConfigurationScrollbarExtension on TrinaGridConfiguration {
@@ -1298,11 +1307,10 @@ extension TrinaGridConfigurationScrollbarExtension on TrinaGridConfiguration {
 
 typedef TrinaGridColumnFilterResolver = Function<T>();
 
-typedef TrinaGridResolveDefaultColumnFilter =
-    TrinaFilterType Function(
-      TrinaColumn column,
-      TrinaGridColumnFilterResolver resolver,
-    );
+typedef TrinaGridResolveDefaultColumnFilter = TrinaFilterType Function(
+  TrinaColumn column,
+  TrinaGridColumnFilterResolver resolver,
+);
 
 class TrinaGridColumnFilterConfig {
   /// # Set the filter information of the column.
@@ -1357,13 +1365,13 @@ class TrinaGridColumnFilterConfig {
     List<TrinaFilterType>? filters,
     TrinaGridResolveDefaultColumnFilter? resolveDefaultColumnFilter,
     int? debounceMilliseconds,
-  }) : _userFilters = filters,
-       _userResolveDefaultColumnFilter = resolveDefaultColumnFilter,
-       _debounceMilliseconds = debounceMilliseconds == null
-           ? TrinaGridSettings.debounceMillisecondsForColumnFilter
-           : debounceMilliseconds < 0
-           ? 0
-           : debounceMilliseconds;
+  })  : _userFilters = filters,
+        _userResolveDefaultColumnFilter = resolveDefaultColumnFilter,
+        _debounceMilliseconds = debounceMilliseconds == null
+            ? TrinaGridSettings.debounceMillisecondsForColumnFilter
+            : debounceMilliseconds < 0
+                ? 0
+                : debounceMilliseconds;
 
   final List<TrinaFilterType>? _userFilters;
 
@@ -1408,10 +1416,10 @@ class TrinaGridColumnFilterConfig {
 
   @override
   int get hashCode => Object.hash(
-    _userFilters,
-    _userResolveDefaultColumnFilter,
-    _debounceMilliseconds,
-  );
+        _userFilters,
+        _userResolveDefaultColumnFilter,
+        _debounceMilliseconds,
+      );
 }
 
 /// Automatically change the column width or set the mode when changing the width.
@@ -1471,16 +1479,13 @@ class TrinaGridColumnSizeConfig {
       resizeMode: resizeMode ?? this.resizeMode,
       restoreAutoSizeAfterHideColumn:
           restoreAutoSizeAfterHideColumn ?? this.restoreAutoSizeAfterHideColumn,
-      restoreAutoSizeAfterFrozenColumn:
-          restoreAutoSizeAfterFrozenColumn ??
+      restoreAutoSizeAfterFrozenColumn: restoreAutoSizeAfterFrozenColumn ??
           this.restoreAutoSizeAfterFrozenColumn,
       restoreAutoSizeAfterMoveColumn:
           restoreAutoSizeAfterMoveColumn ?? this.restoreAutoSizeAfterMoveColumn,
-      restoreAutoSizeAfterInsertColumn:
-          restoreAutoSizeAfterInsertColumn ??
+      restoreAutoSizeAfterInsertColumn: restoreAutoSizeAfterInsertColumn ??
           this.restoreAutoSizeAfterInsertColumn,
-      restoreAutoSizeAfterRemoveColumn:
-          restoreAutoSizeAfterRemoveColumn ??
+      restoreAutoSizeAfterRemoveColumn: restoreAutoSizeAfterRemoveColumn ??
           this.restoreAutoSizeAfterRemoveColumn,
     );
   }
@@ -1506,14 +1511,14 @@ class TrinaGridColumnSizeConfig {
 
   @override
   int get hashCode => Object.hash(
-    autoSizeMode,
-    resizeMode,
-    restoreAutoSizeAfterHideColumn,
-    restoreAutoSizeAfterFrozenColumn,
-    restoreAutoSizeAfterMoveColumn,
-    restoreAutoSizeAfterInsertColumn,
-    restoreAutoSizeAfterRemoveColumn,
-  );
+        autoSizeMode,
+        resizeMode,
+        restoreAutoSizeAfterHideColumn,
+        restoreAutoSizeAfterFrozenColumn,
+        restoreAutoSizeAfterMoveColumn,
+        restoreAutoSizeAfterInsertColumn,
+        restoreAutoSizeAfterRemoveColumn,
+      );
 }
 
 class TrinaGridLocaleText {
@@ -2449,41 +2454,41 @@ class TrinaGridLocaleText {
 
   @override
   int get hashCode => Object.hashAll([
-    unfreezeColumn,
-    freezeColumnToStart,
-    freezeColumnToEnd,
-    autoFitColumn,
-    hideColumn,
-    setColumns,
-    setFilter,
-    resetFilter,
-    setColumnsTitle,
-    filterColumn,
-    filterType,
-    filterValue,
-    filterAllColumns,
-    filterContains,
-    filterEquals,
-    filterStartsWith,
-    filterEndsWith,
-    filterGreaterThan,
-    filterGreaterThanOrEqualTo,
-    filterLessThan,
-    filterLessThanOrEqualTo,
-    sunday,
-    monday,
-    tuesday,
-    wednesday,
-    thursday,
-    friday,
-    saturday,
-    hour,
-    minute,
-    loadingText,
-    multiLineFilterHint,
-    multiLineFilterEditTitle,
-    multiLineFilterOkButton,
-  ]);
+        unfreezeColumn,
+        freezeColumnToStart,
+        freezeColumnToEnd,
+        autoFitColumn,
+        hideColumn,
+        setColumns,
+        setFilter,
+        resetFilter,
+        setColumnsTitle,
+        filterColumn,
+        filterType,
+        filterValue,
+        filterAllColumns,
+        filterContains,
+        filterEquals,
+        filterStartsWith,
+        filterEndsWith,
+        filterGreaterThan,
+        filterGreaterThanOrEqualTo,
+        filterLessThan,
+        filterLessThanOrEqualTo,
+        sunday,
+        monday,
+        tuesday,
+        wednesday,
+        thursday,
+        friday,
+        saturday,
+        hour,
+        minute,
+        loadingText,
+        multiLineFilterHint,
+        multiLineFilterEditTitle,
+        multiLineFilterOkButton,
+      ]);
 }
 
 enum TrinaGridRowSelectionCheckBoxBehavior {

--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -17,8 +17,8 @@ class TrinaColumnTitle extends TrinaStatefulWidget {
     required this.stateManager,
     required this.column,
     double? height,
-  }) : height = height ?? stateManager.columnHeight,
-       super(key: ValueKey('column_title_${column.key}'));
+  })  : height = height ?? stateManager.columnHeight,
+        super(key: ValueKey('column_title_${column.key}'));
 
   @override
   TrinaColumnTitleState createState() => TrinaColumnTitleState();
@@ -200,6 +200,9 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
           icon: TrinaGridColumnIcon(
             sort: _sort,
             color: style.iconColor,
+            widget: widget.column.enableContextMenu
+                ? null
+                : style.columnResizeWidget,
             icon: widget.column.enableContextMenu
                 ? style.columnContextIcon
                 : style.columnResizeIcon,
@@ -226,9 +229,8 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
       showContextIcon: showContextIcon,
       contextMenuIcon: contextMenuIcon,
       isFiltered: isFiltered,
-      showContextMenu: mounted && widget.column.enableContextMenu
-          ? _showContextMenu
-          : null,
+      showContextMenu:
+          mounted && widget.column.enableContextMenu ? _showContextMenu : null,
     );
   }
 
@@ -271,6 +273,7 @@ class TrinaGridColumnIcon extends StatelessWidget {
   final Color color;
 
   final IconData icon;
+  final Widget? widget;
 
   final Widget? ascendingIcon;
 
@@ -278,6 +281,7 @@ class TrinaGridColumnIcon extends StatelessWidget {
 
   const TrinaGridColumnIcon({
     this.sort,
+    this.widget,
     this.color = Colors.black26,
     this.icon = Icons.dehaze,
     this.ascendingIcon,
@@ -300,7 +304,7 @@ class TrinaGridColumnIcon extends StatelessWidget {
             ? const Icon(Icons.sort, color: Colors.red)
             : descendingIcon!;
       default:
-        return Icon(icon, color: color);
+        return widget ?? Icon(icon, color: color);
     }
   }
 }
@@ -570,27 +574,26 @@ class _ColumnTextWidgetState extends TrinaStateWithChange<_ColumnTextWidget> {
       widget.column.titleSpan == null ? widget.column.title : null;
 
   List<InlineSpan> get _children => [
-    if (widget.column.titleSpan != null) widget.column.titleSpan!,
-    if (_isFilteredList && stateManager.configuration.style.filterIcon != null)
-      WidgetSpan(
-        alignment: PlaceholderAlignment.middle,
-        child: IconButton(
-          icon: Icon(
-            stateManager.configuration.style.filterIcon!.icon,
-            color:
-                stateManager.configuration.style.filterHeaderIconColor ??
-                stateManager.configuration.style.iconColor,
-            size: stateManager.configuration.style.iconSize,
+        if (widget.column.titleSpan != null) widget.column.titleSpan!,
+        if (_isFilteredList &&
+            stateManager.configuration.style.filterIcon != null)
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: IconButton(
+              icon: Icon(
+                stateManager.configuration.style.filterIcon!.icon,
+                color: stateManager.configuration.style.filterHeaderIconColor ??
+                    stateManager.configuration.style.iconColor,
+                size: stateManager.configuration.style.iconSize,
+              ),
+              onPressed: _handleOnPressedFilter,
+              constraints: BoxConstraints(
+                maxHeight: widget.height +
+                    (widget.stateManager.style.cellHorizontalBorderWidth * 2),
+              ),
+            ),
           ),
-          onPressed: _handleOnPressedFilter,
-          constraints: BoxConstraints(
-            maxHeight:
-                widget.height +
-                (widget.stateManager.style.cellHorizontalBorderWidth * 2),
-          ),
-        ),
-      ),
-  ];
+      ];
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
<img width="147" height="340" alt="Screenshot 2026-01-27 at 14 02 01" src="https://github.com/user-attachments/assets/b73ea967-ab82-4cfb-bb1c-95983e4e5a48" />

```
TrinaGridConfiguration(
            style: TrinaGridStyleConfig(
   columnResizeWidget: Container(
                height: 20,
                color: Colors.red,
                width: 10,
              ),

              columnResizeIcon: Icons.drag_handle,
            ),
          ),
```
          