### PR TITLE
fix: resolve null check error in visibility layout and clamp scroll o…

### DIFF
--- a/lib/src/manager/state/visibility_layout_state.dart
+++ b/lib/src/manager/state/visibility_layout_state.dart
@@ -26,7 +26,20 @@ mixin VisibilityLayoutState implements ITrinaGridState {
 
     updateScrollViewport();
 
+    // Reset horizontal scroll if current position is beyond valid range
+    _clampHorizontalScrollIfNeeded();
+
     if (notify) scroll.horizontal?.notifyListeners();
+  }
+
+  void _clampHorizontalScrollIfNeeded() {
+    final horizontalScroll = scroll.bodyRowsHorizontal;
+    if (horizontalScroll == null || !horizontalScroll.hasClients) return;
+
+    final maxScroll = scroll.maxScrollHorizontal;
+    if (horizontalScroll.offset > maxScroll) {
+      horizontalScroll.jumpTo(maxScroll > 0 ? maxScroll : 0);
+    }
   }
 
   void _updateColumnSize() {


### PR DESCRIPTION
…n layout change

- Fix null check error in performRebuild by removing createElement() call on unmounted elements
- Simplify performRebuild to match update() method pattern (don't pass custom slots)
- Add fallback to show widgets from position 0 when scroll position is beyond content
- Clamp horizontal scroll to valid range when visibility layout updates
- Remove unused findChildByLayoutId method and collection import