### PR TITLE
fix: row border misalignment with column border (#319)

### DIFF
--- a/lib/src/ui/trina_body_columns.dart
+++ b/lib/src/ui/trina_body_columns.dart
@@ -25,9 +25,6 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
 
   late final ScrollController _scroll;
 
-  // Track the end padding needed to account for vertical scrollbar
-  double _verticalScrollbarWidth = 0;
-
   @override
   TrinaGridStateManager get stateManager => widget.stateManager;
 
@@ -37,35 +34,12 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
 
     _scroll = stateManager.scroll.horizontal!.addAndGet();
 
-    // Calculate vertical scrollbar width when needed
-    _updateVerticalScrollbarWidth();
-
-    // Listen for configuration changes that might affect scrollbar visibility
-    stateManager.addListener(_handleConfigChange);
-
     updateState(TrinaNotifierEventForceUpdate.instance);
-  }
-
-  void _handleConfigChange() {
-    _updateVerticalScrollbarWidth();
-  }
-
-  void _updateVerticalScrollbarWidth() {
-    final scrollConfig = stateManager.configuration.scrollbar;
-    // Only account for vertical scrollbar width if it's shown
-    if (scrollConfig.showVertical && scrollConfig.columnShowScrollWidth) {
-      _verticalScrollbarWidth =
-          scrollConfig.thickness +
-          4; // Add padding as in TrinaVerticalScrollBar
-    } else {
-      _verticalScrollbarWidth = 0;
-    }
   }
 
   @override
   void dispose() {
     _scroll.dispose();
-    stateManager.removeListener(_handleConfigChange);
 
     super.dispose();
   }
@@ -92,9 +66,6 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
     );
 
     _itemCount = update<int>(_itemCount, _getItemCount());
-
-    // Update scrollbar width on state changes
-    _updateVerticalScrollbarWidth();
   }
 
   List<TrinaColumn> _getColumns() {
@@ -131,26 +102,19 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
       controller: _scroll,
       scrollDirection: Axis.horizontal,
       physics: const ClampingScrollPhysics(),
-      child: Row(
-        children: [
-          TrinaVisibilityLayout(
-            delegate: MainColumnLayoutDelegate(
-              stateManager: stateManager,
-              columns: _columns,
-              columnGroups: _columnGroups,
-              frozen: TrinaColumnFrozen.none,
-              textDirection: stateManager.textDirection,
-            ),
-            scrollController: _scroll,
-            initialViewportDimension:
-                MediaQuery.of(context).size.width - _verticalScrollbarWidth,
-            children: _showColumnGroups == true
-                ? _columnGroups.map(_makeColumnGroup).toList(growable: false)
-                : _columns.map(_makeColumn).toList(growable: false),
-          ),
-          // Add a spacer with the same width as the vertical scrollbar
-          SizedBox(width: _verticalScrollbarWidth),
-        ],
+      child: TrinaVisibilityLayout(
+        delegate: MainColumnLayoutDelegate(
+          stateManager: stateManager,
+          columns: _columns,
+          columnGroups: _columnGroups,
+          frozen: TrinaColumnFrozen.none,
+          textDirection: stateManager.textDirection,
+        ),
+        scrollController: _scroll,
+        initialViewportDimension: MediaQuery.of(context).size.width,
+        children: _showColumnGroups == true
+            ? _columnGroups.map(_makeColumnGroup).toList(growable: false)
+            : _columns.map(_makeColumn).toList(growable: false),
       ),
     );
   }

--- a/lib/src/ui/trina_body_columns_footer.dart
+++ b/lib/src/ui/trina_body_columns_footer.dart
@@ -22,9 +22,6 @@ class TrinaBodyColumnsFooterState
 
   late final ScrollController _scroll;
 
-  // Track the end padding needed to account for vertical scrollbar
-  double _verticalScrollbarWidth = 0;
-
   @override
   TrinaGridStateManager get stateManager => widget.stateManager;
 
@@ -34,35 +31,12 @@ class TrinaBodyColumnsFooterState
 
     _scroll = stateManager.scroll.horizontal!.addAndGet();
 
