### PR TITLE
fix: cache fallback cell in row.cells to prevent rebuild churn

### DIFF
--- a/lib/src/ui/trina_base_row.dart
+++ b/lib/src/ui/trina_base_row.dart
@@ -57,8 +57,9 @@ class TrinaBaseRow extends StatelessWidget {
   }
 
   TrinaVisibilityLayoutId _makeCell(TrinaColumn column) {
-    final cell = row.cells[column.field] ??
-        TrinaCell(value: column.type.defaultValue);
+    final cell = row.cells[column.field] ??= TrinaCell(
+      value: column.type.defaultValue,
+    );
     return TrinaVisibilityLayoutId(
       id: column.field,
       child: TrinaBaseCell(


### PR DESCRIPTION
## Summary

- Follow-up to #322 — changes `??` to `??=` so the fallback `TrinaCell` is stored back into `row.cells`
- Without this, a new cell with a new key is created on every rebuild, causing unnecessary widget recreation and making the cell non-interactive

## Test plan

- Existing tests should pass since behavior is unchanged for rows that already have all cells
- WASM builds with missing cells will now have stable, persistent fallback cells