### PR TITLE
fix: account for column footer height in scroll calculations (#315)

### DIFF
--- a/lib/src/manager/state/layout_state.dart
+++ b/lib/src/manager/state/layout_state.dart
@@ -228,7 +228,8 @@ mixin LayoutState implements ITrinaGridState {
       maxHeight! - headerHeight - footerHeight;
 
   @override
-  double get rowContainerHeight => maxHeight! - rowsTopOffset - footerHeight;
+  double get rowContainerHeight =>
+      maxHeight! - rowsTopOffset - footerHeight - columnFooterHeight;
 
   @override
   Offset? get gridGlobalOffset {

--- a/lib/src/manager/state/scroll_state.dart
+++ b/lib/src/manager/state/scroll_state.dart
@@ -115,6 +115,7 @@ mixin ScrollState implements ITrinaGridState {
         columnGroupHeight -
         columnHeight -
         columnFilterHeight -
+        columnFooterHeight -
         configuration.style.cellHorizontalBorderWidth;
 
     final bool inScrollStart = scroll.verticalOffset <= offsetToMove;


### PR DESCRIPTION
## Summary
- Fixes keyboard navigation (ArrowDown/PageDown) hiding selected rows behind the column footer
- Subtracts `columnFooterHeight` from `screenOffset` in `moveScrollByRow()` so ArrowDown correctly detects the visible boundary
- Subtracts `columnFooterHeight` from `rowContainerHeight` so PageDown calculates the correct number of visible rows

Closes #315

## Test plan
- [x] All 1537 existing tests pass
- [ ] Open the column footer demo screen, select a cell, press ArrowDown repeatedly — the selected row should remain visible above the footer
- [ ] Press PageDown — should jump the correct number of rows without hiding behind the footer