### PR TITLE
feat: add updateRowCells helper for batch cell updates

### DIFF
--- a/doc/features/cell_value_change_handling.md
+++ b/doc/features/cell_value_change_handling.md
@@ -288,6 +288,55 @@ TrinaCell(
 )
 ```
 
+## Batch Cell Updates with updateRowCells
+
+When you need to update multiple cells in a single row (e.g., syncing with backend data), use `updateRowCells` instead of calling `changeCellValue` multiple times. It applies all changes and only triggers a single UI notification at the end.
+
+### Syntax
+
+```dart
+stateManager.updateRowCells(
+  row,
+  {
+    'name': 'Updated Name',
+    'age': 25,
+    'status': 'active',
+  },
+);
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `row` | `TrinaRow` | required | The row whose cells should be updated |
+| `values` | `Map<String, dynamic>` | required | Map of column field names to new values |
+| `callOnChangedEvent` | `bool` | `true` | Whether to trigger onChanged callbacks |
+| `force` | `bool` | `false` | Bypass read-only and editability checks |
+| `notify` | `bool` | `true` | Whether to notify listeners (trigger UI rebuild) |
+| `validate` | `bool` | `true` | Whether to validate values before setting |
+
+### Example: Syncing a Row with Backend Data
+
+```dart
+// Fetch updated data from API
+final updatedData = await api.getRecord(recordId);
+
+// Find the row to update
+final row = stateManager.rows.firstWhere(
+  (r) => r.cells['id']?.value == recordId,
+);
+
+// Update all cells in one call
+stateManager.updateRowCells(row, {
+  'name': updatedData['name'],
+  'email': updatedData['email'],
+  'status': updatedData['status'],
+});
+```
+
+Fields that don't exist in the row's cells are silently skipped. Cells that fail validation or are read-only are also skipped without affecting the other updates.
+
 ## Best Practices
 
 1. **Use cell-level callbacks for cell-specific logic** and grid-level callbacks for application-wide concerns.

--- a/lib/src/manager/state/editing_state.dart
+++ b/lib/src/manager/state/editing_state.dart
@@ -55,6 +55,23 @@ abstract class IEditingState {
     bool notify = true,
     bool validate = true,
   });
