### PR TITLE
fix: remove [Selection] debug prints flooding console

### DIFF
--- a/lib/src/manager/event/trina_grid_cell_gesture_event.dart
+++ b/lib/src/manager/event/trina_grid_cell_gesture_event.dart
@@ -51,44 +51,26 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
   }
 
   void _onTapUp(TrinaGridStateManager stateManager) {
-    debugPrint(
-      '[Selection] _onTapUp called - rowIdx: $rowIdx, ctrl: ${stateManager.keyPressed.ctrl}, shift: ${stateManager.keyPressed.shift}',
-    );
-
     if (_setKeepFocusAndCurrentCell(stateManager)) {
-      debugPrint(
-        '[Selection] _onTapUp - setKeepFocusAndCurrentCell returned true, returning',
-      );
       return;
     } else if (stateManager.isSelectingInteraction()) {
-      debugPrint(
-        '[Selection] _onTapUp - isSelectingInteraction, calling _selecting',
-      );
       _selecting(stateManager);
       return;
     } else if (stateManager.mode.isSelectMode) {
-      debugPrint('[Selection] _onTapUp - isSelectMode, calling _selectMode');
       _selectMode(stateManager);
       return;
     }
-
-    debugPrint('[Selection] _onTapUp - Normal tap processing');
 
     // Clear individual selections when clicking without modifiers
     if (stateManager.configuration.enableCtrlClickMultiSelect &&
         !stateManager.keyPressed.ctrl &&
         !stateManager.keyPressed.shift) {
-      debugPrint('[Selection] _onTapUp - Clearing individual selections');
       stateManager.clearIndividualSelections(notify: false);
     }
 
     if (stateManager.isCurrentCell(cell) && stateManager.isEditing != true) {
-      debugPrint('[Selection] _onTapUp - Same cell, starting editing');
       stateManager.setEditing(true);
     } else {
-      debugPrint(
-        '[Selection] _onTapUp - Different cell, calling setCurrentCell',
-      );
       stateManager.setCurrentCell(cell, rowIdx);
 
       // In normal mode, also fire onSelected callback when row selection is configured
@@ -106,7 +88,6 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
     // If drag selection is enabled in cell mode, use the drag selection system
     if (stateManager.configuration.enableDragSelection &&
         stateManager.selectingMode == TrinaGridSelectingMode.cell) {
-      debugPrint('[Selection] _onLongPressStart - Starting drag selection');
       final int? columnIdx = stateManager.columnIndex(column);
       if (columnIdx != null) {
         final cellPosition = TrinaGridCellPosition(
@@ -156,7 +137,6 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
 
     // If drag selection is active, end it
     if (stateManager.isDragSelecting) {
-      debugPrint('[Selection] _onLongPressEnd - Ending drag selection');
       stateManager.endDragSelection();
     } else {
       // Use traditional selection system
@@ -264,17 +244,12 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
   }
 
   void _selecting(TrinaGridStateManager stateManager) {
-    debugPrint(
-      '[Selection] _selecting called - rowIdx: $rowIdx, ctrl: ${stateManager.keyPressed.ctrl}, shift: ${stateManager.keyPressed.shift}',
-    );
-
     // Allow onSelected callback to fire in both multiSelect mode and normal mode with row selection
     bool callOnSelected =
         stateManager.mode.isMultiSelectMode ||
         (stateManager.mode.isNormal && stateManager.selectingMode.isRow);
 
     if (stateManager.keyPressed.shift) {
-      debugPrint('[Selection] _selecting - Shift pressed, extending selection');
       final int? columnIdx = stateManager.columnIndex(column);
 
       stateManager.setCurrentSelectingPosition(
@@ -287,9 +262,6 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
       // Ctrl in cell mode with enableCtrlClickMultiSelect = individual cell toggle
       if (stateManager.selectingMode == TrinaGridSelectingMode.cell &&
           stateManager.configuration.enableCtrlClickMultiSelect) {
-        debugPrint(
-          '[Selection] _selecting - Ctrl pressed, toggling individual cell',
-        );
         final int? columnIdx = stateManager.columnIndex(column);
         if (columnIdx != null) {
           final cellPosition = TrinaGridCellPosition(
@@ -300,12 +272,10 @@ class TrinaGridCellGestureEvent extends TrinaGridEvent {
         }
         callOnSelected = false;
       } else {
-        debugPrint('[Selection] _selecting - Ctrl pressed, toggling row');
         // Ctrl in row mode or without enableCtrlClickMultiSelect = row toggle (existing behavior)
         stateManager.toggleSelectingRow(rowIdx);
       }
     } else {
-      debugPrint('[Selection] _selecting - No modifier keys');
       callOnSelected = false;
     }
 

--- a/lib/src/manager/state/cell_state.dart
+++ b/lib/src/manager/state/cell_state.dart
@@ -195,23 +195,15 @@ mixin CellState implements ITrinaGridState {
     bool notify = true,
     TrinaMoveDirection? direction,
   }) {
-    debugPrint(
-      '[Selection] setCurrentCell called - rowIdx: $rowIdx, notify: $notify, ctrl: ${keyPressed.ctrl}, shift: ${keyPressed.shift}',
-    );
-
     if (cell == null ||
         rowIdx == null ||
         refRows.isEmpty ||
         rowIdx < 0 ||
         rowIdx > refRows.length - 1) {
-      debugPrint(
-        '[Selection] setCurrentCell - Invalid cell or rowIdx, returning',
-      );
       return;
     }
 
     if (currentCell != null && currentCell!.key == cell.key) {
-      debugPrint('[Selection] setCurrentCell - Same cell, returning');
       return;
     }
 
@@ -229,9 +221,6 @@ mixin CellState implements ITrinaGridState {
 
       // If callback returns false, cancel the cell change
       if (!shouldProceed) {
-        debugPrint(
-          '[Selection] setCurrentCell - Callback returned false, canceling',
-        );
         return;
       }
     }
@@ -247,15 +236,9 @@ mixin CellState implements ITrinaGridState {
     // when setting current cell. Only clear range selections.
     if (configuration.enableCtrlClickMultiSelect &&
         selectingMode == TrinaGridSelectingMode.cell) {
-      debugPrint(
-        '[Selection] setCurrentCell - Ctrl+Click mode enabled, clearing only range selections',
-      );
       // Clear only range selection, preserve individual selections
       clearRangeSelections(notify: false);
     } else {
-      debugPrint(
-        '[Selection] setCurrentCell - Standard mode, clearing all selections',
-      );
       // Clear all selections (range + individual + rows)
       clearCurrentSelecting(notify: false);
     }

--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -133,14 +133,8 @@ mixin EditingState implements ITrinaGridState {
     // When Ctrl+Click multi-select is enabled, preserve individual selections
     if (configuration.enableCtrlClickMultiSelect &&
         selectingMode == TrinaGridSelectingMode.cell) {
-      debugPrint(
-        '[Selection] setEditing - Ctrl+Click mode enabled, clearing only range selections',
-      );
       clearRangeSelections(notify: false);
     } else {
-      debugPrint(
-        '[Selection] setEditing - Standard mode, clearing all selections',
-      );
       clearCurrentSelecting(notify: false);
     }
 

--- a/lib/src/manager/state/selecting_state.dart
+++ b/lib/src/manager/state/selecting_state.dart
@@ -223,10 +223,6 @@ mixin SelectingState implements ITrinaGridState {
 
   @override
   void setSelecting(bool flag, {bool notify = true}) {
-    debugPrint(
-      '[Selection] setSelecting called - flag: $flag, notify: $notify, current isSelecting: $isSelecting',
-    );
-
     if (selectingMode.isNone) {
       return;
     }
@@ -246,14 +242,8 @@ mixin SelectingState implements ITrinaGridState {
       // When Ctrl+Click multi-select is enabled, preserve individual selections
       if (configuration.enableCtrlClickMultiSelect &&
           selectingMode == TrinaGridSelectingMode.cell) {
-        debugPrint(
-          '[Selection] setSelecting - Ctrl+Click mode enabled, clearing only range selections',
-        );
         clearRangeSelections(notify: false);
       } else {
-        debugPrint(
-          '[Selection] setSelecting - Standard mode, clearing all selections',
-        );
         clearCurrentSelecting(notify: false);
       }
     }
@@ -457,11 +447,6 @@ mixin SelectingState implements ITrinaGridState {
 
   @override
   void clearCurrentSelecting({bool notify = true}) {
-    debugPrint('[Selection] clearCurrentSelecting called - notify: $notify');
-    debugPrint(
-      '[Selection] Clearing ${_state._individuallySelectedCells.length} individual cells',
-    );
-
     _clearCurrentSelectingPosition(notify: false);
 
     _clearCurrentSelectingRows(notify: false);
@@ -476,11 +461,6 @@ mixin SelectingState implements ITrinaGridState {
 
   @override
   void clearRangeSelections({bool notify = true}) {
-    debugPrint('[Selection] clearRangeSelections called - notify: $notify');
-    debugPrint(
-      '[Selection] Preserving ${_state._individuallySelectedCells.length} individual cells',
-    );
-
     _clearCurrentSelectingPosition(notify: false);
 
     _clearCurrentSelectingRows(notify: false);
@@ -519,23 +499,10 @@ mixin SelectingState implements ITrinaGridState {
     TrinaGridCellPosition cellPosition, {
     bool notify = true,
   }) {
-    debugPrint(
-      '[Selection] toggleSelectingCell called - cellPosition: (${cellPosition.columnIdx}, ${cellPosition.rowIdx}), notify: $notify',
-    );
-    debugPrint(
-      '[Selection] Individual cells count before: ${_state._individuallySelectedCells.length}',
-    );
-
     if (!configuration.enableCtrlClickMultiSelect) {
-      debugPrint(
-        '[Selection] toggleSelectingCell - Feature not enabled, returning',
-      );
       return;
     }
     if (selectingMode != TrinaGridSelectingMode.cell) {
-      debugPrint(
-        '[Selection] toggleSelectingCell - Not in cell mode, returning',
-      );
       return;
     }
 
@@ -546,18 +513,11 @@ mixin SelectingState implements ITrinaGridState {
     }
 
     if (_state._individuallySelectedCells.contains(cellPosition)) {
-      debugPrint(
-        '[Selection] toggleSelectingCell - Removing cell from selection',
-      );
       _state._individuallySelectedCells.remove(cellPosition);
     } else {
-      debugPrint('[Selection] toggleSelectingCell - Adding cell to selection');
       _state._individuallySelectedCells.add(cellPosition);
     }
 
-    debugPrint(
-      '[Selection] Individual cells count after: ${_state._individuallySelectedCells.length}',
-    );
     notifyListeners(notify, toggleSelectingCell.hashCode);
   }
 
@@ -572,23 +532,14 @@ mixin SelectingState implements ITrinaGridState {
 
   /// Start drag selection.
   void startDragSelection(TrinaGridCellPosition startPosition) {
-    debugPrint(
-      '[Selection] startDragSelection called - col: ${startPosition.columnIdx}, row: ${startPosition.rowIdx}',
-    );
-
     if (!configuration.enableDragSelection) {
-      debugPrint('[Selection] startDragSelection - Drag selection not enabled');
       return;
     }
     if (selectingMode != TrinaGridSelectingMode.cell) {
-      debugPrint(
-        '[Selection] startDragSelection - Not in cell selecting mode: $selectingMode',
-      );
       return;
     }
 
     _state._isDragSelecting = true;
-    debugPrint('[Selection] startDragSelection - Set _isDragSelecting to true');
 
     // Set the start position as current cell
     if (startPosition.columnIdx != null && startPosition.rowIdx != null) {
@@ -607,30 +558,16 @@ mixin SelectingState implements ITrinaGridState {
 
   /// Update drag selection endpoint.
   void updateDragSelection(TrinaGridCellPosition endPosition) {
-    debugPrint(
-      '[Selection] updateDragSelection called - isDragSelecting: ${_state._isDragSelecting}, col: ${endPosition.columnIdx}, row: ${endPosition.rowIdx}',
-    );
-
     if (!_state._isDragSelecting) {
-      debugPrint(
-        '[Selection] updateDragSelection - Not drag selecting, returning',
-      );
       return;
     }
 
-    debugPrint(
-      '[Selection] updateDragSelection - Calling setCurrentSelectingPosition',
-    );
     setCurrentSelectingPosition(cellPosition: endPosition, notify: true);
   }
 
   /// End drag selection.
   void endDragSelection() {
     if (!_state._isDragSelecting) return;
-
-    debugPrint(
-      '[Selection] endDragSelection - Adding ${currentSelectingPositionList.length} cells to individual selections',
-    );
 
     // Add all cells in the current selection range to individual selections
     if (configuration.enableCtrlClickMultiSelect) {
@@ -648,9 +585,6 @@ mixin SelectingState implements ITrinaGridState {
             rowIdx: position.rowIdx,
           );
           _state._individuallySelectedCells.add(cellPos);
-          debugPrint(
-            '[Selection] Added cell to individual selections: field=${position.field}, col=$columnIdx, row=${position.rowIdx}',
-          );
         }
       }
     }
@@ -659,10 +593,6 @@ mixin SelectingState implements ITrinaGridState {
     clearRangeSelections(notify: false);
 
     _state._isDragSelecting = false;
-
-    debugPrint(
-      '[Selection] endDragSelection - Total individual cells: ${_state._individuallySelectedCells.length}',
-    );
 
     // Notify listeners to update the UI
     notifyListeners(true, endDragSelection.hashCode);


### PR DESCRIPTION
## Summary
- Removes ~50 `debugPrint('[Selection]...')` statements accidentally left in the selection code
- Fixes #310 — debug console was being spammed with selection logs on every grid interaction

## Files changed
- `lib/src/manager/state/selecting_state.dart` — 70 lines removed
- `lib/src/manager/event/trina_grid_cell_gesture_event.dart` — 30 lines removed
- `lib/src/manager/state/cell_state.dart` — 17 lines removed
- `lib/src/manager/state/editing_state.dart` — 6 lines removed

## Test plan
- [ ] Verify no `[Selection]` messages appear in debug console during grid interactions
- [ ] Verify selection functionality (tap, shift+click, ctrl+click, drag) still works correctly