### PR TITLE
Add keyboardType support to filter TextFields

### DIFF
--- a/lib/src/model/trina_column.dart
+++ b/lib/src/model/trina_column.dart
@@ -475,6 +475,7 @@ class TrinaFilterColumnWidgetDelegate {
     this.onFilterSuffixTap,
     this.clearIcon = const Icon(Icons.clear),
     this.onClear,
+    this.keyboardType,
   }) : filterWidgetBuilder = null,
        caseSensitive = null,
        isMultiItems = false;
@@ -486,6 +487,7 @@ class TrinaFilterColumnWidgetDelegate {
       filterHintTextColor = null,
       clearIcon = const Icon(Icons.clear),
       onClear = null,
+      keyboardType = null,
       caseSensitive = null,
       isMultiItems = false;
 
@@ -497,6 +499,7 @@ class TrinaFilterColumnWidgetDelegate {
       filterWidgetBuilder = null,
       clearIcon = const Icon(Icons.clear),
       onClear = null,
+      keyboardType = null,
       isMultiItems = true;
 
   ///Set hint text for filter field
@@ -536,6 +539,11 @@ class TrinaFilterColumnWidgetDelegate {
   final bool? isMultiItems;
 
   final bool? caseSensitive;
+
+  /// Set keyboard type for filter text field.
+  /// When null, automatically uses [TextInputType.number] for number,
+  /// currency, and percentage column types.
+  final TextInputType? keyboardType;
 }
 
 class TrinaColumnRendererContext {

--- a/lib/src/ui/columns/trina_column_filter.dart
+++ b/lib/src/ui/columns/trina_column_filter.dart
@@ -323,6 +323,13 @@ class TrinaColumnFilterState extends TrinaStateWithChange<TrinaColumnFilter> {
         controller: _controller,
         enabled: _enabled,
         style: style.cellTextStyle,
+        keyboardType:
+            filterDelegate?.keyboardType ??
+            (widget.column.type is TrinaColumnTypeNumber ||
+                    widget.column.type is TrinaColumnTypeCurrency ||
+                    widget.column.type is TrinaColumnTypePercentage
+                ? TextInputType.number
+                : null),
         onTap: _handleOnTap,
         onChanged: _handleOnChanged,
         onEditingComplete: _handleOnEditingComplete,


### PR DESCRIPTION
## Summary
- Adds optional `keyboardType` parameter to `TrinaFilterColumnWidgetDelegate.textField()` for manual control over the filter TextField keyboard type
- Automatically uses `TextInputType.number` for number, currency, and percentage column types when no explicit `keyboardType` is set
- No breaking changes — existing behavior is preserved (text columns still default to text keyboard)

## Motivation
On mobile devices, filter TextFields for numeric columns (number, currency, percentage) show a full text keyboard instead of a numeric one. This makes it harder to input filter values for these column types.

## Changes
- **`trina_column.dart`**: Added `TextInputType? keyboardType` field to `TrinaFilterColumnWidgetDelegate` and all three constructors (`textField`, `builder`, `multiItems`)
- **`trina_column_filter.dart`**: Pass `keyboardType` to the filter `TextField`, with automatic fallback to `TextInputType.number` for numeric column types

## Usage

Automatic (no code changes needed):
```dart
// Number, currency, and percentage columns automatically get numeric keyboard
TrinaColumn(
  field: 'amount',
  type: TrinaColumnType.number(),
  // filter TextField will automatically use TextInputType.number
)
```

Manual override:
```dart
// Explicitly set keyboard type for any column
TrinaColumn(
  field: 'sequenceId',
  type: TrinaColumnType.text(),
  filterWidgetDelegate: TrinaFilterColumnWidgetDelegate.textField(
    keyboardType: TextInputType.number,
  ),
)
```