+
+  /// Update multiple cell values in a row from a map of field names to values.
+  ///
+  /// More efficient than calling [changeCellValue] multiple times because
+  /// it only calls [notifyListeners] once at the end.
+  ///
+  /// [row] is the row whose cells should be updated.
+  /// [values] is a map where keys are column field names and values are
+  /// the new cell values.
+  void updateRowCells(
+    TrinaRow row,
+    Map<String, dynamic> values, {
+    bool callOnChangedEvent = true,
+    bool force = false,
+    bool notify = true,
+    bool validate = true,
+  });
 }
 
 class _State {
@@ -353,6 +370,109 @@ mixin EditingState implements ITrinaGridState {
     }
 
     notifyListeners(notify, changeCellValue.hashCode);
+  }
+
+  @override
+  void updateRowCells(
+    TrinaRow row,
+    Map<String, dynamic> values, {
+    bool callOnChangedEvent = true,
+    bool force = false,
+    bool notify = true,
+    bool validate = true,
+  }) {
+    if (values.isEmpty) return;
+
+    final rowIdx = refRows.indexOf(row);
+    if (rowIdx < 0) return;
+
+    for (final entry in values.entries) {
+      final field = entry.key;
+      final cell = row.cells[field];
+
+      if (cell == null) continue;
+
+      final currentColumn = cell.column;
+      final dynamic oldValue = cell.value;
+      dynamic newValue = entry.value;
+
+      newValue = filteredCellValue(
+        column: currentColumn,
+        newValue: newValue,
+        oldValue: oldValue,
+      );
+
+      if (validate) {
+        newValue = castValueByColumnType(newValue, currentColumn);
+      }
+
+      if (force == false &&
+          canNotChangeCellValue(
+            cell: cell,
+            newValue: newValue,
+            oldValue: oldValue,
+          )) {
+        continue;
+      }
+
+      if (validate) {
+        final validationError = validateValue(
+          newValue,
+          currentColumn,
+          row,
+          rowIdx,
+          oldValue,
+        );
+
+        if (validationError != null) {
+          if (onValidationFailed != null) {
+            onValidationFailed!(
+              TrinaGridValidationEvent(
+                column: currentColumn,
+                row: row,
+                rowIdx: rowIdx,
+                value: newValue,
+                oldValue: oldValue,
+                errorMessage: validationError,
+              ),
+            );
+          }
+          continue;
+        }
+      }
+
+      if ((this as TrinaGridStateManager).enableChangeTracking &&
+          !cell.isDirty) {
+        cell.trackChange();
+      }
+
+      row.setState(TrinaRowState.updated);
+      cell.value = newValue;
+      row.incrementVersion();
+
+      if (callOnChangedEvent) {
+        final changedEvent = TrinaGridOnChangedEvent(
+          columnIdx:
+              columnIndex(currentColumn) ?? refColumns.indexOf(currentColumn),
+          column: currentColumn,
+          rowIdx: rowIdx,
+          row: row,
+          cell: cell,
+          value: newValue,
+          oldValue: oldValue,
+        );
+
+        if (cell.onChanged != null) {
+          cell.onChanged!(changedEvent);
+        }
+
+        if (onChanged != null) {
+          onChanged!(changedEvent);
+        }
+      }
+    }
+
+    notifyListeners(notify, updateRowCells.hashCode);
   }
 
   void _pasteCellValueIntoSelectingRows({List<List<String>>? textList}) {

--- a/test/src/manager/state/editing_state_update_row_cells_test.dart
+++ b/test/src/manager/state/editing_state_update_row_cells_test.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  group('EditingState.updateRowCells', () {
+    late TrinaGridStateManager stateManager;
+    late List<TrinaColumn> columns;
+    late List<TrinaRow> rows;
+
+    setUp(() {
+      columns = [
+        TrinaColumn(title: 'Name', field: 'name', type: TrinaColumnType.text()),
+        TrinaColumn(title: 'Age', field: 'age', type: TrinaColumnType.number()),
+        TrinaColumn(
+          title: 'Status',
+          field: 'status',
+          type: TrinaColumnType.text(),
+        ),
+      ];
+
+      rows = [
+        TrinaRow(
+          cells: {
+            'name': TrinaCell(value: 'Alice'),
+            'age': TrinaCell(value: 30),
+            'status': TrinaCell(value: 'active'),
+          },
+        ),
+        TrinaRow(
+          cells: {
+            'name': TrinaCell(value: 'Bob'),
+            'age': TrinaCell(value: 25),
+            'status': TrinaCell(value: 'inactive'),
+          },
+        ),
+      ];
+
+      stateManager = TrinaGridStateManager(
+        columns: columns,
+        rows: rows,
+        gridFocusNode: FocusNode(),
+        scroll: TrinaGridScrollController(),
+      );
+    });
+
+    test('should update multiple cells in a row', () {
+      final row = rows[0];
+
+      stateManager.updateRowCells(row, {'name': 'Charlie', 'age': 40});
+
+      expect(row.cells['name']!.value, equals('Charlie'));
+      expect(row.cells['age']!.value, equals(40));
+      expect(row.cells['status']!.value, equals('active'));
+    });
+
+    test('should set row state to updated', () {
+      final row = rows[0];
+
+      stateManager.updateRowCells(row, {'name': 'Charlie'});
+
+      expect(row.state, equals(TrinaRowState.updated));
+    });
+
+    test('should do nothing with empty values map', () {
+      final row = rows[0];
+
+      stateManager.updateRowCells(row, {});
+
+      expect(row.cells['name']!.value, equals('Alice'));
+    });
+
+    test('should skip invalid field names', () {
+      final row = rows[0];
+
+      stateManager.updateRowCells(row, {
+        'nonexistent_field': 'value',
+        'name': 'Updated',
+      });
+
+      expect(row.cells['name']!.value, equals('Updated'));
+    });
+
+    test('should skip cells with same value', () {
+      final row = rows[0];
+
+      stateManager.updateRowCells(row, {
+        'name': 'Alice', // same value
+        'age': 99,
+      });
+
+      expect(row.cells['age']!.value, equals(99));
+    });
+
+    group('read-only columns', () {
+      test('should skip read-only columns', () {
+        final readOnlyColumns = [
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            readOnly: true,
+          ),
+          TrinaColumn(
+            title: 'Age',
+            field: 'age',
+            type: TrinaColumnType.number(),
+          ),
+        ];
+
+        final testRows = [
+          TrinaRow(
+            cells: {
+              'name': TrinaCell(value: 'Alice'),
+              'age': TrinaCell(value: 30),
+            },
+          ),
+        ];
+
+        final sm = TrinaGridStateManager(
+          columns: readOnlyColumns,
+          rows: testRows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          configuration: const TrinaGridConfiguration(
+            columnSize: TrinaGridColumnSizeConfig(
+              autoSizeMode: TrinaAutoSizeMode.none,
+            ),
+          ),
+        );
+
+        sm.updateRowCells(testRows[0], {'name': 'Updated', 'age': 40});
+
+        expect(testRows[0].cells['name']!.value, equals('Alice'));
+        expect(testRows[0].cells['age']!.value, equals(40));
+      });
+    });
+
+    group('force parameter', () {
+      test('should bypass checks when force is true', () {
+        final readOnlyColumns = [
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            readOnly: true,
+          ),
+        ];
+
+        final testRows = [
+          TrinaRow(cells: {'name': TrinaCell(value: 'Alice')}),
+        ];
+
+        final sm = TrinaGridStateManager(
+          columns: readOnlyColumns,
+          rows: testRows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          configuration: const TrinaGridConfiguration(
+            columnSize: TrinaGridColumnSizeConfig(
+              autoSizeMode: TrinaAutoSizeMode.none,
+            ),
+          ),
+        );
+
+        sm.updateRowCells(testRows[0], {'name': 'Forced'}, force: true);
+
+        expect(testRows[0].cells['name']!.value, equals('Forced'));
+      });
+    });
+
+    group('validation', () {
+      test('should skip cells that fail validation', () {
+        final validatedColumns = [
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            validator: (value, context) {
+              if (value == null || value.toString().isEmpty) {
+                return 'Name cannot be empty';
+              }
+              return null;
+            },
+          ),
+          TrinaColumn(
+            title: 'Age',
+            field: 'age',
+            type: TrinaColumnType.number(),
+          ),
+        ];
+
+        final testRows = [
+          TrinaRow(
+            cells: {
+              'name': TrinaCell(value: 'Alice'),
+              'age': TrinaCell(value: 30),
+            },
+          ),
+        ];
+
+        final sm = TrinaGridStateManager(
+          columns: validatedColumns,
+          rows: testRows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          configuration: const TrinaGridConfiguration(
+            columnSize: TrinaGridColumnSizeConfig(
+              autoSizeMode: TrinaAutoSizeMode.none,
+            ),
+          ),
+        );
+
+        sm.updateRowCells(testRows[0], {
+          'name': '', // should fail validation
+          'age': 40, // should succeed
+        });
+
+        expect(testRows[0].cells['name']!.value, equals('Alice'));
+        expect(testRows[0].cells['age']!.value, equals(40));
+      });
+
+      test('should fire onValidationFailed callback', () {
+        TrinaGridValidationEvent? validationEvent;
+
+        final validatedColumns = [
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            validator: (value, context) {
+              if (value == null || value.toString().isEmpty) {
+                return 'Name cannot be empty';
+              }
+              return null;
+            },
+          ),
+        ];
+
+        final testRows = [
+          TrinaRow(cells: {'name': TrinaCell(value: 'Alice')}),
+        ];
+
+        final sm = TrinaGridStateManager(
+          columns: validatedColumns,
+          rows: testRows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          configuration: const TrinaGridConfiguration(
+            columnSize: TrinaGridColumnSizeConfig(
+              autoSizeMode: TrinaAutoSizeMode.none,
+            ),
+          ),
+          onValidationFailed: (event) {
+            validationEvent = event;
+          },
+        );
+
+        sm.updateRowCells(testRows[0], {'name': ''});
+
+        expect(validationEvent, isNotNull);
+        expect(validationEvent!.errorMessage, equals('Name cannot be empty'));
+      });
+    });
+
+    group('change tracking', () {
+      test('should track changes when enableChangeTracking is true', () {
+        final sm = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+        );
+        sm.setChangeTracking(true);
+
+        final cell = rows[0].cells['name']!;
+        final originalValue = cell.value;
+
+        sm.updateRowCells(rows[0], {'name': 'Updated'});
+
+        expect(cell.isDirty, isTrue);
+        expect(cell.originalValue, equals(originalValue));
+      });
+    });
+
+    group('callbacks', () {
+      test('should fire onChanged callbacks', () {
+        final changedEvents = <TrinaGridOnChangedEvent>[];
+
+        final sm = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          onChanged: (event) {
+            changedEvents.add(event);
+          },
+        );
+
+        sm.updateRowCells(rows[0], {'name': 'Updated', 'age': 99});
+
+        expect(changedEvents.length, equals(2));
+        expect(changedEvents[0].column.field, equals('name'));
+        expect(changedEvents[0].value, equals('Updated'));
+        expect(changedEvents[1].column.field, equals('age'));
+        expect(changedEvents[1].value, equals(99));
+      });
+
+      test('should not fire callbacks when callOnChangedEvent is false', () {
+        final changedEvents = <TrinaGridOnChangedEvent>[];
+
+        final sm = TrinaGridStateManager(
+          columns: columns,
+          rows: rows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+          onChanged: (event) {
+            changedEvents.add(event);
+          },
+        );
+
+        sm.updateRowCells(rows[0], {
+          'name': 'Updated',
+        }, callOnChangedEvent: false);
+
+        expect(changedEvents.length, equals(0));
+        expect(rows[0].cells['name']!.value, equals('Updated'));
+      });
+
+      test('should fire cell-level onChanged callback', () {
+        TrinaGridOnChangedEvent? cellEvent;
+
+        final testRows = [
+          TrinaRow(
+            cells: {
+              'name': TrinaCell(
+                value: 'Alice',
+                onChanged: (event) {
+                  cellEvent = event;
+                },
+              ),
+              'age': TrinaCell(value: 30),
+            },
+          ),
+        ];
+
+        final sm = TrinaGridStateManager(
+          columns: columns,
+          rows: testRows,
+          gridFocusNode: FocusNode(),
+          scroll: TrinaGridScrollController(),
+        );
+
+        sm.updateRowCells(testRows[0], {'name': 'Updated'});
+
+        expect(cellEvent, isNotNull);
+        expect(cellEvent!.value, equals('Updated'));
+        expect(cellEvent!.oldValue, equals('Alice'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `stateManager.updateRowCells(row, Map<String, dynamic> values)` for batch cell updates
- More efficient than calling `changeCellValue` per cell — only triggers `notifyListeners` once
- Handles filtering, casting, validation, change tracking, and callbacks per cell
- Skips unknown fields, read-only columns, and validation failures gracefully

Closes #308