### PR TITLE
fix: metadata constructor bug and doc comments

### DIFF
--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -99,7 +99,7 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
     TrinaChangeNotifierFilterResolver? notifierFilterResolver,
     TrinaGridConfiguration configuration = const TrinaGridConfiguration(),
     TrinaGridMode? mode,
-    metadata,
+    this.metadata,
   }) : refColumns = FilteredList(initialList: columns),
        refRows = FilteredList(initialList: rows),
        refColumnGroups = FilteredList<TrinaColumnGroup>(
@@ -219,7 +219,7 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
   /// Get the current state of change tracking
   bool get enableChangeTracking => _enableChangeTracking;
 
-  // Optional metadata to attach additional data to the state manager
+  /// Optional metadata to attach additional data to the state manager
   Map<String, dynamic>? metadata = {};
 
   /// Enable or disable change tracking

--- a/lib/src/model/trina_cell.dart
+++ b/lib/src/model/trina_cell.dart
@@ -75,7 +75,7 @@ class TrinaCell {
   /// If provided, this will override the column padding and default padding.
   final EdgeInsets? padding;
 
-  // Optional metadata to attach additional data to cells
+  /// Optional metadata to attach additional data to cells
   Map<String, dynamic>? metadata = {};
 
   /// Returns true if this cell has a custom renderer.

--- a/lib/src/model/trina_column.dart
+++ b/lib/src/model/trina_column.dart
@@ -283,7 +283,7 @@ class TrinaColumn {
   /// If null, it falls back to the grid's enterKeyAction configuration.
   final TrinaGridEnterKeyAction? filterEnterKeyAction;
 
-  // Optional metadata to attach additional data to columns
+  /// Optional metadata to attach additional data to columns
   Map<String, dynamic>? metadata = {};
 
   TrinaColumn({

--- a/lib/src/model/trina_row.dart
+++ b/lib/src/model/trina_row.dart
@@ -36,7 +36,7 @@ class TrinaRow<T> {
   /// If null, uses the global rowHeight from configuration
   final double? height;
 
-  // Optional metadata to attach additional data to rows
+  /// Optional metadata to attach additional data to rows
   Map<String, dynamic>? metadata = {};
 
   Map<String, TrinaCell> cells;


### PR DESCRIPTION
## Summary
- Fix `metadata` parameter in `TrinaGridStateChangeNotifier` constructor to use `this.metadata` so it actually assigns to the field
- Change `//` to `///` for metadata doc comments on `TrinaRow`, `TrinaColumn`, `TrinaCell`, and `TrinaGridStateChangeNotifier`

Follow-up to #300.