### PR TITLE
fix: null-safe cell access in row grouping with hidden columns

### DIFF
--- a/lib/src/helper/trina_row_group_delegate.dart
+++ b/lib/src/helper/trina_row_group_delegate.dart
@@ -301,7 +301,7 @@ class TrinaRowGroupByColumnDelegate extends TrinaRowGroupDelegate {
     Iterator<MapEntry<String, List<TrinaRow>>>? currentIter;
     currentIter = groupBy<TrinaRow, String>(
       rows,
-      (r) => r.cells[groupFields[depth]]!.value.toString(),
+      (r) => r.cells[groupFields[depth]]?.value?.toString() ?? '',
     ).entries.iterator;
 
     while (currentIter != null || stack.isNotEmpty) {
@@ -331,7 +331,7 @@ class TrinaRowGroupByColumnDelegate extends TrinaRowGroupDelegate {
         if (depth + 1 < maxDepth) {
           currentIter = groupBy<TrinaRow, String>(
             currentIter.current.value,
-            (r) => r.cells[groupFields[depth + 1]]!.value.toString(),
+            (r) => r.cells[groupFields[depth + 1]]?.value?.toString() ?? '',
           ).entries.iterator;
         }
 
@@ -438,16 +438,18 @@ class TrinaRowGroupByColumnDelegate extends TrinaRowGroupDelegate {
     );
 
     for (var e in sampleRow.cells.entries) {
+      final sampleCell = e.value;
+      if (!sampleCell.initialized) continue;
       cells[e.key] =
           TrinaCell(
               value:
                   visibleColumns.firstWhereOrNull((c) => c.field == e.key) !=
                       null
-                  ? e.value.value
+                  ? sampleCell.value
                   : null,
               key: ValueKey('${groupKey}_${e.key}_cell'),
             )
-            ..setColumn(e.value.column)
+            ..setColumn(sampleCell.column)
             ..setRow(row);
     }
 

--- a/lib/src/manager/state/row_group_state.dart
+++ b/lib/src/manager/state/row_group_state.dart
@@ -770,7 +770,10 @@ mixin RowGroupState implements ITrinaGridState {
 
     for (final row in rows) {
       for (final column in groupedColumn) {
-        row.cells[column.field]!.value = target.cells[column.field]!.value;
+        final rowCell = row.cells[column.field];
+        final targetCell = target.cells[column.field];
+        if (rowCell == null || targetCell == null) continue;
+        rowCell.value = targetCell.value;
       }
     }
   }

--- a/lib/src/ui/cells/trina_default_cell.dart
+++ b/lib/src/ui/cells/trina_default_cell.dart
@@ -514,7 +514,8 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
 
       if (widget.row.depth < delegate.columns.length) {
         cellValue =
-            widget.row.cells[delegate.columns[widget.row.depth].field]!.value;
+            widget.row.cells[delegate.columns[widget.row.depth].field]?.value ??
+            cellValue;
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #320: Row grouping crashes when non-grouping columns are hidden
- Adds null-safe cell access in `toGroup()`, `_createRowGroup()`, `_updateCellsByTargetForGroupByColumn()`, and `_text` getter
- Skips uninitialized cells in `_createRowGroup` to prevent assertion errors

## Test plan
- All 112 row group tests pass
- Full test suite passes with no regressions