### PR TITLE
fix: use number format to calculate decimal points

### DIFF
--- a/lib/src/model/column_types/trina_column_type_number.dart
+++ b/lib/src/model/column_types/trina_column_type_number.dart
@@ -31,20 +31,13 @@ class TrinaColumnTypeNumber
     required this.applyFormatOnInit,
     required this.allowFirstDot,
     required this.locale,
-  }) : numberFormat = intl.NumberFormat(format, locale),
-       decimalPoint = _getDecimalPoint(format);
+  }) : numberFormat = intl.NumberFormat(format, locale);
 
   @override
   final intl.NumberFormat numberFormat;
 
   @override
-  final int decimalPoint;
-
-  static int _getDecimalPoint(String format) {
-    final int dotIndex = format.indexOf('.');
-
-    return dotIndex < 0 ? 0 : format.substring(dotIndex).length - 1;
-  }
+  int get decimalPoint => numberFormat.maximumFractionDigits;
 
   @override
   Widget buildCell(


### PR DESCRIPTION
A small change to calculate the decimal points in the `TrinaColumnTypeNumber` via the `intl.NumberFormat ` already created by it. This helps with locales, that use a different decimal point symbol.