### PR TITLE
feat: add customizable column resize widget support

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -430,6 +430,7 @@ class TrinaGridStyleConfig {
     this.cellTextStyle = defaultLightCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
+    this.columnResizeWidget,
     this.columnAscendingIcon,
     this.columnDescendingIcon,
     this.rowGroupExpandedIcon = Icons.keyboard_arrow_down,
@@ -513,6 +514,7 @@ class TrinaGridStyleConfig {
     this.cellTextStyle = defaultDarkCellTextStyle,
     this.columnContextIcon = Icons.dehaze,
     this.columnResizeIcon = Icons.code_sharp,
+    this.columnResizeWidget,
     this.columnAscendingIcon,
     this.columnDescendingIcon,
     this.rowGroupExpandedIcon = Icons.keyboard_arrow_down,
@@ -714,6 +716,11 @@ class TrinaGridStyleConfig {
   /// only the width of the column can be adjusted.
   final IconData columnResizeIcon;
 
+  /// Custom widget to use for the column resize handle when
+  /// [TrinaColumn.enableContextMenu] is false.
+  /// If provided, this widget replaces the default [columnResizeIcon].
+  final Widget? columnResizeWidget;
+
   /// Ascending icon when sorting a column.
   ///
   /// If no value is specified, the default icon is set.
@@ -807,6 +814,7 @@ class TrinaGridStyleConfig {
     TextStyle? cellTextStyle,
     IconData? columnContextIcon,
     IconData? columnResizeIcon,
+    Widget? columnResizeWidget,
     TrinaOptional<Widget?>? columnAscendingIcon,
     TrinaOptional<Widget?>? columnDescendingIcon,
     IconData? rowGroupExpandedIcon,
@@ -825,6 +833,7 @@ class TrinaGridStyleConfig {
     // Preserve the dark style flag by using the appropriate constructor
     if (isDarkStyle) {
       return TrinaGridStyleConfig.dark(
+        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
         cellVerticalBorderWidth:
             cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
         cellHorizontalBorderWidth:
@@ -911,6 +920,7 @@ class TrinaGridStyleConfig {
       );
     } else {
       return TrinaGridStyleConfig(
+        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
         cellVerticalBorderWidth:
             cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
         cellHorizontalBorderWidth:
@@ -1047,6 +1057,7 @@ class TrinaGridStyleConfig {
             cellTextStyle == other.cellTextStyle &&
             columnContextIcon == other.columnContextIcon &&
             columnResizeIcon == other.columnResizeIcon &&
+            columnResizeWidget == other.columnResizeWidget &&
             columnAscendingIcon == other.columnAscendingIcon &&
             columnDescendingIcon == other.columnDescendingIcon &&
             rowGroupExpandedIcon == other.rowGroupExpandedIcon &&
@@ -1109,6 +1120,7 @@ class TrinaGridStyleConfig {
     cellTextStyle,
     columnContextIcon,
     columnResizeIcon,
+    columnResizeWidget,
     columnAscendingIcon,
     columnDescendingIcon,
     rowGroupExpandedIcon,

--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -200,6 +200,9 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
           icon: TrinaGridColumnIcon(
             sort: _sort,
             color: style.iconColor,
+            customResizeWidget: widget.column.enableContextMenu
+                ? null
+                : style.columnResizeWidget,
             icon: widget.column.enableContextMenu
                 ? style.columnContextIcon
                 : style.columnResizeIcon,
@@ -272,6 +275,8 @@ class TrinaGridColumnIcon extends StatelessWidget {
 
   final IconData icon;
 
+  final Widget? customResizeWidget;
+
   final Widget? ascendingIcon;
 
   final Widget? descendingIcon;
@@ -280,6 +285,7 @@ class TrinaGridColumnIcon extends StatelessWidget {
     this.sort,
     this.color = Colors.black26,
     this.icon = Icons.dehaze,
+    this.customResizeWidget,
     this.ascendingIcon,
     this.descendingIcon,
     super.key,
@@ -300,7 +306,7 @@ class TrinaGridColumnIcon extends StatelessWidget {
             ? const Icon(Icons.sort, color: Colors.red)
             : descendingIcon!;
       default:
-        return Icon(icon, color: color);
+        return customResizeWidget ?? Icon(icon, color: color);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `columnResizeWidget` property to `TrinaGridStyleConfig` allowing a custom widget to replace the default resize icon when `enableContextMenu` is `false` on a column
- Clean re-implementation of #305 without formatting noise or example changes

## Usage
```dart
TrinaGridConfiguration(
  style: TrinaGridStyleConfig(
    columnResizeWidget: Container(
      height: 20,
      width: 10,
      color: Colors.red,
    ),
  ),
)
```

Set `enableContextMenu: false` on a column to use the custom widget instead of the default resize icon.

## Test plan
- [x] `dart analyze` passes with no new errors
- [x] All existing tests pass
- [ ] Manual: set `columnResizeWidget` with `enableContextMenu: false` on a column and verify custom widget appears

Closes #305