### PR TITLE
fix: allow scrollPhysics parameter to take effect in body rows

### DIFF
--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -217,7 +217,6 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                     : SingleChildScrollView.new)(
                   controller: _horizontalScroll,
                   scrollDirection: Axis.horizontal,
-                  physics: const ClampingScrollPhysics(),
                   child: CustomSingleChildLayout(
                     delegate: ListResizeDelegate(stateManager, _columns),
                     child: Column(
@@ -240,7 +239,6 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                                 cacheExtent: stateManager.rowsCacheExtent,
                                 controller: _verticalScroll,
                                 scrollDirection: Axis.vertical,
-                                physics: const ClampingScrollPhysics(),
                                 itemCount: _scrollableRows.length,
                                 itemExtent:
                                     (stateManager.rowWrapper != null &&


### PR DESCRIPTION
## Summary
- Removed hardcoded `ClampingScrollPhysics()` from horizontal and vertical scrollables in `trina_body_rows.dart`
- The `scrollPhysics` parameter on `TrinaGrid` was being ignored because body rows overrode it with hardcoded physics
- Now scroll physics flow correctly through `ScrollConfiguration` / `TrinaScrollBehavior`, enabling use cases like nesting inside `InteractiveViewer`

Closes #96