### PR TITLE
Fix null check crash in WASM when row cell missing for column

### DIFF
--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -705,7 +705,9 @@ class _ApplyCellForSetColumnRow implements _Apply {
     }
 
     for (var element in refColumns) {
-      row.cells[element.field]!
+      final cell = row.cells[element.field];
+      if (cell == null) continue;
+      cell
         ..setColumn(element)
         ..setRow(row);
     }

--- a/lib/src/ui/trina_base_row.dart
+++ b/lib/src/ui/trina_base_row.dart
@@ -57,11 +57,13 @@ class TrinaBaseRow extends StatelessWidget {
   }
 
   TrinaVisibilityLayoutId _makeCell(TrinaColumn column) {
+    final cell = row.cells[column.field] ??
+        TrinaCell(value: column.type.defaultValue);
     return TrinaVisibilityLayoutId(
       id: column.field,
       child: TrinaBaseCell(
-        key: row.cells[column.field]!.key,
-        cell: row.cells[column.field]!,
+        key: cell.key,
+        cell: cell,
         column: column,
         rowIdx: rowIdx,
         row: row,


### PR DESCRIPTION
## Summary

- Fixes `Null check operator used on a null value` crash in WASM builds when a `TrinaRow` doesn't have a cell for every column
- In dart2js release builds, the `!` operator is often compiled away (no runtime null check), so missing cells were silently ignored. In WASM, `!` always throws at runtime, exposing the pre-existing issue and causing an infinite rebuild loop that freezes the app

## Changes

**`lib/src/ui/trina_base_row.dart`** — `_makeCell` method:
- Instead of force-unwrapping `row.cells[column.field]!`, falls back to creating a default `TrinaCell` with `column.type.defaultValue` when the cell is missing

**`lib/src/manager/trina_grid_state_manager.dart`** — `_ApplyCellForSetColumnRow.execute`:
- Skips missing cells with a null check instead of crashing on `row.cells[element.field]!`

## Test plan

- [x] Verified the fix resolves the WASM crash in a production Flutter WASM app using frozen columns with rows that don't always have cells for every column
- [ ] Existing tests should continue to pass since the change only adds null-safety guards