-    // Calculate vertical scrollbar width when needed
-    _updateVerticalScrollbarWidth();
-
-    // Listen for configuration changes that might affect scrollbar visibility
-    stateManager.addListener(_handleConfigChange);
-
     updateState(TrinaNotifierEventForceUpdate.instance);
-  }
-
-  void _handleConfigChange() {
-    _updateVerticalScrollbarWidth();
-  }
-
-  void _updateVerticalScrollbarWidth() {
-    final scrollConfig = stateManager.configuration.scrollbar;
-    // Only account for vertical scrollbar width if it's shown
-    if (scrollConfig.showVertical && scrollConfig.columnShowScrollWidth) {
-      _verticalScrollbarWidth =
-          scrollConfig.thickness +
-          4; // Add padding as in TrinaVerticalScrollBar
-    } else {
-      _verticalScrollbarWidth = 0;
-    }
   }
 
   @override
   void dispose() {
     _scroll.dispose();
-    stateManager.removeListener(_handleConfigChange);
 
     super.dispose();
   }
@@ -76,9 +50,6 @@ class TrinaBodyColumnsFooterState
     );
 
     _itemCount = update<int>(_itemCount, _columns.length);
-
-    // Update scrollbar width on state changes
-    _updateVerticalScrollbarWidth();
   }
 
   List<TrinaColumn> _getColumns() {
@@ -100,22 +71,15 @@ class TrinaBodyColumnsFooterState
       controller: _scroll,
       scrollDirection: Axis.horizontal,
       physics: const ClampingScrollPhysics(),
-      child: Row(
-        children: [
-          TrinaVisibilityLayout(
-            delegate: ColumnFooterLayoutDelegate(
-              stateManager: stateManager,
-              columns: _columns,
-              textDirection: stateManager.textDirection,
-            ),
-            scrollController: _scroll,
-            initialViewportDimension:
-                MediaQuery.of(context).size.width - _verticalScrollbarWidth,
-            children: _columns.map(_makeFooter).toList(growable: false),
-          ),
-          // Add a spacer with the same width as the vertical scrollbar
-          SizedBox(width: _verticalScrollbarWidth),
-        ],
+      child: TrinaVisibilityLayout(
+        delegate: ColumnFooterLayoutDelegate(
+          stateManager: stateManager,
+          columns: _columns,
+          textDirection: stateManager.textDirection,
+        ),
+        scrollController: _scroll,
+        initialViewportDimension: MediaQuery.of(context).size.width,
+        children: _columns.map(_makeFooter).toList(growable: false),
       ),
     );
   }

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -205,100 +205,101 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
       child: Column(
         children: [
           // Main content with vertical scrollbar
+          // Use Stack so the scrollbar overlays the scroll content,
+          // keeping the scroll viewport width identical to the column header.
           Expanded(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
+            child: Stack(
+              fit: StackFit.expand,
               children: [
-                // Main grid content
-                Expanded(
-                  child:
-                      (scrollConfig.smoothScrolling
-                      ? TrinaSingleChildSmoothScrollView.new
-                      : SingleChildScrollView.new)(
-                        controller: _horizontalScroll,
-                        scrollDirection: Axis.horizontal,
-                        physics: const ClampingScrollPhysics(),
-                        child: CustomSingleChildLayout(
-                          delegate: ListResizeDelegate(stateManager, _columns),
-                          child: Column(
-                            children: [
-                              // Frozen top rows
-                              if (_frozenTopRows.isNotEmpty)
-                                Column(
-                                  children: _frozenTopRows
-                                      .asMap()
-                                      .entries
-                                      .map(
-                                        (e) =>
-                                            _buildRow(context, e.value, e.key),
-                                      )
-                                      .toList(),
-                                ),
-                              // Scrollable rows
-                              Expanded(
-                                child:
-                                    (scrollConfig.smoothScrolling
-                                    ? TrinaSmoothListView.builder
-                                    : ListView.builder)(
-                                      cacheExtent: stateManager.rowsCacheExtent,
-                                      controller: _verticalScroll,
-                                      scrollDirection: Axis.vertical,
-                                      physics: const ClampingScrollPhysics(),
-                                      itemCount: _scrollableRows.length,
-                                      itemExtent:
-                                          (stateManager.rowWrapper != null &&
-                                              !stateManager
-                                                  .configuration
-                                                  .rowWrapperIsConstantHeight)
-                                          ? null
-                                          : stateManager.rowTotalHeight,
-                                      addRepaintBoundaries: false,
-                                      itemBuilder: (ctx, i) => _buildRow(
-                                        context,
-                                        _scrollableRows[i],
-                                        i + _frozenTopRows.length,
-                                      ),
-                                    ),
-                              ),
-                              // Frozen bottom rows
-                              if (_frozenBottomRows.isNotEmpty)
-                                Column(
-                                  children: _frozenBottomRows
-                                      .asMap()
-                                      .entries
-                                      .map(
-                                        (e) => _buildRow(
-                                          context,
-                                          e.value,
-                                          e.key +
-                                              _frozenTopRows.length +
-                                              _scrollableRows.length,
-                                        ),
-                                      )
-                                      .toList(),
-                                ),
-                            ],
+                // Main grid content - takes full width
+                (scrollConfig.smoothScrolling
+                    ? TrinaSingleChildSmoothScrollView.new
+                    : SingleChildScrollView.new)(
+                  controller: _horizontalScroll,
+                  scrollDirection: Axis.horizontal,
+                  physics: const ClampingScrollPhysics(),
+                  child: CustomSingleChildLayout(
+                    delegate: ListResizeDelegate(stateManager, _columns),
+                    child: Column(
+                      children: [
+                        // Frozen top rows
+                        if (_frozenTopRows.isNotEmpty)
+                          Column(
+                            children: _frozenTopRows
+                                .asMap()
+                                .entries
+                                .map((e) => _buildRow(context, e.value, e.key))
+                                .toList(),
                           ),
+                        // Scrollable rows
+                        Expanded(
+                          child:
+                              (scrollConfig.smoothScrolling
+                              ? TrinaSmoothListView.builder
+                              : ListView.builder)(
+                                cacheExtent: stateManager.rowsCacheExtent,
+                                controller: _verticalScroll,
+                                scrollDirection: Axis.vertical,
+                                physics: const ClampingScrollPhysics(),
+                                itemCount: _scrollableRows.length,
+                                itemExtent:
+                                    (stateManager.rowWrapper != null &&
+                                        !stateManager
+                                            .configuration
+                                            .rowWrapperIsConstantHeight)
+                                    ? null
+                                    : stateManager.rowTotalHeight,
+                                addRepaintBoundaries: false,
+                                itemBuilder: (ctx, i) => _buildRow(
+                                  context,
+                                  _scrollableRows[i],
+                                  i + _frozenTopRows.length,
+                                ),
+                              ),
                         ),
-                      ),
+                        // Frozen bottom rows
+                        if (_frozenBottomRows.isNotEmpty)
+                          Column(
+                            children: _frozenBottomRows
+                                .asMap()
+                                .entries
+                                .map(
+                                  (e) => _buildRow(
+                                    context,
+                                    e.value,
+                                    e.key +
+                                        _frozenTopRows.length +
+                                        _scrollableRows.length,
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                      ],
+                    ),
+                  ),
                 ),
 
-                // Fake vertical scrollbar
+                // Vertical scrollbar overlaid on the right
                 if (scrollConfig.showVertical)
-                  LayoutBuilder(
-                    builder: (context, constraints) {
-                      return TrinaVerticalScrollBar(
-                        stateManager: stateManager,
-                        verticalScrollExtentNotifier:
-                            _verticalScrollExtentNotifier,
-                        verticalViewportExtentNotifier:
-                            _verticalViewportExtentNotifier,
-                        verticalScrollOffsetNotifier:
-                            _verticalScrollOffsetNotifier,
-                        context: context,
-                        height: constraints.maxHeight,
-                      );
-                    },
+                  Positioned(
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        return TrinaVerticalScrollBar(
+                          stateManager: stateManager,
+                          verticalScrollExtentNotifier:
+                              _verticalScrollExtentNotifier,
+                          verticalViewportExtentNotifier:
+                              _verticalViewportExtentNotifier,
+                          verticalScrollOffsetNotifier:
+                              _verticalScrollOffsetNotifier,
+                          context: context,
+                          height: constraints.maxHeight,
+                        );
+                      },
+                    ),
                   ),
               ],
             ),

--- a/lib/src/widgets/trina_vertical_scroll_bar.dart
+++ b/lib/src/widgets/trina_vertical_scroll_bar.dart
@@ -168,244 +168,258 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
   Widget build(BuildContext context) {
     final scrollConfig = widget.stateManager.configuration.scrollbar;
 
-    return MouseRegion(
-      onEnter: (_) {
-        setState(() {
-          _hovering = true;
-          if (!scrollConfig.isAlwaysShown) {
-            _fadeController.forward();
-          }
-        });
+    return AnimatedBuilder(
+      animation: _fadeController,
+      builder: (context, child) {
+        return IgnorePointer(
+          ignoring: _fadeController.value == 0 && !_isDragging,
+          child: child,
+        );
       },
-      onExit: (_) {
-        setState(() {
-          _hovering = false;
-          _isThumbHovered = false;
-          if (!scrollConfig.isAlwaysShown && !_isDragging) {
-            _fadeController.reverse();
-          }
-        });
-      },
-      child: GestureDetector(
-        onTapUp: (details) {
-          // Handle clicks on the track to jump to that position
-          final scrollController = widget.stateManager.scroll.bodyRowsVertical;
-          if (scrollController == null) return;
-
-          final scrollExtent = widget.verticalScrollExtentNotifier.value;
-          final viewportExtent = widget.verticalViewportExtentNotifier.value;
-
-          if (scrollExtent <= 0) return;
-
-          final double thumbHeight =
-              (viewportExtent / (viewportExtent + scrollExtent)) *
-              widget.height;
-
-          // Get the local Y position of the tap
-          final tapY = details.localPosition.dy;
-
-          // Calculate the scroll position where the center of the thumb should be at tapY
-          // thumbPosition = (scrollOffset / scrollExtent) * (widget.height - thumbHeight)
-          // Solving for scrollOffset when thumbPosition + thumbHeight/2 = tapY:
-          final targetThumbPosition = tapY - (thumbHeight / 2);
-          final newScrollOffset =
-              (targetThumbPosition / (widget.height - thumbHeight)) *
-              scrollExtent;
-
-          // Clamp to valid range
-          final clampedOffset = newScrollOffset.clamp(
-            0.0,
-            scrollController.position.maxScrollExtent,
-          );
-
-          // Use animateTo for smooth scrolling instead of jumpTo
-          scrollController.animateTo(
-            clampedOffset,
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOutCubic,
-          );
-        },
-        onPanDown: (_) {
+      child: MouseRegion(
+        onEnter: (_) {
           setState(() {
-            _isDragging = true;
+            _hovering = true;
+            if (!scrollConfig.isAlwaysShown) {
+              _fadeController.forward();
+            }
           });
         },
-        onPanEnd: (_) {
+        onExit: (_) {
           setState(() {
-            _isDragging = false;
-            if (!scrollConfig.isAlwaysShown && !_hovering) {
+            _hovering = false;
+            _isThumbHovered = false;
+            if (!scrollConfig.isAlwaysShown && !_isDragging) {
               _fadeController.reverse();
             }
           });
         },
-        onPanCancel: () {
-          setState(() {
-            _isDragging = false;
-            if (!scrollConfig.isAlwaysShown && !_hovering) {
-              _fadeController.reverse();
-            }
-          });
-        },
-        child: FadeTransition(
-          opacity: _fadeAnimation,
-          child: ValueListenableBuilder<double>(
-            valueListenable: widget.verticalScrollExtentNotifier,
-            builder: (context, scrollExtent, _) {
-              if (scrollExtent <= 0) {
-                return SizedBox(width: scrollConfig.thickness);
+        child: GestureDetector(
+          onTapUp: (details) {
+            // Handle clicks on the track to jump to that position
+            final scrollController =
+                widget.stateManager.scroll.bodyRowsVertical;
+            if (scrollController == null) return;
+
+            final scrollExtent = widget.verticalScrollExtentNotifier.value;
+            final viewportExtent = widget.verticalViewportExtentNotifier.value;
+
+            if (scrollExtent <= 0) return;
+
+            final double thumbHeight =
+                (viewportExtent / (viewportExtent + scrollExtent)) *
+                widget.height;
+
+            // Get the local Y position of the tap
+            final tapY = details.localPosition.dy;
+
+            // Calculate the scroll position where the center of the thumb should be at tapY
+            // thumbPosition = (scrollOffset / scrollExtent) * (widget.height - thumbHeight)
+            // Solving for scrollOffset when thumbPosition + thumbHeight/2 = tapY:
+            final targetThumbPosition = tapY - (thumbHeight / 2);
+            final newScrollOffset =
+                (targetThumbPosition / (widget.height - thumbHeight)) *
+                scrollExtent;
+
+            // Clamp to valid range
+            final clampedOffset = newScrollOffset.clamp(
+              0.0,
+              scrollController.position.maxScrollExtent,
+            );
+
+            // Use animateTo for smooth scrolling instead of jumpTo
+            scrollController.animateTo(
+              clampedOffset,
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutCubic,
+            );
+          },
+          onPanDown: (_) {
+            setState(() {
+              _isDragging = true;
+            });
+          },
+          onPanEnd: (_) {
+            setState(() {
+              _isDragging = false;
+              if (!scrollConfig.isAlwaysShown && !_hovering) {
+                _fadeController.reverse();
               }
+            });
+          },
+          onPanCancel: () {
+            setState(() {
+              _isDragging = false;
+              if (!scrollConfig.isAlwaysShown && !_hovering) {
+                _fadeController.reverse();
+              }
+            });
+          },
+          child: FadeTransition(
+            opacity: _fadeAnimation,
+            child: ValueListenableBuilder<double>(
+              valueListenable: widget.verticalScrollExtentNotifier,
+              builder: (context, scrollExtent, _) {
+                if (scrollExtent <= 0) {
+                  return SizedBox(width: scrollConfig.thickness);
+                }
 
-              return ValueListenableBuilder<double>(
-                valueListenable: widget.verticalViewportExtentNotifier,
-                builder: (context, viewportExtent, _) {
-                  final double thumbHeight =
-                      (viewportExtent / (viewportExtent + scrollExtent)) *
-                      widget.height;
+                return ValueListenableBuilder<double>(
+                  valueListenable: widget.verticalViewportExtentNotifier,
+                  builder: (context, viewportExtent, _) {
+                    final double thumbHeight =
+                        (viewportExtent / (viewportExtent + scrollExtent)) *
+                        widget.height;
 
-                  return ValueListenableBuilder<double>(
-                    valueListenable: widget.verticalScrollOffsetNotifier,
-                    builder: (context, scrollOffset, _) {
-                      final double thumbPosition =
-                          (scrollOffset / scrollExtent) *
-                          (widget.height - thumbHeight);
+                    return ValueListenableBuilder<double>(
+                      valueListenable: widget.verticalScrollOffsetNotifier,
+                      builder: (context, scrollOffset, _) {
+                        final double thumbPosition =
+                            (scrollOffset / scrollExtent) *
+                            (widget.height - thumbHeight);
 
-                      return SizedBox(
-                        width: scrollConfig.thickness + 4, // Add padding
-                        height: widget.height,
-                        child: Stack(
-                          children: [
-                            // Track
-                            if (scrollConfig.showTrack)
-                              Container(
-                                width: scrollConfig.thickness,
-                                margin: const EdgeInsets.symmetric(
-                                  horizontal: 2,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: _hovering
-                                      ? scrollConfig.effectiveTrackHoverColor
-                                      : scrollConfig.effectiveTrackColor,
-                                  borderRadius: BorderRadius.circular(
-                                    scrollConfig.effectiveRadius,
+                        return SizedBox(
+                          width: scrollConfig.thickness + 4, // Add padding
+                          height: widget.height,
+                          child: Stack(
+                            children: [
+                              // Track
+                              if (scrollConfig.showTrack)
+                                Container(
+                                  width: scrollConfig.thickness,
+                                  margin: const EdgeInsets.symmetric(
+                                    horizontal: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: _hovering
+                                        ? scrollConfig.effectiveTrackHoverColor
+                                        : scrollConfig.effectiveTrackColor,
+                                    borderRadius: BorderRadius.circular(
+                                      scrollConfig.effectiveRadius,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            // Thumb
-                            if (scrollConfig.thumbVisible)
-                              Positioned(
-                                top: thumbPosition.isNaN ? 0 : thumbPosition,
-                                height: thumbHeight.isNaN
-                                    ? widget.height
-                                    : thumbHeight.clamp(
-                                        scrollConfig.minThumbLength >
-                                                widget.height
-                                            ? widget.height
-                                            : scrollConfig.minThumbLength,
-                                        widget.height,
-                                      ),
-                                width: scrollConfig.thickness,
-                                left: widget.stateManager.isRTL ? 2 : null,
-                                right: widget.stateManager.isRTL ? null : 2,
-                                child: MouseRegion(
-                                  cursor: SystemMouseCursors.grab,
-                                  onEnter: (_) {
-                                    if (!_isThumbHovered) {
-                                      setState(() {
-                                        _isThumbHovered = true;
-                                      });
-                                    }
-                                  },
-                                  onExit: (_) {
-                                    if (_isThumbHovered) {
-                                      setState(() {
-                                        _isThumbHovered = false;
-                                      });
-                                    }
-                                  },
-                                  child: GestureDetector(
-                                    onVerticalDragStart:
-                                        scrollConfig.isDraggable
-                                        ? (details) {
-                                            setState(() {
-                                              _isDragging = true;
-                                            });
-                                          }
-                                        : null,
-                                    onVerticalDragUpdate:
-                                        scrollConfig.isDraggable
-                                        ? (details) {
-                                            // Direct thumb manipulation approach
-                                            final double dragDelta =
-                                                details.delta.dy;
-
-                                            // Calculate how much to scroll based on thumb movement
-                                            // The available space for the thumb to move is (widget.height - thumbHeight)
-                                            // The total scrollable content is scrollExtent
-                                            final double scrollableRatio =
-                                                scrollExtent /
-                                                (widget.height - thumbHeight);
-                                            final double scrollDelta =
-                                                dragDelta * scrollableRatio;
-
-                                            // Get the scroll controller
-                                            final scrollController = widget
-                                                .stateManager
-                                                .scroll
-                                                .bodyRowsVertical;
-                                            if (scrollController != null &&
-                                                scrollController.hasClients) {
-                                              // Apply the scroll by adding delta to current position
-                                              final currentOffset =
-                                                  scrollController.offset;
-                                              final newOffset =
-                                                  (currentOffset + scrollDelta)
-                                                      .clamp(
-                                                        0.0,
-                                                        scrollController
-                                                            .position
-                                                            .maxScrollExtent,
-                                                      );
-
-                                              // Use jumpTo for immediate response during drag
-                                              scrollController.jumpTo(
-                                                newOffset,
-                                              );
+                              // Thumb
+                              if (scrollConfig.thumbVisible)
+                                Positioned(
+                                  top: thumbPosition.isNaN ? 0 : thumbPosition,
+                                  height: thumbHeight.isNaN
+                                      ? widget.height
+                                      : thumbHeight.clamp(
+                                          scrollConfig.minThumbLength >
+                                                  widget.height
+                                              ? widget.height
+                                              : scrollConfig.minThumbLength,
+                                          widget.height,
+                                        ),
+                                  width: scrollConfig.thickness,
+                                  left: widget.stateManager.isRTL ? 2 : null,
+                                  right: widget.stateManager.isRTL ? null : 2,
+                                  child: MouseRegion(
+                                    cursor: SystemMouseCursors.grab,
+                                    onEnter: (_) {
+                                      if (!_isThumbHovered) {
+                                        setState(() {
+                                          _isThumbHovered = true;
+                                        });
+                                      }
+                                    },
+                                    onExit: (_) {
+                                      if (_isThumbHovered) {
+                                        setState(() {
+                                          _isThumbHovered = false;
+                                        });
+                                      }
+                                    },
+                                    child: GestureDetector(
+                                      onVerticalDragStart:
+                                          scrollConfig.isDraggable
+                                          ? (details) {
+                                              setState(() {
+                                                _isDragging = true;
+                                              });
                                             }
-                                          }
-                                        : null,
-                                    onVerticalDragEnd: scrollConfig.isDraggable
-                                        ? (_) {
-                                            setState(() {
-                                              _isDragging = false;
-                                              if (!scrollConfig.isAlwaysShown &&
-                                                  !_hovering) {
-                                                _fadeController.reverse();
+                                          : null,
+                                      onVerticalDragUpdate:
+                                          scrollConfig.isDraggable
+                                          ? (details) {
+                                              // Direct thumb manipulation approach
+                                              final double dragDelta =
+                                                  details.delta.dy;
+
+                                              // Calculate how much to scroll based on thumb movement
+                                              // The available space for the thumb to move is (widget.height - thumbHeight)
+                                              // The total scrollable content is scrollExtent
+                                              final double scrollableRatio =
+                                                  scrollExtent /
+                                                  (widget.height - thumbHeight);
+                                              final double scrollDelta =
+                                                  dragDelta * scrollableRatio;
+
+                                              // Get the scroll controller
+                                              final scrollController = widget
+                                                  .stateManager
+                                                  .scroll
+                                                  .bodyRowsVertical;
+                                              if (scrollController != null &&
+                                                  scrollController.hasClients) {
+                                                // Apply the scroll by adding delta to current position
+                                                final currentOffset =
+                                                    scrollController.offset;
+                                                final newOffset =
+                                                    (currentOffset +
+                                                            scrollDelta)
+                                                        .clamp(
+                                                          0.0,
+                                                          scrollController
+                                                              .position
+                                                              .maxScrollExtent,
+                                                        );
+
+                                                // Use jumpTo for immediate response during drag
+                                                scrollController.jumpTo(
+                                                  newOffset,
+                                                );
                                               }
-                                            });
-                                          }
-                                        : null,
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        color: _isThumbHovered || _isDragging
-                                            ? scrollConfig
-                                                  .effectiveThumbHoverColor
-                                            : scrollConfig.effectiveThumbColor,
-                                        borderRadius: BorderRadius.circular(
-                                          scrollConfig.effectiveRadius,
+                                            }
+                                          : null,
+                                      onVerticalDragEnd:
+                                          scrollConfig.isDraggable
+                                          ? (_) {
+                                              setState(() {
+                                                _isDragging = false;
+                                                if (!scrollConfig
+                                                        .isAlwaysShown &&
+                                                    !_hovering) {
+                                                  _fadeController.reverse();
+                                                }
+                                              });
+                                            }
+                                          : null,
+                                      child: Container(
+                                        decoration: BoxDecoration(
+                                          color: _isThumbHovered || _isDragging
+                                              ? scrollConfig
+                                                    .effectiveThumbHoverColor
+                                              : scrollConfig
+                                                    .effectiveThumbColor,
+                                          borderRadius: BorderRadius.circular(
+                                            scrollConfig.effectiveRadius,
+                                          ),
                                         ),
                                       ),
                                     ),
                                   ),
                                 ),
-                              ),
-                          ],
-                        ),
-                      );
-                    },
-                  );
-                },
-              );
-            },
+                            ],
+                          ),
+                        );
+                      },
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Overlay the vertical scrollbar on the body rows using a Stack instead of placing it in a Row, so header, body, and footer share identical horizontal scroll viewport widths
- Remove the compensating SizedBox spacer from column header and footer widgets
- Add IgnorePointer to scrollbar overlay when invisible to prevent blocking gestures

Closes #319