### PR TITLE
feat: Add llm.txt for AI agent discoverability

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -11,3 +11,4 @@
 /build
 pubspec.lock
 /.fvm
+llms-full.txt

--- a/README.md
+++ b/README.md
@@ -552,6 +552,8 @@ TrinaGrid comes with comprehensive documentation covering all features and use c
 
 Visit our [Documentation Index](https://github.com/doonfrs/trina_grid/blob/main/doc/index.md) for a complete overview.
 
+- **[LLM Documentation](llm.txt)** - Machine-readable project summary for AI agents ([full version](llms-full.txt))
+
 ---
 
 ## 🧑‍💻 Examples

--- a/bin/trina_grid.dart
+++ b/bin/trina_grid.dart
@@ -18,6 +18,8 @@ void main(List<String> args) {
 
     // Run the migration tool
     runMigration(migrationArgs);
+  } else if (args.contains('--generate-llms')) {
+    generateLlmsFull();
   } else {
     // Show general help if no specific command is provided
     printUsage();
@@ -330,6 +332,148 @@ int _countOccurrences(String text, String pattern) {
   return count;
 }
 
+void generateLlmsFull() {
+  // Find the repository root by looking for pubspec.yaml
+  var dir = Directory.current;
+  while (!File(path.join(dir.path, 'pubspec.yaml')).existsSync()) {
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      print('Error: Could not find repository root (no pubspec.yaml found).');
+      exit(1);
+    }
+    dir = parent;
+  }
+  final repoRoot = dir.path;
+
+  final llmTxtFile = File(path.join(repoRoot, 'llm.txt'));
+  final docDir = Directory(path.join(repoRoot, 'doc'));
+  final indexFile = File(path.join(repoRoot, 'doc', 'index.md'));
+  final outputFile = File(path.join(repoRoot, 'llms-full.txt'));
+
+  if (!llmTxtFile.existsSync()) {
+    print('Error: llm.txt not found at ${llmTxtFile.path}');
+    exit(1);
+  }
+  if (!docDir.existsSync()) {
+    print('Error: doc/ directory not found at ${docDir.path}');
+    exit(1);
+  }
+
+  const baseUrl = 'https://github.com/doonfrs/trina_grid/blob/main';
+
+  // 1. Extract ordering from doc/index.md by parsing markdown links
+  final orderedPaths = <String>[];
+  if (indexFile.existsSync()) {
+    final indexContent = indexFile.readAsStringSync();
+    // Match markdown links like [text](path.md) or [text](path.md#anchor)
+    final linkPattern = RegExp(r'\]\(([^)#]+\.md)');
+    for (final match in linkPattern.allMatches(indexContent)) {
+      orderedPaths.add(match.group(1)!);
+    }
+  }
+
+  // 2. Discover all .md files in doc/ recursively
+  final allDocFiles = docDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.md'))
+      .toList();
+
+  // Build a map of relative path -> File for quick lookup
+  final fileMap = <String, File>{};
+  for (final file in allDocFiles) {
+    final relativePath =
+        path.relative(file.path, from: docDir.path).replaceAll('\\', '/');
+    fileMap[relativePath] = file;
+  }
+
+  // 3. Build final ordered list: index.md order first, then remaining files
+  //    Skip index.md itself and contributing/ docs (not useful for agents)
+  final processedPaths = <String>{};
+  final finalOrder = <String>[];
+
+  for (final relPath in orderedPaths) {
+    if (fileMap.containsKey(relPath) && !processedPaths.contains(relPath)) {
+      if (relPath == 'index.md') continue;
+      if (relPath.startsWith('contributing/')) continue;
+      if (relPath == 'changelog.md') continue;
+      finalOrder.add(relPath);
+      processedPaths.add(relPath);
+    }
+  }
+
+  // Append any .md files not referenced in index.md
+  final remainingPaths = fileMap.keys
+      .where((p) =>
+          !processedPaths.contains(p) &&
+          p != 'index.md' &&
+          !p.startsWith('contributing/'))
+      .toList()
+    ..sort();
+  finalOrder.addAll(remainingPaths);
+
+  // 4. Extract header from llm.txt (everything before the first ## section)
+  final llmContent = llmTxtFile.readAsStringSync();
+  final firstH2 = llmContent.indexOf('\n## ');
+  final header = firstH2 != -1 ? llmContent.substring(0, firstH2) : llmContent;
+
+  // 5. Generate llms-full.txt
+  final buffer = StringBuffer();
+
+  // Write header with modified H1
+  final headerWithoutH1 =
+      header.replaceFirst(RegExp(r'^# .+'), '').trimLeft();
+  buffer.writeln('# TrinaGrid - Complete Documentation');
+  buffer.writeln();
+  buffer.write(headerWithoutH1);
+  buffer.writeln();
+  buffer.writeln('---');
+  buffer.writeln();
+
+  int filesProcessed = 0;
+  for (final relPath in finalOrder) {
+    final file = fileMap[relPath]!;
+    var content = file.readAsStringSync();
+
+    // Convert the first H1 to H2
+    content = content.replaceFirst(RegExp(r'^# ', multiLine: true), '## ');
+
+    // Convert relative links to absolute GitHub URLs
+    // ../features/foo.md -> absolute URL
+    final docRelDir = path.dirname(relPath).replaceAll('\\', '/');
+    content = content.replaceAllMapped(
+      RegExp(r'\]\((\.\./[^)#]+\.md)(#[^)]+)?\)'),
+      (match) {
+        final linkPath = match.group(1)!;
+        final anchor = match.group(2) ?? '';
+        // Resolve the relative path
+        final resolved =
+            path.normalize('doc/$docRelDir/$linkPath').replaceAll('\\', '/');
+        return ']($baseUrl/$resolved$anchor)';
+      },
+    );
+    // ./foo.md -> absolute URL
+    content = content.replaceAllMapped(
+      RegExp(r'\]\(\./([^)#]+\.md)(#[^)]+)?\)'),
+      (match) {
+        final linkPath = match.group(1)!;
+        final anchor = match.group(2) ?? '';
+        return ']($baseUrl/doc/$docRelDir/$linkPath$anchor)';
+      },
+    );
+
+    buffer.writeln(content);
+    buffer.writeln();
+    buffer.writeln('---');
+    buffer.writeln();
+    filesProcessed++;
+  }
+
+  outputFile.writeAsStringSync(buffer.toString());
+  final lineCount = buffer.toString().split('\n').length;
+  print('Generated llms-full.txt ($filesProcessed doc files, $lineCount lines)');
+}
+
 void printUsage() {
   print('TrinaGrid CLI Tool');
   print('----------------');
@@ -339,9 +483,13 @@ void printUsage() {
   print(
     '  --migrate-from-pluto-grid  Migrate your codebase from PlutoGrid to TrinaGrid',
   );
+  print(
+    '  --generate-llms            Generate llms-full.txt from doc/ files',
+  );
   print('');
-  print('Example:');
+  print('Examples:');
   print('  flutter pub run trina_grid --migrate-from-pluto-grid');
+  print('  flutter pub run trina_grid --generate-llms');
   print('');
   print('For more information on a specific command, run:');
   print('  flutter pub run trina_grid --migrate-from-pluto-grid --help');

--- a/deploy-demo.sh
+++ b/deploy-demo.sh
@@ -32,6 +32,9 @@ mv /tmp/build_web/* .
 
 rm -rf /tmp/build_web
 
+# Copy llm.txt files for AI agent discoverability
+git checkout main -- llm.txt llms-full.txt 2>/dev/null || true
+
 git add .
 git commit -m "🚀 Deploy updated Flutter Web Demo"
 git push origin $BRANCH

--- a/llm.txt
+++ b/llm.txt
@@ -1,0 +1,101 @@
+# TrinaGrid
+
+> TrinaGrid is a powerful, keyboard-navigable data grid widget for Flutter. It supports text, number, date, time, datetime, boolean, select, currency, percentage, and custom column types with built-in editing, filtering, sorting, pagination, and export (CSV, JSON, PDF). It works on web, desktop (Windows, macOS, Linux), and mobile (Android, iOS). Published on pub.dev as `trina_grid`. Fork/continuation of the discontinued PlutoGrid package; an automatic migration tool is included. MIT License.
+
+- Import: `import 'package:trina_grid/trina_grid.dart';`
+- Main widget: `TrinaGrid(columns: [...], rows: [...], onLoaded: (event) { stateManager = event.stateManager; })`
+- Core models: `TrinaColumn(title, field, type)`, `TrinaRow(cells: {'field': TrinaCell(value: ...)})`, `TrinaCell(value)`
+- Column types: `TrinaColumnType.text()`, `.number()`, `.date()`, `.time()`, `.dateTime()`, `.boolean()`, `.select(items)`, `.currency()`, `.percentage()`, `.custom()`
+- State management: `TrinaGridStateManager` — obtained from `onLoaded` callback via `event.stateManager`
+- Configuration: `TrinaGridConfiguration` — styles, scrollbars, column sizing, selection mode, keyboard shortcuts
+- Pagination: `TrinaPagination` (client-side), `TrinaLazyPagination` (server-side), `TrinaInfinityScrollRows`
+- Export: `TrinaGridExportCsv`, `TrinaGridExportJson`, `TrinaGridExportPdf`
+- Dual grid: `TrinaDualGrid` (two grids side by side), `TrinaGridPopup` (popup selection grid)
+- Column groups: `TrinaColumnGroup` — group columns under a shared header
+- Custom renderers: `TrinaColumn.renderer` for cells, `TrinaColumn.titleRenderer` for headers, `TrinaColumn.footerRenderer` for footers
+
+## Docs
+
+- [Full Documentation for LLMs](https://raw.githubusercontent.com/doonfrs/trina_grid/main/llms-full.txt): All documentation inlined in a single file for LLM consumption
+- [Documentation Index](https://github.com/doonfrs/trina_grid/blob/main/doc/index.md): Complete documentation table of contents
+- [Installation](https://github.com/doonfrs/trina_grid/blob/main/doc/getting-started/installation.md): Adding trina_grid to your project
+- [Basic Usage](https://github.com/doonfrs/trina_grid/blob/main/doc/getting-started/basic-usage.md): Creating columns, rows, cells and the grid widget
+- [Configuration](https://github.com/doonfrs/trina_grid/blob/main/doc/getting-started/configuration.md): TrinaGridConfiguration options
+
+## Column Features
+
+- [Column Types](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-types.md): All column type options with properties and examples
+- [Column Freezing](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-freezing.md): Pin columns to left or right
+- [Column Resizing](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-resizing.md): Resize column widths
+- [Column Moving](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-moving.md): Reorder columns by drag
+- [Column Hiding](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-hiding.md): Show/hide columns programmatically
+- [Column Sorting](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-sorting.md): Click-to-sort with custom sort icons
+- [Column Filtering](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-filtering.md): Built-in filter widgets including multi-item filters
+- [Column Groups](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-groups.md): Group related columns under a shared header
+- [Column Renderers](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-renderer.md): Custom widgets for column cells
+- [Column Title Renderer](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-title-renderer.md): Custom header widgets
+- [Column Footer](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-footer.md): Aggregate values at column bottom
+- [Column Visibility](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-visibility.md): Viewport visibility tracking
+
+## Row Features
+
+- [Row Selection](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-selection.md): Single and multi-row selection modes
+- [Row Moving](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-moving.md): Drag to reorder rows
+- [Row Coloring](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-color.md): Conditional row background colors
+- [Row Wrapper](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-wrapper.md): Wrap rows with custom widgets
+- [Row Checking](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-checking.md): Checkbox selection for rows
+- [Row Groups](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-groups.md): Group rows with expandable sections
+- [Frozen Rows](https://github.com/doonfrs/trina_grid/blob/main/doc/features/frozen-rows.md): Pin rows to top or bottom
+- [Dynamic Row Heights](https://github.com/doonfrs/trina_grid/blob/main/doc/features/dynamic-row-heights.md): Variable height rows
+- [Row Custom Data](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-custom-data.md): Attach metadata to rows
+
+## Cell Features
+
+- [Cell Selection](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-selection.md): Cell focus and selection
+- [Cell Editing](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-editing.md): In-place cell editing with type-specific editors
+- [Cell Navigation Validation](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-navigation-validation.md): Control cell navigation
+- [Cell Renderers](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-renderer.md): Custom widgets for cell display
+- [Cell Validation](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-validation.md): Validate cell input with error callbacks
+- [Cell Value Change Handling](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell_value_change_handling.md): React to cell value changes
+- [Cell Color](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-color.md): Conditional cell background colors
+
+## Data Management
+
+- [Pagination Overview](https://github.com/doonfrs/trina_grid/blob/main/doc/features/pagination.md): Client-side and server-side pagination
+- [Client-Side Pagination](https://github.com/doonfrs/trina_grid/blob/main/doc/features/pagination-client.md): TrinaPagination widget
+- [Lazy Pagination](https://github.com/doonfrs/trina_grid/blob/main/doc/features/lazy-pagination.md): Server-side pagination with TrinaLazyPagination
+- [Lazy Pagination Events](https://github.com/doonfrs/trina_grid/blob/main/doc/features/lazy-pagination-events.md): Events for lazy pagination
+- [Infinite Scrolling](https://github.com/doonfrs/trina_grid/blob/main/doc/features/infinite-scrolling.md): Load more rows on scroll
+- [Lazy Loading](https://github.com/doonfrs/trina_grid/blob/main/doc/features/lazy-loading.md): Load data on demand
+- [Copy & Paste](https://github.com/doonfrs/trina_grid/blob/main/doc/features/copy-paste.md): Clipboard support
+- [Export](https://github.com/doonfrs/trina_grid/blob/main/doc/features/export.md): CSV, JSON, and PDF export
+
+## UI Customization
+
+- [Loading Options](https://github.com/doonfrs/trina_grid/blob/main/doc/features/loading-options.md): Loading indicator configuration
+- [Scrollbars](https://github.com/doonfrs/trina_grid/blob/main/doc/features/scrollbars.md): Draggable, customizable scrollbars
+
+## Other Features
+
+- [Context Menus](https://github.com/doonfrs/trina_grid/blob/main/doc/features/context-menus.md): Right-click menus for columns and cells
+- [Dual Grid Mode](https://github.com/doonfrs/trina_grid/blob/main/doc/features/dual-grid-mode.md): Two linked grids side by side
+- [Change Tracking](https://github.com/doonfrs/trina_grid/blob/main/doc/features/change-tracking.md): Track dirty cells, commit or revert changes
+
+## Examples
+
+- [Custom Renderers](https://github.com/doonfrs/trina_grid/blob/main/doc/examples/custom-renderers.md): Column and cell renderer examples
+- [Dynamic Row Heights](https://github.com/doonfrs/trina_grid/blob/main/doc/examples/dynamic-row-heights.md): Variable height rows example
+- [Live Demo](https://doonfrs.github.io/trina_grid/): Interactive Flutter web demo
+
+## Migration
+
+- [Migration from PlutoGrid](https://github.com/doonfrs/trina_grid/blob/main/doc/migration/pluto-to-trina.md): Automatic migration tool and manual steps
+- [Migration Tool Reference](https://github.com/doonfrs/trina_grid/blob/main/doc/migration/migration-tool.md): CLI tool usage
+- [Dynamic Row Heights Migration](https://github.com/doonfrs/trina_grid/blob/main/doc/migration/dynamic-row-heights-migration.md): Migrating dynamic row heights
+
+## Source
+
+- [README](https://github.com/doonfrs/trina_grid/blob/main/README.md): Full README with feature overview and code examples
+- [CHANGELOG](https://github.com/doonfrs/trina_grid/blob/main/CHANGELOG.md): Version history and release notes
+- [pub.dev](https://pub.dev/packages/trina_grid): Package page on pub.dev
+- [GitHub Repository](https://github.com/doonfrs/trina_grid): Source code, issues, contributions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,15686 @@
+# TrinaGrid - Complete Documentation
+
+> TrinaGrid is a powerful, keyboard-navigable data grid widget for Flutter. It supports text, number, date, time, datetime, boolean, select, currency, percentage, and custom column types with built-in editing, filtering, sorting, pagination, and export (CSV, JSON, PDF). It works on web, desktop (Windows, macOS, Linux), and mobile (Android, iOS). Published on pub.dev as `trina_grid`. Fork/continuation of the discontinued PlutoGrid package; an automatic migration tool is included. MIT License.
+
+- Import: `import 'package:trina_grid/trina_grid.dart';`
+- Main widget: `TrinaGrid(columns: [...], rows: [...], onLoaded: (event) { stateManager = event.stateManager; })`
+- Core models: `TrinaColumn(title, field, type)`, `TrinaRow(cells: {'field': TrinaCell(value: ...)})`, `TrinaCell(value)`
+- Column types: `TrinaColumnType.text()`, `.number()`, `.date()`, `.time()`, `.dateTime()`, `.boolean()`, `.select(items)`, `.currency()`, `.percentage()`, `.custom()`
+- State management: `TrinaGridStateManager` — obtained from `onLoaded` callback via `event.stateManager`
+- Configuration: `TrinaGridConfiguration` — styles, scrollbars, column sizing, selection mode, keyboard shortcuts
+- Pagination: `TrinaPagination` (client-side), `TrinaLazyPagination` (server-side), `TrinaInfinityScrollRows`
+- Export: `TrinaGridExportCsv`, `TrinaGridExportJson`, `TrinaGridExportPdf`
+- Dual grid: `TrinaDualGrid` (two grids side by side), `TrinaGridPopup` (popup selection grid)
+- Column groups: `TrinaColumnGroup` — group columns under a shared header
+- Custom renderers: `TrinaColumn.renderer` for cells, `TrinaColumn.titleRenderer` for headers, `TrinaColumn.footerRenderer` for footers
+
+---
+
+## Installation
+
+Adding TrinaGrid to your Flutter project is straightforward. Follow these steps to get started:
+
+## 1. Add Dependency
+
+Add the following dependency to your `pubspec.yaml` file:
+
+```yaml
+dependencies:
+  trina_grid: <latest_version>
+```
+
+## 2. Install Package
+
+Run the following command to install the package:
+
+```bash
+flutter pub get
+```
+
+## 3. Import Package
+
+Import the package in your Dart code:
+
+```dart
+import 'package:trina_grid/trina_grid.dart';
+```
+
+## 4. Optional Dependencies
+
+## Platform-Specific Considerations
+
+### Web
+
+TrinaGrid works well on the web platform without any additional configuration.
+
+### Desktop (Windows, macOS, Linux)
+
+TrinaGrid is optimized for desktop platforms with keyboard navigation and shortcuts.
+
+### Mobile (Android, iOS)
+
+While TrinaGrid works on mobile platforms, it's primarily designed for larger screens. Consider the following when using on mobile:
+
+- Use appropriate column widths for smaller screens
+- Consider using fewer columns for better usability
+- Test scrolling and touch interactions thoroughly
+
+## Compatibility
+
+TrinaGrid requires:
+
+- Flutter 3.0.0 or higher
+- Dart 2.17.0 or higher
+
+## Troubleshooting
+
+If you encounter any issues during installation:
+
+1. Make sure you have the correct version specified in your pubspec.yaml
+2. Run `flutter clean` followed by `flutter pub get`
+3. Restart your IDE
+4. Check for any conflicting dependencies
+
+If problems persist, please [open an issue](https://github.com/doonfrs/trina_grid/issues) on GitHub.
+
+
+---
+
+## Basic Usage
+
+This guide will walk you through creating a simple TrinaGrid implementation.
+
+## Creating a Basic Grid
+
+Here's a complete example of a basic TrinaGrid implementation:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'TrinaGrid Basic Example',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key? key}) : super(key: key);
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        width: 100,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+      TrinaColumn(
+        title: 'Age',
+        field: 'age',
+        type: TrinaColumnType.number(),
+        width: 100,
+      ),
+      TrinaColumn(
+        title: 'Role',
+        field: 'role',
+        type: TrinaColumnType.select(['Developer', 'Designer', 'Manager']),
+        width: 150,
+      ),
+    ]);
+    
+    // Create rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '1'),
+          'name': TrinaCell(value: 'John Doe'),
+          'age': TrinaCell(value: 28),
+          'role': TrinaCell(value: 'Developer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '2'),
+          'name': TrinaCell(value: 'Jane Smith'),
+          'age': TrinaCell(value: 32),
+          'role': TrinaCell(value: 'Designer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '3'),
+          'name': TrinaCell(value: 'Mike Johnson'),
+          'age': TrinaCell(value: 45),
+          'role': TrinaCell(value: 'Manager'),
+        },
+      ),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('TrinaGrid Basic Example'),
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(16),
+        child: TrinaGrid(
+          columns: columns,
+          rows: rows,
+          onLoaded: (TrinaGridOnLoadedEvent event) {
+            stateManager = event.stateManager;
+          },
+          onChanged: (TrinaGridOnChangedEvent event) {
+            print('Cell changed: ${event.value}');
+          },
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Key Components
+
+### 1. Columns
+
+Columns define the structure of your grid. Each column needs:
+
+- `title`: The text displayed in the column header
+- `field`: A unique identifier for the column
+- `type`: The data type (text, number, select, date, time, etc.)
+- `width`: The width of the column (optional, but recommended)
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  width: 200,
+)
+```
+
+### 2. Rows
+
+Rows contain the data displayed in the grid. Each row consists of cells that correspond to the columns:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: '1'),
+    'name': TrinaCell(value: 'John Doe'),
+    'age': TrinaCell(value: 28),
+    'role': TrinaCell(value: 'Developer'),
+  },
+)
+```
+
+### 3. StateManager
+
+The `TrinaGridStateManager` provides methods to control the grid programmatically:
+
+```dart
+late TrinaGridStateManager stateManager;
+
+// In your onLoaded callback:
+onLoaded: (TrinaGridOnLoadedEvent event) {
+  stateManager = event.stateManager;
+},
+```
+
+## Column Types
+
+TrinaGrid supports various column types:
+
+### Text
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+)
+```
+
+### Number
+
+```dart
+TrinaColumn(
+  title: 'Age',
+  field: 'age',
+  type: TrinaColumnType.number(),
+)
+```
+
+### Select
+
+```dart
+TrinaColumn(
+  title: 'Role',
+  field: 'role',
+  type: TrinaColumnType.select(['Developer', 'Designer', 'Manager']),
+)
+```
+
+### Date
+
+```dart
+TrinaColumn(
+  title: 'Birth Date',
+  field: 'birth_date',
+  type: TrinaColumnType.date(),
+)
+```
+
+### Time
+
+```dart
+TrinaColumn(
+  title: 'Start Time',
+  field: 'start_time',
+  type: TrinaColumnType.time(),
+)
+```
+
+### Currency
+
+```dart
+TrinaColumn(
+  title: 'Salary',
+  field: 'salary',
+  type: TrinaColumnType.currency(
+    symbol: '\$',
+    decimalDigits: 2,
+  ),
+)
+```
+
+## Event Handling
+
+### onLoaded
+
+Called when the grid is first loaded:
+
+```dart
+onLoaded: (TrinaGridOnLoadedEvent event) {
+  stateManager = event.stateManager;
+},
+```
+
+### onChanged
+
+Called when a cell value is changed:
+
+```dart
+onChanged: (TrinaGridOnChangedEvent event) {
+  print('Cell changed: ${event.value}');
+},
+```
+
+### Other Events
+
+TrinaGrid provides many other events for specific interactions:
+
+- `onSelected`: Called when a cell or row is selected
+- `onRowChecked`: Called when a row checkbox is toggled
+- `onSorted`: Called when columns are sorted
+- `onRowsMoved`: Called when rows are moved
+
+## Next Steps
+
+Now that you understand the basics, explore more advanced features:
+
+- [Column Configuration](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-types.md)
+- [Row Operations](https://github.com/doonfrs/trina_grid/blob/main/doc/features/row-selection.md)
+- [Cell Customization](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-renderer.md)
+- [Styling and Theming](https://github.com/doonfrs/trina_grid/blob/main/doc/features/themes.md)
+
+
+---
+
+## Configuration
+
+TrinaGrid offers extensive configuration options to customize its appearance and behavior. This guide covers the main configuration options available.
+
+## TrinaGridConfiguration
+
+The `TrinaGridConfiguration` class is the main way to configure TrinaGrid. You can pass it to the `configuration` parameter of the `TrinaGrid` widget:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    // Configuration options here
+  ),
+)
+```
+
+## Basic Configuration
+
+### Style Configuration
+
+The `style` property allows you to customize the visual appearance of the grid:
+
+```dart
+TrinaGridConfiguration(
+  style: TrinaGridStyleConfig(
+    // Colors
+    gridBackgroundColor: Colors.white,
+    borderColor: Colors.grey[300]!,
+    activatedBorderColor: Colors.blue,
+    activatedColor: Colors.blue.withOpacity(0.2),
+    inactivatedBorderColor: Colors.grey[300]!,
+    
+    // Cell styles
+    cellColorInEditState: Colors.white,
+    cellColorInReadOnlyState: Colors.grey[200]!,
+    cellHorizontalBorderWidth: 1.0,
+    cellVerticalBorderWidth: 1.0,
+    
+    // Text styles
+    columnTextStyle: TextStyle(
+      color: Colors.black,
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+    ),
+    cellTextStyle: TextStyle(
+      color: Colors.black,
+      fontSize: 14,
+    ),
+    
+    // Sizes
+    rowHeight: 45,
+    columnHeight: 45,
+    columnFilterHeight: 45,
+    
+    // Icons
+    iconSize: 18,
+    iconColor: Colors.black54,
+    
+    // Filter colors
+    filterHeaderColor: Colors.blue[50],      // Filter row background & input fields
+    filterPopupHeaderColor: Colors.grey[100], // Filter popup headers
+    filterHeaderIconColor: Colors.blue,      // Filter icons (indicators, controls)
+    
+    // Even/odd row colors
+    oddRowColor: Colors.grey[100],
+    evenRowColor: Colors.white,
+  ),
+)
+```
+
+### Filter Color Configuration
+
+The filter color properties allow you to customize the appearance of filter-related elements:
+
+- **`filterHeaderColor`**: Background color for the main grid filter row and filter input fields (text fields, multiline inputs)
+- **`filterPopupHeaderColor`**: Background color for filter popup headers (used in separate popup dialogs)
+- **`filterHeaderIconColor`**: Color for filter-related icons (filter indicators in column titles, clear/edit buttons in multiline filters)
+
+```dart
+TrinaGridConfiguration(
+  style: TrinaGridStyleConfig(
+    // Main grid filter row styling
+    filterHeaderColor: Colors.lightBlue[50],
+    
+    // Popup filter header styling  
+    filterPopupHeaderColor: Colors.grey[200],
+    
+    // Filter icon coloring
+    filterHeaderIconColor: Colors.blue,
+    
+    // Regular icons (fallback)
+    iconColor: Colors.grey[600],
+  ),
+)
+```
+
+**Priority System:**
+- Filter inputs use `filterHeaderColor` first, then fall back to `cellColorInEditState`/`cellColorInReadOnlyState`
+- Filter icons use `filterHeaderIconColor` first, then fall back to `iconColor`
+- All properties are optional and maintain backward compatibility
+
+### Scrollbar Configuration
+
+Configure the scrollbars with the `scrollbar` property:
+
+```dart
+TrinaGridConfiguration(
+  scrollbar: TrinaGridScrollbarConfig(
+    // Visibility settings
+    isAlwaysShown: true,      // Prevents scrollbars from fading out after scrolling stops
+    thumbVisible: true,       // Whether the scrollbar thumb is visible at all
+    showTrack: true,          // Whether to show the scrollbar track background
+    showHorizontal: true,     // Whether to show the horizontal scrollbar
+    showVertical: true,       // Whether to show the vertical scrollbar
+    
+    // Appearance settings
+    thickness: 8.0,
+    minThumbLength: 40.0,
+    thumbColor: Colors.blue.withOpacity(0.6),
+    trackColor: Colors.grey.withOpacity(0.2),
+    thumbHoverColor: Colors.blue.withOpacity(0.8),
+    trackHoverColor: Colors.grey.withOpacity(0.3),
+    isDraggable: true,
+  ),
+)
+```
+
+The `TrinaGridScrollbarConfig` provides the following options:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `isAlwaysShown` | `bool` | `false` | If true, scrollbars remain visible all the time. If false, they appear during scrolling and fade out after about 3 seconds of inactivity. |
+| `thumbVisible` | `bool` | `true` | Whether the scrollbar thumb is visible at all. If false, scrollbars won't show even during scrolling. |
+| `showTrack` | `bool` | `true` | Whether to show the scrollbar track background. |
+| `showHorizontal` | `bool` | `true` | Whether to show the horizontal scrollbar. |
+| `showVertical` | `bool` | `true` | Whether to show the vertical scrollbar. |
+| `thickness` | `double` | `8.0` | Thickness of the scrollbar. |
+| `minThumbLength` | `double` | `40.0` | Minimum length of the scrollbar thumb. |
+| `thumbColor` | `Color?` | `null` | Color of the scrollbar thumb. |
+| `trackColor` | `Color?` | `null` | Color of the scrollbar track. |
+| `thumbHoverColor` | `Color?` | `null` | Color of the scrollbar thumb when hovered. |
+| `trackHoverColor` | `Color?` | `null` | Color of the scrollbar track when hovered. |
+| `isDraggable` | `bool` | `true` | Whether scrollbar thumbs can be dragged with mouse or touch to scroll. |
+
+For more detailed information about scrollbar customization, see the [Scrollbars](https://github.com/doonfrs/trina_grid/blob/main/doc/features/scrollbars.md) feature documentation.
+
+### Column Configuration
+
+Set default column behavior:
+
+```dart
+TrinaGridConfiguration(
+  columnSize: TrinaGridColumnSizeConfig(
+    autoSizeMode: TrinaAutoSizeMode.scale,
+    resizeMode: TrinaResizeMode.normal,
+  ),
+)
+```
+
+## Behavior Configuration
+
+### Selection Mode
+
+Configure how cells or rows can be selected:
+
+```dart
+TrinaGridConfiguration(
+  selectingMode: TrinaGridSelectingMode.cell, // or row, none
+)
+```
+
+The available selection modes are:
+
+- `TrinaGridSelectingMode.cell`: Allows selection of individual cells or ranges of cells
+- `TrinaGridSelectingMode.row`: Selects entire rows when clicking on any cell  
+- `TrinaGridSelectingMode.none`: Disables selection functionality
+
+Note: This setting may be overridden by the grid mode:
+
+- In `TrinaGridMode.select` or `TrinaGridMode.selectWithOneTap`, it's forced to `TrinaGridSelectingMode.none`
+- In `TrinaGridMode.multiSelect`, it's forced to `TrinaGridSelectingMode.row`
+
+### Editing Configuration
+
+Control editing behavior:
+
+```dart
+TrinaGridConfiguration(
+  enableMoveDownAfterSelecting: true,
+  enterKeyAction: TrinaGridEnterKeyAction.editingAndMoveDown,
+  enableEditingMode: true,
+)
+```
+
+### Copy & Paste Configuration
+
+Configure custom separators for copy and paste operations:
+
+```dart
+TrinaGridConfiguration(
+  // Cell separator (default: null, which uses tab '\t')
+  copyPasteCellSeparator: '\t',  // or ',' for CSV format
+
+  // Line separator (default: null, which uses platform-specific line endings)
+  // null = CRLF ('\r\n') on Windows, LF ('\n') on macOS/Linux
+  copyPasteLineSeparator: '\n',  // Force LF on all platforms
+)
+```
+
+**Configuration Options:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `copyPasteCellSeparator` | `String?` | `null` | Separator between cells in the same row. When `null`, uses tab (`\t`) for spreadsheet compatibility. |
+| `copyPasteLineSeparator` | `String?` | `null` | Separator between rows. When `null`, uses platform-specific line endings (CRLF on Windows, LF on macOS/Linux). |
+
+**Common Use Cases:**
+
+```dart
+// CSV format - comma-separated with LF line endings
+TrinaGridConfiguration(
+  copyPasteCellSeparator: ',',
+  copyPasteLineSeparator: '\n',
+)
+
+// Excel-compatible format with platform-specific line endings
+TrinaGridConfiguration(
+  copyPasteCellSeparator: '\t',
+  copyPasteLineSeparator: null,  // Uses platform-specific
+)
+
+// Custom format - pipe-separated
+TrinaGridConfiguration(
+  copyPasteCellSeparator: '|',
+  copyPasteLineSeparator: '\n',
+)
+```
+
+For more details, see the [Copy & Paste](https://github.com/doonfrs/trina_grid/blob/main/doc/features/copy-paste.md) feature documentation.
+
+### Keyboard Navigation
+
+Configure keyboard shortcuts:
+
+```dart
+TrinaGridConfiguration(
+  shortcut: TrinaGridShortcut(
+    actions: {
+      // Custom shortcuts
+      LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyA):
+          TrinaGridShortcutAction.selectAll,
+    },
+  ),
+)
+```
+
+## Predefined Configurations
+
+TrinaGrid provides some predefined configurations:
+
+### Dark Mode
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration.dark(),
+)
+```
+
+### Custom Theme
+
+You can create your own theme by extending the default configuration:
+
+```dart
+final myTheme = TrinaGridConfiguration(
+  style: TrinaGridStyleConfig(
+    gridBackgroundColor: Colors.indigo[50]!,
+    borderColor: Colors.indigo[300]!,
+    activatedBorderColor: Colors.indigo,
+    activatedColor: Colors.indigo.withOpacity(0.2),
+    columnTextStyle: const TextStyle(
+      color: Colors.indigo[900]!,
+      fontWeight: FontWeight.bold,
+    ),
+    cellTextStyle: TextStyle(
+      color: Colors.indigo[900]!,
+    ),
+    iconColor: Colors.indigo,
+  ),
+);
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: myTheme,
+)
+```
+
+## Column-Specific Configuration
+
+Many configuration options can be set at the column level, which will override the global configuration:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  width: 200,
+  // Column-specific configuration
+  textAlign: TrinaColumnTextAlign.center,
+  titleTextAlign: TrinaColumnTextAlign.center,
+  enableSorting: true,
+  enableFilterMenuItem: true,
+  enableContextMenu: true,
+  enableDropToResize: true,
+  enableRowDrag: false,
+  enableRowChecked: false,
+  enableEditingMode: true,
+  readOnly: false,
+  // Override Enter key behavior for this column's filter
+  filterEnterKeyAction: TrinaGridEnterKeyAction.none,
+)
+```
+
+## Row-Specific Configuration
+
+Rows can also have specific configurations:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: '1'),
+    'name': TrinaCell(value: 'John Doe'),
+  },
+  // Row-specific configuration
+  checked: true,
+  type: TrinaRowType.normal(), // or group
+)
+```
+
+## Cell-Specific Configuration
+
+Individual cells can have their own configuration:
+
+```dart
+TrinaCell(
+  value: 'John Doe',
+  // Cell-specific configuration
+  renderer: (context) => Text(
+    context.cell.value.toString(),
+    style: const TextStyle(fontWeight: FontWeight.bold),
+  ),
+  // Custom padding for this specific cell
+  padding: const EdgeInsets.all(16.0),
+)
+```
+
+### Cell-Level Padding
+
+Cells can override the default padding with the `padding` property. The padding system follows a priority hierarchy:
+
+1. **Cell padding** (highest priority) - Custom padding set on individual cells
+2. **Column padding** - Padding defined at the column level with `cellPadding`
+3. **Configuration padding** (lowest priority) - Global default padding from grid configuration
+
+```dart
+// Examples of cell-level padding
+TrinaCell(
+  value: 'Emphasized Cell',
+  padding: const EdgeInsets.all(20.0), // More padding for emphasis
+)
+
+TrinaCell(
+  value: 'Compact Cell',
+  padding: const EdgeInsets.symmetric(vertical: 4.0), // Less vertical space
+)
+
+TrinaCell(
+  value: 'Asymmetric Cell',
+  padding: const EdgeInsets.only(left: 16.0, right: 8.0), // Different sides
+)
+```
+
+## Complete Configuration Example
+
+Here's a complete example showing various configuration options:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    stateManager = event.stateManager;
+  },
+  configuration: TrinaGridConfiguration(
+    // Style configuration
+    style: TrinaGridStyleConfig(
+      gridBackgroundColor: Colors.white,
+      borderColor: Colors.grey[300]!,
+      activatedBorderColor: Colors.blue,
+      activatedColor: Colors.blue.withOpacity(0.2),
+      cellTextStyle: const TextStyle(fontSize: 14),
+      columnTextStyle: const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.bold,
+      ),
+      rowHeight: 45,
+      columnHeight: 45,
+      iconSize: 18,
+      iconColor: Colors.blue,
+      enableCellBorderHorizontal: true,
+      enableCellBorderVertical: true,
+      cellVerticalBorderWidth: 1.0,
+      cellHorizontalBorderWidth: 1.0,
+      gridBorderRadius: BorderRadius.circular(8),
+      gridPopupBorderRadius: BorderRadius.circular(8),
+      enableGridBorderShadow: true,
+      oddRowColor: Colors.grey[100],
+      evenRowColor: Colors.white,
+    ),
+    
+    // Scrollbar configuration
+    scrollbar: TrinaGridScrollbarConfig(
+      isAlwaysShown: true,         // Always show scrollbars
+      thumbVisible: true,          // Show scrollbar thumbs
+      showTrack: true,             // Show scrollbar tracks
+      thickness: 8.0,              // Scrollbar thickness
+      minThumbLength: 40.0,        // Minimum thumb length
+      thumbColor: Colors.blue.withOpacity(0.6),  // Thumb color
+      trackColor: Colors.grey.withOpacity(0.2),  // Track color
+      thumbHoverColor: Colors.blue.withOpacity(0.8),
+      trackHoverColor: Colors.grey.withOpacity(0.3),
+      isDraggable: true,
+    ),
+    
+    // Column configuration
+    columnSize: const TrinaGridColumnSizeConfig(
+      autoSizeMode: TrinaAutoSizeMode.scale,
+      resizeMode: TrinaResizeMode.normal,
+    ),
+    
+    // Behavior configuration
+    enableMoveDownAfterSelecting: true,
+    enterKeyAction: TrinaGridEnterKeyAction.editingAndMoveDown,
+    selectingMode: TrinaGridSelectingMode.cell,
+
+    // Copy & Paste configuration
+    copyPasteCellSeparator: null,  // Uses default tab separator
+    copyPasteLineSeparator: null,  // Uses platform-specific line endings
+
+    // Keyboard shortcuts
+    shortcut: TrinaGridShortcut(
+      actions: {
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyA):
+            TrinaGridShortcutAction.selectAll,
+      },
+    ),
+  ),
+)
+```
+
+> **Note:** While most keyboard behavior is configured at the grid level with `enterKeyAction`, you can override the Enter key behavior for specific column filters using the `filterEnterKeyAction` property on individual columns. See [Column Filtering](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-filtering.md#controlling-keyboard-navigation-in-column-filters) for more details.
+
+## Next Steps
+
+- [Column Types](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-types.md)
+- [Cell Renderers](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-renderer.md)
+- [Custom Styling](https://github.com/doonfrs/trina_grid/blob/main/doc/features/custom-styling.md)
+
+
+---
+
+## Migrating from PlutoGrid to TrinaGrid
+
+This guide will help you migrate your existing PlutoGrid implementation to TrinaGrid. TrinaGrid is a maintained and enhanced version of PlutoGrid, offering improved performance, additional features, and ongoing support.
+
+## Automatic Migration Tool
+
+TrinaGrid includes a migration tool that automatically replaces PlutoGrid references with their TrinaGrid equivalents in your codebase. For a quick reference, see the [Migration Tool Guide](migration-tool.md).
+
+### Using the Migration Tool
+
+1. First, add TrinaGrid to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  trina_grid: <latest_version>
+```
+
+2. Run `flutter pub get` to install the package.
+
+3. Run the migration tool with a dry run to see what changes would be made:
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --dry-run
+```
+
+4. Apply the changes:
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid
+```
+
+5. For more thorough scanning (including build and platform-specific directories):
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --scan-all
+```
+
+### Migration Tool Options
+
+- `--dry-run`: Show changes without applying them
+- `--dir`, `-d`: Specify the directory to migrate (defaults to current directory)
+- `--verbose`, `-v`: Show detailed output
+- `--scan-all`: Scan all directories, including build and platform-specific directories
+- `--help`, `-h`: Show help message
+
+## What Gets Replaced
+
+The migration tool automatically replaces:
+
+- Package imports:
+  - `import 'package:pluto_grid/pluto_grid.dart'` → `import 'package:trina_grid/trina_grid.dart'`
+  - `import 'package:pluto_grid_plus/pluto_grid_plus.dart'` → `import 'package:trina_grid/trina_grid.dart'`
+
+- Package references in pubspec.yaml:
+  - `pluto_grid:` → `trina_grid:`
+  - `pluto_grid_plus:` → `trina_grid:`
+
+- Class names and components:
+  - `PlutoGrid` → `TrinaGrid`
+  - `PlutoColumn` → `TrinaColumn`
+  - `PlutoRow` → `TrinaRow`
+  - `PlutoCell` → `TrinaCell`
+  - And many more (see complete list below)
+
+## Complete Class Mapping
+
+### Main Components
+
+- `PlutoGrid` → `TrinaGrid`
+
+### Column Related
+
+- `PlutoColumn` → `TrinaColumn`
+- `PlutoColumnGroup` → `TrinaColumnGroup`
+- `PlutoColumnType` → `TrinaColumnType`
+- `PlutoColumnSort` → `TrinaColumnSort`
+- `PlutoColumnFreeze` → `TrinaColumnFreeze`
+- `PlutoColumnTextAlign` → `TrinaColumnTextAlign`
+
+### Row Related
+
+- `PlutoRow` → `TrinaRow`
+- `PlutoRowType` → `TrinaRowType`
+- `PlutoRowColorContext` → `TrinaRowColorContext`
+
+### Cell Related
+
+- `PlutoCell` → `TrinaCell`
+- `PlutoCellDisplayType` → `TrinaCellDisplayType`
+
+### State Management
+
+- `PlutoGridStateManager` → `TrinaGridStateManager`
+- `PlutoNotifierEvent` → `TrinaNotifierEvent`
+- `PlutoGridEventManager` → `TrinaGridEventManager`
+
+### Selection
+
+- `PlutoGridSelectingMode` → `TrinaGridSelectingMode`
+
+### Other Components
+
+- `PlutoGridConfiguration` → `TrinaGridConfiguration`
+- `PlutoGridScrollbarConfig` → `TrinaGridScrollbarConfig`
+- `PlutoGridStyleConfig` → `TrinaGridStyleConfig`
+- `PlutoGridLocaleText` → `TrinaGridLocaleText`
+- `PlutoGridKeyManager` → `TrinaGridKeyManager`
+- `PlutoGridKeyPressed` → `TrinaGridKeyPressed`
+
+### Enums and Constants
+
+- `PlutoGridMode` → `TrinaGridMode`
+- `PlutoGridScrollUpdateEvent` → `TrinaGridScrollUpdateEvent`
+- `PlutoGridScrollAnimationEvent` → `TrinaGridScrollAnimationEvent`
+- `PlutoMoveDirection` → `TrinaMoveDirection`
+
+### Widgets
+
+- `PlutoBaseCell` → `TrinaBaseCell`
+- `PlutoBaseColumn` → `TrinaBaseColumn`
+- `PlutoBaseRow` → `TrinaBaseRow`
+
+### Additional Components
+
+- `
+
+
+---
+
+## TrinaGrid Migration Tool
+
+TrinaGrid includes a powerful migration tool that helps you automatically update your codebase when migrating from PlutoGrid.
+
+## Quick Start
+
+```bash
+# Add trina_grid to your pubspec.yaml and run flutter pub get
+
+# Run a dry run to see what changes would be made
+flutter pub run trina_grid --migrate-from-pluto-grid --dry-run
+
+# Apply the changes
+flutter pub run trina_grid --migrate-from-pluto-grid
+```
+
+## Command Options
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Show changes without applying them |
+| `--dir`, `-d` | Specify the directory to migrate (defaults to current directory) |
+| `--verbose`, `-v` | Show detailed output |
+| `--scan-all` | Scan all directories, including build and platform-specific directories |
+| `--help`, `-h` | Show help message |
+
+## Examples
+
+### Dry Run
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --dry-run
+```
+
+This will scan your project and show what changes would be made without actually applying them.
+
+### Migrate a Specific Directory
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --dir=lib/screens
+```
+
+This will only scan and migrate files in the specified directory.
+
+### Verbose Output
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --verbose
+```
+
+This will show detailed information about each replacement made.
+
+### Scan All Directories
+
+```bash
+flutter pub run trina_grid --migrate-from-pluto-grid --scan-all
+```
+
+By default, the migration tool skips certain directories like `build`, `.dart_tool`, and platform-specific directories. This option forces the tool to scan all directories.
+
+## How It Works
+
+The migration tool:
+
+1. Scans your project for files with `.dart`, `.yaml`, and `.json` extensions
+2. Searches for PlutoGrid references in these files
+3. Replaces them with their TrinaGrid equivalents
+4. Cleans up any redundant imports
+
+## Troubleshooting
+
+### Common Issues
+
+- **No changes detected**: Make sure you're running the command from your project root directory.
+- **Missing replacements**: Use the `--scan-all` flag to ensure all directories are scanned.
+- **Build errors after migration**: Check that all PlutoGrid references have been replaced.
+
+### Getting Help
+
+If you encounter any issues with the migration tool:
+
+- Check the [full migration guide](pluto-to-trina.md)
+- Open an issue on the [TrinaGrid GitHub repository](https://github.com/doonfrs/trina_grid/issues)
+- Reach out to the maintainer [Feras Abdulrahman](https://github.com/doonfrs) 
+
+---
+
+## Dynamic Row Heights Migration Guide
+
+This guide helps existing TrinaGrid users migrate to the new dynamic row heights feature.
+
+## Overview
+
+The dynamic row heights feature has been added to TrinaGrid while maintaining full backward compatibility. This means:
+
+- ✅ **Existing code continues to work** without any changes
+- ✅ **New functionality is opt-in** via new method calls
+- ✅ **Global row height configuration** remains the default behavior
+- ✅ **All existing features** work with variable heights
+
+## What's New
+
+### New Properties
+
+#### TrinaRow.height
+```dart
+class TrinaRow<T> {
+  /// Custom height for this specific row
+  /// If null, uses the global rowHeight from configuration
+  final double? height;
+  
+  // ... existing properties
+}
+```
+
+### New Methods
+
+#### TrinaGridStateManager.setRowHeight()
+```dart
+void setRowHeight(int rowIndex, double height)
+```
+
+#### TrinaGridStateManager.resetRowHeight()
+```dart
+void resetRowHeight(int rowIndex)
+```
+
+#### TrinaGridStateManager.resetAllRowHeights()
+```dart
+void resetAllRowHeights()
+```
+
+#### TrinaGridStateManager.getRowHeight()
+```dart
+double getRowHeight(int rowIndex)
+```
+
+## Migration Scenarios
+
+### Scenario 1: No Changes Required (Recommended)
+
+If you're happy with uniform row heights, you don't need to make any changes:
+
+```dart
+// This code continues to work exactly as before
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      rowHeight: 45.0, // Global row height
+    ),
+  ),
+)
+```
+
+### Scenario 2: Add Custom Heights to Specific Rows
+
+If you want some rows to have different heights:
+
+```dart
+// Before: All rows had the same height
+List<TrinaRow> rows = [
+  TrinaRow(cells: {'id': TrinaCell(value: '1'), 'name': TrinaCell(value: 'John')}),
+  TrinaRow(cells: {'id': TrinaCell(value: '2'), 'name': TrinaCell(value: 'Jane')}),
+];
+
+// After: Some rows have custom heights
+List<TrinaRow> rows = [
+  TrinaRow(
+    cells: {'id': TrinaCell(value: '1'), 'name': TrinaCell(value: 'John')},
+    height: 60.0, // Custom height
+  ),
+  TrinaRow(
+    cells: {'id': TrinaCell(value: '2'), 'name': TrinaCell(value: 'Jane')},
+    // Uses default height (45.0)
+  ),
+];
+```
+
+### Scenario 3: Dynamic Height Changes
+
+If you want to change row heights at runtime:
+
+```dart
+class MyGridScreen extends StatefulWidget {
+  @override
+  _MyGridScreenState createState() => _MyGridScreenState();
+}
+
+class _MyGridScreenState extends State<MyGridScreen> {
+  TrinaGridStateManager? stateManager;
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      columns: columns,
+      rows: rows,
+      onLoaded: (TrinaGridOnLoadedEvent event) {
+        stateManager = event.stateManager;
+      },
+      // ... other properties
+    );
+  }
+
+  // New method: Change row height dynamically
+  void _expandRow(int rowIndex) {
+    if (stateManager != null) {
+      stateManager!.setRowHeight(rowIndex, 80.0);
+      setState(() {}); // Trigger rebuild
+    }
+  }
+
+  // New method: Reset row to default height
+  void _collapseRow(int rowIndex) {
+    if (stateManager != null) {
+      stateManager!.resetRowHeight(rowIndex);
+      setState(() {}); // Trigger rebuild
+    }
+  }
+}
+```
+
+## Step-by-Step Migration
+
+### Step 1: Verify Current Setup
+
+Ensure your current TrinaGrid implementation is working correctly:
+
+```dart
+// Your existing code should work unchanged
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    // Store stateManager reference
+    stateManager = event.stateManager;
+  },
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      rowHeight: 45.0, // Your current row height
+    ),
+  ),
+)
+```
+
+### Step 2: Add StateManager Reference
+
+Store the `TrinaGridStateManager` reference for later use:
+
+```dart
+class _MyGridScreenState extends State<MyGridScreen> {
+  TrinaGridStateManager? stateManager;
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      // ... existing properties
+      onLoaded: (TrinaGridOnLoadedEvent event) {
+        setState(() {
+          stateManager = event.stateManager;
+        });
+      },
+    );
+  }
+}
+```
+
+### Step 3: Add Custom Heights (Optional)
+
+If you want some rows to have custom heights from the start:
+
+```dart
+void _initializeData() {
+  rows = [
+    TrinaRow(
+      cells: {'id': TrinaCell(value: '1'), 'name': TrinaCell(value: 'Header')},
+      height: 60.0, // Custom height for header
+    ),
+    TrinaRow(
+      cells: {'id': TrinaCell(value: '2'), 'name': TrinaCell(value: 'Data')},
+      // Uses default height
+    ),
+  ];
+}
+```
+
+### Step 4: Add Dynamic Height Controls (Optional)
+
+If you want users to control row heights:
+
+```dart
+Widget _buildHeightControls() {
+  return Row(
+    children: [
+      ElevatedButton(
+        onPressed: () => _setRowHeight(0, 60.0),
+        child: Text('Expand Row 0'),
+      ),
+      ElevatedButton(
+        onPressed: () => _resetRowHeight(0),
+        child: Text('Reset Row 0'),
+      ),
+    ],
+  );
+}
+
+void _setRowHeight(int rowIndex, double height) {
+  if (stateManager != null) {
+    stateManager!.setRowHeight(rowIndex, height);
+    setState(() {}); // Trigger rebuild
+  }
+}
+
+void _resetRowHeight(int rowIndex) {
+  if (stateManager != null) {
+    stateManager!.resetRowHeight(rowIndex);
+    setState(() {}); // Trigger rebuild
+  }
+}
+```
+
+### Step 5: Add Visual Indicators (Optional)
+
+Use `rowColorCallback` to highlight rows with custom heights:
+
+```dart
+TrinaGrid(
+  // ... existing properties
+  rowColorCallback: (TrinaRowColorContext context) {
+    if (context.row.height != null) {
+      return Colors.blue.withValues(alpha: 0.1); // Custom height rows
+    }
+    return context.rowIdx % 2 == 0 ? Colors.white : Colors.grey[50]!; // Default
+  },
+)
+```
+
+## Common Migration Patterns
+
+### Pattern 1: Header Rows with Custom Heights
+
+```dart
+// Before: All rows had uniform height
+List<TrinaRow> rows = [
+  TrinaRow(cells: {'title': TrinaCell(value: 'Section 1')}),
+  TrinaRow(cells: {'id': TrinaCell(value: '1'), 'name': TrinaCell(value: 'Item 1')}),
+  TrinaRow(cells: {'id': TrinaCell(value: '2'), 'name': TrinaCell(value: 'Item 2')}),
+];
+
+// After: Header rows have custom heights
+List<TrinaRow> rows = [
+  TrinaRow(
+    cells: {'title': TrinaCell(value: 'Section 1')},
+    height: 60.0, // Taller header
+  ),
+  TrinaRow(cells: {'id': TrinaCell(value: '1'), 'name': TrinaCell(value: 'Item 1')}),
+  TrinaRow(cells: {'id': TrinaCell(value: '2'), 'name': TrinaCell(value: 'Item 2')}),
+];
+```
+
+### Pattern 2: Expandable Rows
+
+```dart
+// Before: Fixed row heights
+List<TrinaRow> rows = List.generate(10, (index) {
+  return TrinaRow(cells: {
+    'id': TrinaCell(value: '${index + 1}'),
+    'content': TrinaCell(value: 'Content ${index + 1}'),
+  });
+});
+
+// After: Expandable rows with custom heights
+List<TrinaRow> rows = List.generate(10, (index) {
+  final isExpanded = index % 3 == 0; // Every 3rd row is expanded
+  
+  return TrinaRow(
+    cells: {
+      'id': TrinaCell(value: '${index + 1}'),
+      'content': TrinaCell(value: 'Content ${index + 1}'),
+    },
+    height: isExpanded ? 80.0 : null, // Custom height for expanded rows
+  );
+});
+```
+
+### Pattern 3: Content-Based Heights
+
+```dart
+// Before: All rows had the same height
+List<TrinaRow> rows = [
+  TrinaRow(cells: {'id': TrinaCell(value: '1'), 'text': TrinaCell(value: 'Short text')}),
+  TrinaRow(cells: {'id': TrinaCell(value: '2'), 'text': TrinaCell(value: 'Very long text that needs more space to display properly without truncation')}),
+];
+
+// After: Rows with long content have custom heights
+List<TrinaRow> rows = [
+  TrinaRow(cells: {'id': TrinaCell(value: '1'), 'text': TrinaCell(value: 'Short text')}),
+  TrinaRow(
+    cells: {'id': TrinaCell(value: '2'), 'text': TrinaCell(value: 'Very long text that needs more space to display properly without truncation')},
+    height: 80.0, // Extra height for long content
+  ),
+];
+```
+
+## Testing Your Migration
+
+### Test 1: Verify Existing Functionality
+
+Ensure your current grid still works:
+
+```dart
+// Test that existing features still work
+// - Row selection
+// - Column sorting
+// - Column filtering
+// - Row movement
+// - Cell editing
+// - etc.
+```
+
+### Test 2: Test Custom Heights
+
+Verify that custom heights work correctly:
+
+```dart
+// Test setting custom heights
+stateManager.setRowHeight(0, 80.0);
+
+// Test getting custom heights
+final height = stateManager.getRowHeight(0);
+assert(height == 80.0);
+
+// Test resetting heights
+stateManager.resetRowHeight(0);
+final resetHeight = stateManager.getRowHeight(0);
+assert(resetHeight == 45.0); // Default height
+```
+
+### Test 3: Test Visual Indicators
+
+Verify that custom height rows are visually distinct:
+
+```dart
+// Check that rows with custom heights have different colors
+// Check that height changes trigger UI updates
+// Check that scrolling works correctly with variable heights
+```
+
+## Performance Considerations
+
+### Before Migration
+- All rows had uniform heights
+- Efficient `ListView.builder` with `itemExtent`
+- Simple scroll calculations
+
+### After Migration
+- Rows can have variable heights
+- `ListView.builder` without `itemExtent` (less efficient)
+- More complex scroll calculations
+
+### Mitigation Strategies
+1. **Set heights at creation time** when possible
+2. **Limit the number of variable-height rows**
+3. **Use visual indicators** to help users understand the layout
+4. **Consider performance impact** for large datasets
+
+## Troubleshooting
+
+### Issue: Row heights not updating visually
+**Solution:** Make sure to call `setState()` after modifying row heights.
+
+### Issue: Scrolling seems slower
+**Solution:** This is expected behavior with variable heights. Consider limiting custom heights to essential rows.
+
+### Issue: Layout issues with custom heights
+**Solution:** Ensure custom heights are reasonable (e.g., between 30px and 200px).
+
+### Issue: Performance problems with many custom heights
+**Solution:** Consider using custom heights only for important rows or implementing lazy height calculation.
+
+## Rollback Plan
+
+If you encounter issues, you can easily rollback:
+
+1. **Remove custom height properties** from `TrinaRow` instances
+2. **Remove calls** to `setRowHeight()`, `resetRowHeight()`, etc.
+3. **Remove visual indicators** from `rowColorCallback`
+4. **Your grid will return** to the previous uniform height behavior
+
+## Next Steps
+
+After successful migration:
+
+1. **Explore advanced features** like content-based height calculation
+2. **Implement user controls** for height management
+3. **Add visual feedback** for height changes
+4. **Consider performance optimizations** for your specific use case
+
+## Support
+
+If you encounter issues during migration:
+
+1. Check the [Dynamic Row Heights](features/dynamic-row-heights.md) documentation
+2. Review the [examples](examples/dynamic-row-heights.md)
+3. Check the [API reference](api/trina-grid-state-manager.md)
+4. Report issues on the project's issue tracker
+
+The dynamic row heights feature is designed to be a smooth, opt-in enhancement to your existing TrinaGrid implementation. Take your time with the migration and test thoroughly at each step!
+
+
+---
+
+## Column Types
+
+TrinaGrid supports various column types to handle different kinds of data efficiently. Each column type provides specialized rendering, editing, filtering, and sorting capabilities tailored to specific data types.
+
+## Overview
+
+When creating columns for your TrinaGrid, you can specify the column type using the `type` property of `TrinaColumn`. The column type determines:
+
+- How cell values are displayed
+- The editor widget used for editing cells
+- How values are sorted
+- Available filtering options
+
+## Available Column Types
+
+TrinaGrid provides the following built-in column types:
+
+### Text Column
+
+The default column type for displaying and editing text values.
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+)
+```
+
+#### Text Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `textAlign` | `TextAlign` | Alignment of text within cells |
+| `maxLines` | `int?` | Maximum number of lines to display |
+| `overflow` | `TextOverflow` | How to handle text overflow |
+| `enableAutoSize` | `bool` | Whether to automatically resize text to fit |
+
+### Number Column
+
+Specialized for numeric values with formatting options.
+
+```dart
+TrinaColumn(
+  title: 'Price',
+  field: 'price',
+  type: TrinaColumnType.number(
+    format: '#,##0.00',
+    negative: true,
+    decimal: true,
+  ),
+)
+```
+
+#### Number Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `format` | `String?` | Number format pattern |
+| `negative` | `bool` | Whether to allow negative values |
+| `decimal` | `bool` | Whether to allow decimal values |
+| `decimalDigits` | `int?` | Number of decimal places to display |
+| `thousandSeparator` | `String` | Character used as thousand separator |
+| `decimalSeparator` | `String` | Character used as decimal separator |
+| `prefix` | `String?` | Text to display before the number (e.g., currency symbol) |
+| `suffix` | `String?` | Text to display after the number (e.g., unit) |
+
+### Date Column
+
+For displaying and editing date values.
+
+```dart
+TrinaColumn(
+  title: 'Birthday',
+  field: 'birthday',
+  type: TrinaColumnType.date(
+    format: 'yyyy-MM-dd',
+  ),
+)
+```
+
+#### Date Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `format` | `String` | Date format pattern |
+| `startDate` | `DateTime?` | Minimum selectable date |
+| `endDate` | `DateTime?` | Maximum selectable date |
+| `firstDate` | `DateTime?` | First date visible in calendar |
+| `lastDate` | `DateTime?` | Last date visible in calendar |
+| `closePopupOnSelection` | `bool` | Whether to close the popup immediately after a date is selected. Defaults to `true`. |
+| `popupIcon` | `IconData?` | Custom icon for the popup button (defaults to `Icons.date_range`) |
+
+### Time Column
+
+For displaying and editing time values.
+
+```dart
+TrinaColumn(
+  title: 'Start Time',
+  field: 'startTime',
+  type: TrinaColumnType.time(
+    format: 'HH:mm',
+  ),
+)
+```
+
+#### Time Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `format` | `String` | Time format pattern |
+| `minTime` | `TimeOfDay?` | The minimum selectable time. |
+| `maxTime` | `TimeOfDay?` | The maximum selectable time. |
+| `saveAndClosePopupWithEnter` | `bool` | If true, pressing Enter will save the value and close the popup. |
+
+
+### DateTime Column
+
+For displaying and editing both date and time values in a single field.
+
+```dart
+TrinaColumn(
+  title: 'Created At',
+  field: 'createdAt',
+  type: TrinaColumnType.dateTime(
+    format: 'yyyy-MM-dd HH:mm',
+    headerFormat: 'MMMM yyyy',
+    startDate: DateTime(2023, 1, 1),
+    endDate: DateTime(2025, 12, 31),
+    popupIcon: Icons.event_available,
+  ),
+)
+```
+
+#### DateTime Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `format` | `String` | DateTime format pattern (defaults to 'yyyy-MM-dd HH:mm') |
+| `headerFormat` | `String` | Format for the header in date picker (defaults to 'yyyy-MM') |
+| `startDate` | `DateTime?` | Minimum selectable date (optional) |
+| `endDate` | `DateTime?` | Maximum selectable date (optional) |
+| `applyFormatOnInit` | `bool` | Whether to apply format when initializing (defaults to `true`) |
+| `popupIcon` | `IconData?` | Custom icon for the popup button (defaults to calendar icon) |
+
+### Select Column
+
+For selecting a value from a predefined list of items.  
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.select(
+    items: ['pending', 'in_progress', 'completed', 'cancelled'],
+    itemToString: (value) => value.toString().toUpperCase(),
+  ),
+)
+```
+
+#### Select Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `items` | `List<dynamic>` | The list of items to display in the select menu. |
+| `itemToString` | `String Function(dynamic)?` | A function that returns the string representation of an item. This is required for search and filtering. |
+| `itemToValue` | `dynamic Function(dynamic)?` | A function that returns a unique value for an item, used for comparison and selection. |
+| `variant` | `TrinaDropdownMenuVariant` | The select menu variant; one of `select`, `selectWithSearch`, or `selectWithFilters`. |
+| `filters` | `List<TrinaDropdownMenuFilter>` | A list of filters to be used when `variant` is `TrinaDropdownMenuVariant.selectWithFilters`. |
+| `filtersInitiallyExpanded` | `bool` | Whether the filters section is initially expanded. Defaults to `true`. |
+| `emptySearchResultBuilder` | `WidgetBuilder?` | A builder function to create a widget to display when a search yields no results. |
+| `emptyFilterResultBuilder` | `WidgetBuilder?` | A builder function to create a widget to display when filtering yields no results. |
+| `menuItemBuilder` | `Widget Function(dynamic item)?` | A builder function to create a custom widget for each item in the list. |
+
+### Boolean Column
+
+For displaying and editing boolean values.
+
+```dart
+TrinaColumn(
+  title: 'Active',
+  field: 'isActive',
+  type: TrinaColumnType.boolean(
+    trueText: 'Yes',
+    falseText: 'No',
+    allowEmpty: false,
+    defaultValue: false,
+    width: 120,
+    popupIcon: Icons.check_box,
+    menuItemBuilder: (bool item) => CustomBooleanWidget(value: item),
+    onItemSelected: (bool item) {},
+  ),
+)
+```
+
+#### Boolean Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `defaultValue` | `dynamic` | Default value for new cells (defaults to `false`) |
+| `allowEmpty` | `bool` | Whether to allow null/empty values (defaults to `false`) |
+| `trueText` | `String` | Text to display for true values (defaults to "Yes") |
+| `falseText` | `String` | Text to display for false values (defaults to "No") |
+| `width` | `double?` | Width of the popup selector |
+| `popupIcon` | `IconData?` | Icon to display for opening the popup selector |
+| `menuItemBuilder` | `Widget Function(dynamic item)?` | Custom widget builder for rendering boolean values |
+| `onItemSelected` | `void Function(dynamic value)?` | Callback when a value is selected |
+
+### Currency Column
+
+Specialized for monetary values.
+
+```dart
+TrinaColumn(
+  title: 'Price',
+  field: 'price',
+  type: TrinaColumnType.currency(
+    symbol: '\$',
+    decimalDigits: 2,
+  ),
+)
+```
+
+#### Currency Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `symbol` | `String` | Currency symbol |
+| `symbolPosition` | `CurrencySymbolPosition` | Position of currency symbol (before/after) |
+| `decimalDigits` | `int` | Number of decimal places |
+| `thousandSeparator` | `String` | Character used as thousand separator |
+| `decimalSeparator` | `String` | Character used as decimal separator |
+| `negativeFormat` | `CurrencyNegativeFormat` | How to format negative values |
+
+### Percentage Column
+
+For displaying and editing percentage values.
+
+```dart
+TrinaColumn(
+  title: 'Completion',
+  field: 'completion',
+  type: TrinaColumnType.percentage(
+    decimalDigits: 1,
+    showSymbol: true,
+  ),
+)
+```
+
+#### Percentage Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `defaultValue` | `dynamic` | Default value for new cells (defaults to `0`) |
+| `decimalDigits` | `int` | Number of decimal places (defaults to `2`) |
+| `showSymbol` | `bool` | Whether to show the % symbol (defaults to `true`) |
+| `symbolPosition` | `PercentageSymbolPosition` | Position of % symbol (before/after, defaults to `after`) |
+| `negative` | `bool` | Whether to allow negative values (defaults to `true`) |
+| `applyFormatOnInit` | `bool` | When the editor loads, it resets the value to formatted value (defaults to `true`) |
+| `allowFirstDot` | `bool` | Allow a dot at the beginning when accepting negative numbers (defaults to `false`) |
+| `locale` | `String?` | Specifies the numeric locale of the column (if not specified, uses default locale) |
+| `decimalInput` | `bool` | When true, users can input direct percentage values (42 for 42%) rather than decimal values (0.42) (defaults to `false`) |
+
+#### Using `decimalInput`
+
+When `decimalInput` is set to `true`, the column will:
+
+1. Accept direct percentage values as input (e.g., 42 for 42%)
+2. Display values as percentages (e.g., 42.0%)
+3. Store values internally as percentages (not as decimals)
+
+```dart
+// Example of a column with decimalInput enabled
+TrinaColumn(
+  title: 'Percentage',
+  field: 'percentage',
+  type: TrinaColumnType.percentage(
+    decimalInput: true,
+    decimalDigits: 1,
+  ),
+)
+
+// Usage with decimalInput: true
+TrinaCell(value: 42)  // Displays as "42.0%"
+
+// Regular percentage column (decimalInput: false)
+TrinaCell(value: 0.42)  // Displays as "42.00%"
+```
+
+### Custom Column
+
+For storing complex objects (maps, custom classes, etc.) that don't fit the built-in column types.
+
+```dart
+TrinaColumn(
+  title: 'Address',
+  field: 'address',
+  type: TrinaColumnType.custom(
+    defaultValue: {'street': '', 'city': ''},
+    toDisplayString: (value) => '${value['street']}, ${value['city']}',
+    compare: (a, b) => a['city'].compareTo(b['city']),
+    isValid: (value) => value is Map && value.containsKey('city'),
+  ),
+)
+```
+
+By default, all values are considered valid, sorting uses `toString()` comparison,
+and display text uses `toString()`. All callbacks are optional.
+
+For custom rendering, combine with `TrinaColumn.renderer`:
+
+```dart
+TrinaColumn(
+  title: 'Rating',
+  field: 'rating',
+  type: TrinaColumnType.custom(
+    toDisplayString: (value) => '${value} stars',
+    compare: (a, b) => (a as num).compareTo(b as num),
+  ),
+  renderer: (rendererContext) {
+    return StarRating(rating: rendererContext.cell.value);
+  },
+)
+```
+
+#### Custom Column Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `defaultValue` | `dynamic` | Default value for new cells (defaults to `null`) |
+| `isValid` | `bool Function(dynamic)` | Validates cell values (defaults to always `true`) |
+| `compare` | `int Function(dynamic, dynamic)` | Comparator for sorting (defaults to `toString()` comparison) |
+| `toDisplayString` | `String Function(dynamic)` | Converts value to display text (defaults to `toString()`) |
+
+## Column Type Configuration
+
+### Default Column Type
+
+You can set a default column type for all columns in your grid:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    defaultColumnType: TrinaColumnType.text(),
+  ),
+)
+```
+
+### Type Inheritance
+
+Column types can inherit properties from other column types:
+
+```dart
+// Create a base column type with common properties
+final baseTextColumn = TrinaColumnType.text(
+  textAlign: TextAlign.start,
+  maxLines: 2,
+);
+
+// Create columns that inherit from the base type
+TrinaColumn(
+  title: 'Description',
+  field: 'description',
+  type: baseTextColumn.copyWith(
+    maxLines: 3,
+    overflow: TextOverflow.ellipsis,
+  ),
+)
+```
+
+## Best Practices
+
+1. **Choose the appropriate column type** for your data to leverage built-in formatting, editing, and validation
+2. **Use custom column types** when you need specialized behavior not covered by built-in types
+3. **Create reusable column type configurations** for consistent appearance across your grid
+4. **Consider performance implications** when using complex custom renderers or editors
+5. **Provide clear validation feedback** to users when they enter invalid data
+
+## Examples
+
+### Mixed Column Types
+
+```dart
+List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'ID',
+    field: 'id',
+    type: TrinaColumnType.number(format: '#'),
+    width: 80,
+    frozen: true,
+  ),
+  TrinaColumn(
+    title: 'Name',
+    field: 'name',
+    type: TrinaColumnType.text(),
+    width: 150,
+  ),
+  TrinaColumn(
+    title: 'Birth Date',
+    field: 'birthDate',
+    type: TrinaColumnType.date(format: 'yyyy-MM-dd'),
+    width: 120,
+  ),
+  TrinaColumn(
+    title: 'Created At',
+    field: 'createdAt',
+    type: TrinaColumnType.dateTime(
+      format: 'yyyy-MM-dd HH:mm',
+    ),
+    width: 150,
+  ),
+  TrinaColumn(
+    title: 'Salary',
+    field: 'salary',
+    type: TrinaColumnType.currency(
+      symbol: '\$',
+      decimalDigits: 2,
+    ),
+    width: 120,
+  ),
+  TrinaColumn(
+    title: 'Completion',
+    field: 'completion',
+    type: TrinaColumnType.percentage(
+      decimalDigits: 1,
+      showSymbol: true,
+    ),
+    width: 100,
+  ),
+  TrinaColumn(
+    title: 'Active',
+    field: 'isActive',
+    type: TrinaColumnType.boolean(),
+    width: 100,
+  ),
+  TrinaColumn(
+    title: 'Department',
+    field: 'department',
+    type: TrinaColumnType.select(
+      items: ['engineering', 'marketing', 'sales', 'hr'],
+    ),
+    width: 150,
+  ),
+];
+```
+
+### Custom Rating Column
+
+```dart
+TrinaColumn(
+  title: 'Rating',
+  field: 'rating',
+  type: TrinaColumnType.custom(
+    renderer: (rendererContext) {
+      final rating = rendererContext.cell.value as double;
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(5, (index) {
+          return Icon(
+            index < rating ? Icons.star : Icons.star_border,
+            color: Colors.amber,
+            size: 16,
+          );
+        }),
+      );
+    },
+    editor: (editorContext) {
+      return StatefulBuilder(
+        builder: (context, setState) {
+          double rating = editorContext.cell.value ?? 0.0;
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(5, (index) {
+              return IconButton(
+                icon: Icon(
+                  index < rating ? Icons.star : Icons.star_border,
+                  color: Colors.amber,
+                ),
+                onPressed: () {
+                  setState(() {
+                    rating = index + 1.0;
+                    editorContext.onChanged(rating);
+                  });
+                },
+                iconSize: 24,
+                padding: EdgeInsets.zero,
+                constraints: BoxConstraints(minWidth: 24, minHeight: 24),
+              );
+            }),
+          );
+        },
+      );
+    },
+  ),
+  width: 150,
+)
+```
+
+## Related Features
+
+- [Column Renderers](column-renderer.md) - For more advanced column rendering
+- [Cell Editing](cell-editing.md) - For more details on cell editing behavior
+- [Cell Validation](cell-validation.md) - For validating cell input
+- [Column Filtering](column-filtering.md) - For filtering data based on column values
+- [Column Sorting](column-sorting.md) - For sorting data based on column values
+
+
+---
+
+## Column Freezing
+
+Column freezing is a feature that allows you to lock columns in place while scrolling horizontally through a data grid. This is particularly useful when working with wide tables that have identifying columns (like ID, name, etc.) that you want to keep visible at all times.
+
+## Overview
+
+TrinaGrid supports freezing columns on both the left and right sides of the grid. When columns are frozen, they remain visible even when scrolling horizontally through the grid content.
+
+## Types of Column Freezing
+
+TrinaGrid supports three states for column freezing:
+
+- **None**: The default state where columns scroll normally with the grid.
+- **Start (Left)**: Freezes the column to the left side of the grid.
+- **End (Right)**: Freezes the column to the right side of the grid.
+
+## How to Freeze Columns
+
+### Programmatically
+
+You can set the frozen state of a column when defining your columns:
+
+```dart
+final List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'ID',
+    field: 'id',
+    type: TrinaColumnType.number(),
+    frozen: TrinaColumnFrozen.start, // Freeze this column to the left
+  ),
+  TrinaColumn(
+    title: 'Name',
+    field: 'name',
+    type: TrinaColumnType.text(),
+  ),
+  TrinaColumn(
+    title: 'Actions',
+    field: 'actions',
+    type: TrinaColumnType.text(),
+    frozen: TrinaColumnFrozen.end, // Freeze this column to the right
+  ),
+];
+```
+
+### Using the Column Menu
+
+Users can freeze columns through the column menu that appears when clicking on the menu icon in the column header:
+
+1. Click on the menu icon in the column header
+2. Select "Freeze to start" to freeze the column to the left side
+3. Select "Freeze to end" to freeze the column to the right side
+4. Select "Unfreeze" to return the column to normal scrolling behavior
+
+### Using the State Manager
+
+You can also toggle column freezing using the state manager:
+
+```dart
+// Freeze a column to the left
+stateManager.toggleFrozenColumn(column, TrinaColumnFrozen.start);
+
+// Freeze a column to the right
+stateManager.toggleFrozenColumn(column, TrinaColumnFrozen.end);
+
+// Unfreeze a column
+stateManager.toggleFrozenColumn(column, TrinaColumnFrozen.none);
+```
+
+## Limitations
+
+TrinaGrid has built-in safeguards to prevent freezing too many columns:
+
+1. The grid ensures there's always enough space for non-frozen columns to be visible.
+2. If the width of the middle (non-frozen) columns becomes too narrow, frozen columns will be automatically released.
+3. The `limitToggleFrozenColumn` method checks if there's enough space before allowing a column to be frozen.
+
+## Example
+
+Here's a complete example demonstrating column freezing:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnFreezingExample extends StatefulWidget {
+  @override
+  _ColumnFreezingExampleState createState() => _ColumnFreezingExampleState();
+}
+
+class _ColumnFreezingExampleState extends State<ColumnFreezingExample> {
+  final List<TrinaColumn> columns = [
+    TrinaColumn(
+      title: 'ID',
+      field: 'id',
+      type: TrinaColumnType.number(),
+      frozen: TrinaColumnFrozen.start, // Frozen to left by default
+    ),
+    TrinaColumn(
+      title: 'Name',
+      field: 'name',
+      type: TrinaColumnType.text(),
+    ),
+    TrinaColumn(
+      title: 'Email',
+      field: 'email',
+      type: TrinaColumnType.text(),
+    ),
+    TrinaColumn(
+      title: 'Role',
+      field: 'role',
+      type: TrinaColumnType.text(),
+    ),
+    TrinaColumn(
+      title: 'Actions',
+      field: 'actions',
+      type: TrinaColumnType.text(),
+      frozen: TrinaColumnFrozen.end, // Frozen to right by default
+    ),
+  ];
+
+  final List<TrinaRow> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Generate sample data
+    for (int i = 0; i < 100; i++) {
+      rows.add(
+        TrinaRow(
+          cells: {
+            'id': TrinaCell(value: i),
+            'name': TrinaCell(value: 'User $i'),
+            'email': TrinaCell(value: 'user$i@example.com'),
+            'role': TrinaCell(value: i % 2 == 0 ? 'Admin' : 'User'),
+            'actions': TrinaCell(value: 'Edit | Delete'),
+          },
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Freezing Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          // You can also freeze columns after the grid is loaded
+          // event.stateManager.toggleFrozenColumn(columns[1], TrinaColumnFrozen.start);
+        },
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Freeze Important Columns**: Typically, you'll want to freeze columns containing identifying information (like IDs or names) on the left, and action columns on the right.
+
+2. **Don't Freeze Too Many Columns**: Freezing too many columns can reduce the space available for scrollable content. Only freeze columns that are essential for context.
+
+3. **Consider Column Width**: Frozen columns take up fixed space in the grid. Make sure your frozen columns aren't too wide to ensure enough space for the scrollable content.
+
+4. **Responsive Design**: When implementing column freezing in a responsive layout, be aware that on smaller screens, having frozen columns might take up too much space. Consider making column freezing conditional based on screen width.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Resizing](column-resizing.md)
+- [Column Moving](column-moving.md)
+
+
+---
+
+## Column Resizing
+
+Column resizing is a feature that allows users to adjust the width of columns in TrinaGrid. This feature provides flexibility in displaying data and helps users optimize their view based on the content in each column.
+
+## Overview
+
+TrinaGrid provides a comprehensive column resizing system with different modes and behaviors. Users can resize columns by dragging the right edge of a column header, and developers can configure how the resizing behaves through various configuration options.
+
+## Resize Modes
+
+TrinaGrid supports three resize modes, defined by the `TrinaResizeMode` enum:
+
+### 1. None (`TrinaResizeMode.none`)
+
+In this mode, column resizing is disabled. Users cannot resize columns by dragging the column edges.
+
+### 2. Normal (`TrinaResizeMode.normal`)
+
+This is the default mode. When a column is resized, only that specific column's width changes. Other columns maintain their original widths, which may change the overall width of the grid.
+
+### 3. Push and Pull (`TrinaResizeMode.pushAndPull`)
+
+In this mode, when a column is resized, neighboring columns adjust their widths to maintain the overall grid width. This creates a more fluid resizing experience where:
+
+- When a column is expanded, other columns shrink to compensate
+- When a column is shrunk, other columns expand to fill the available space
+
+This mode is particularly useful when you want to maintain a fixed total width for your grid.
+
+## Auto-Size Modes
+
+In addition to resize modes, TrinaGrid also supports auto-sizing columns through the `TrinaAutoSizeMode` enum:
+
+### 1. None (`TrinaAutoSizeMode.none`)
+
+Columns are not automatically sized and maintain their explicitly set widths.
+
+### 2. Equal (`TrinaAutoSizeMode.equal`)
+
+All columns are sized equally, regardless of their content.
+
+### 3. Scale (`TrinaAutoSizeMode.scale`)
+
+Columns are sized proportionally based on their current widths.
+
+## How to Configure Column Resizing
+
+### Basic Configuration
+
+You can configure column resizing when creating your TrinaGrid:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    columnSize: TrinaGridColumnSizeConfig(
+      autoSizeMode: TrinaAutoSizeMode.none,
+      resizeMode: TrinaResizeMode.normal,
+    ),
+  ),
+)
+```
+
+### Configuring Individual Columns
+
+You can also control whether specific columns can be resized:
+
+```dart
+final List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'ID',
+    field: 'id',
+    type: TrinaColumnType.number(),
+    enableDropToResize: false, // Disable resizing for this column
+  ),
+  TrinaColumn(
+    title: 'Name',
+    field: 'name',
+    type: TrinaColumnType.text(),
+    // This column can be resized (default)
+  ),
+];
+```
+
+### Using the State Manager
+
+You can dynamically change column resizing configuration using the state manager:
+
+```dart
+// Change the column size configuration
+stateManager.setColumnSizeConfig(
+  TrinaGridColumnSizeConfig(
+    autoSizeMode: TrinaAutoSizeMode.equal,
+    resizeMode: TrinaResizeMode.pushAndPull,
+  ),
+);
+
+// Resize a specific column programmatically
+stateManager.resizeColumn(column, 50); // Increase width by 50 pixels
+```
+
+### Restore Options
+
+TrinaGrid provides options to control when auto-sizing should be restored after certain actions:
+
+```dart
+TrinaGridColumnSizeConfig(
+  autoSizeMode: TrinaAutoSizeMode.equal,
+  resizeMode: TrinaResizeMode.normal,
+  // Restore auto-sizing after these actions
+  restoreAutoSizeAfterHideColumn: true,
+  restoreAutoSizeAfterFrozenColumn: true,
+  restoreAutoSizeAfterMoveColumn: true,
+  restoreAutoSizeAfterInsertColumn: true,
+  restoreAutoSizeAfterRemoveColumn: true,
+)
+```
+
+## How Column Resizing Works
+
+### User Interaction
+
+1. The user hovers over the right edge of a column header, and the cursor changes to a resize cursor
+2. The user clicks and drags to resize the column
+3. Depending on the resize mode, other columns may adjust their widths
+
+### Implementation Details
+
+When a column is resized:
+
+1. The `resizeColumn` method is called with the column and the offset (change in width)
+2. If the resize mode is `normal`, only the target column's width is updated
+3. If the resize mode is `pushAndPull`, the `TrinaResizePushAndPull` class handles distributing the width changes across multiple columns
+4. The grid layout is updated to reflect the new column widths
+
+## Minimum Column Width
+
+Each column has a minimum width to ensure that content remains visible. When resizing a column, it cannot be made smaller than its minimum width.
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  minWidth: 100, // Set minimum width to 100 pixels
+)
+```
+
+## Auto-Fitting Columns
+
+TrinaGrid also provides the ability to automatically fit a column's width to its content:
+
+```dart
+// Auto-fit a column to its content
+stateManager.autoFitColumn(context, column);
+```
+
+This calculates the optimal width based on the column's content and header text.
+
+## Example
+
+Here's a complete example demonstrating column resizing:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnResizingExample extends StatefulWidget {
+  @override
+  _ColumnResizingExampleState createState() => _ColumnResizingExampleState();
+}
+
+class _ColumnResizingExampleState extends State<ColumnResizingExample> {
+  final List<TrinaColumn> columns = [
+    TrinaColumn(
+      title: 'ID',
+      field: 'id',
+      type: TrinaColumnType.number(),
+      width: 80,
+      minWidth: 60,
+    ),
+    TrinaColumn(
+      title: 'Name',
+      field: 'name',
+      type: TrinaColumnType.text(),
+      width: 150,
+      minWidth: 100,
+    ),
+    TrinaColumn(
+      title: 'Email',
+      field: 'email',
+      type: TrinaColumnType.text(),
+      width: 200,
+      minWidth: 120,
+    ),
+    TrinaColumn(
+      title: 'Role',
+      field: 'role',
+      type: TrinaColumnType.text(),
+      width: 120,
+      minWidth: 80,
+    ),
+  ];
+
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Generate sample data
+    for (int i = 0; i < 100; i++) {
+      rows.add(
+        TrinaRow(
+          cells: {
+            'id': TrinaCell(value: i),
+            'name': TrinaCell(value: 'User $i'),
+            'email': TrinaCell(value: 'user$i@example.com'),
+            'role': TrinaCell(value: i % 2 == 0 ? 'Admin' : 'User'),
+          },
+        ),
+      );
+    }
+  }
+
+  void _setResizeMode(TrinaResizeMode mode) {
+    stateManager.setColumnSizeConfig(
+      TrinaGridColumnSizeConfig(
+        autoSizeMode: TrinaAutoSizeMode.none,
+        resizeMode: mode,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Resizing Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () => _setResizeMode(TrinaResizeMode.normal),
+                  child: Text('Normal Resize'),
+                ),
+                SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () => _setResizeMode(TrinaResizeMode.pushAndPull),
+                  child: Text('Push and Pull Resize'),
+                ),
+                SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () => _setResizeMode(TrinaResizeMode.none),
+                  child: Text('Disable Resize'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              configuration: const TrinaGridConfiguration(
+                columnSize: TrinaGridColumnSizeConfig(
+                  autoSizeMode: TrinaAutoSizeMode.none,
+                  resizeMode: TrinaResizeMode.normal,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Choose the Right Resize Mode**: Use `normal` for independent column resizing or `pushAndPull` when you want to maintain a fixed grid width.
+
+2. **Set Appropriate Minimum Widths**: Define minimum widths for columns to ensure content remains readable after resizing.
+
+3. **Consider Auto-Size Options**: Use auto-sizing for initial column widths, but allow users to manually resize columns for their specific needs.
+
+4. **Restore Auto-Size Selectively**: Configure restore options based on your application's needs. For example, you might want to restore auto-sizing after hiding a column but not after freezing a column.
+
+5. **Combine with Column Freezing**: When using column resizing with column freezing, be aware that frozen columns will maintain their position while non-frozen columns can be resized.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Freezing](column-freezing.md)
+- [Column Moving](column-moving.md)
+
+
+---
+
+## Column Moving
+
+Column moving is a feature that allows users to change the order of columns in TrinaGrid by dragging and dropping column headers. This feature enhances the user experience by enabling customization of the grid layout according to user preferences.
+
+## Overview
+
+TrinaGrid provides a flexible column moving system that allows users to rearrange columns through a simple drag-and-drop interface. Developers can also programmatically move columns using the state manager API.
+
+## How to Move Columns
+
+### Using Drag and Drop (UI)
+
+The most intuitive way to move columns is through the user interface:
+
+1. Hover over the column header you want to move
+2. Click and hold the column header
+3. Drag the column to the desired position
+4. Release the mouse button to drop the column in its new position
+
+As you drag a column, a visual indicator will show where the column will be placed when you release the mouse button.
+
+### Using the State Manager (Programmatic)
+
+You can also move columns programmatically using the state manager:
+
+```dart
+// Move 'columnA' to the position of 'columnB'
+stateManager.moveColumn(
+  column: columnA,
+  targetColumn: columnB,
+);
+```
+
+This will move `columnA` to the position where `columnB` is currently located.
+
+## Behavior with Frozen Columns
+
+Column moving has special behavior when working with frozen columns:
+
+1. When moving a non-frozen column to a frozen area, the column will adopt the frozen state of the target column
+2. There are width limitations when moving columns to frozen areas to ensure the frozen area doesn't exceed the available space
+3. The system handles the transition between different frozen states (start, end, none) automatically
+
+## Limitations
+
+### Width Limitations
+
+When moving columns to frozen areas, there are width limitations to consider:
+
+- The total width of frozen columns cannot exceed a certain percentage of the grid width
+- If moving a column would cause the frozen area to exceed this limit, the move operation will be prevented
+- These limitations ensure that non-frozen columns always have sufficient space to be displayed
+
+### Frozen Column Limitations
+
+There are specific limitations when moving frozen columns:
+
+1. Moving a frozen column to a non-frozen area will change its frozen state
+2. Moving a non-frozen column to a frozen area will change its frozen state to match the target area
+3. The system prevents moves that would violate the frozen column width limitations
+
+## Events
+
+When columns are moved, TrinaGrid fires events that you can listen to:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    stateManager = event.stateManager;
+  },
+  onColumnsMoved: (TrinaGridOnColumnsMovedEvent event) {
+    // Handle column moved event
+    print('Column moved to index: ${event.idx}');
+    print('Column moved to visual index: ${event.visualIdx}');
+    print('Moved columns: ${event.columns}');
+  },
+)
+```
+
+## Auto-Size Restoration
+
+By default, TrinaGrid will restore auto-sizing after moving columns. You can control this behavior through the configuration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    columnSize: TrinaGridColumnSizeConfig(
+      // Set to false to prevent auto-size restoration after moving columns
+      restoreAutoSizeAfterMoveColumn: false,
+    ),
+  ),
+)
+```
+
+## Example
+
+Here's a complete example demonstrating column moving:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnMovingExample extends StatefulWidget {
+  @override
+  _ColumnMovingExampleState createState() => _ColumnMovingExampleState();
+}
+
+class _ColumnMovingExampleState extends State<ColumnMovingExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'Column A',
+        field: 'column_a',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Column B',
+        field: 'column_b',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Column C',
+        field: 'column_c',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a1'),
+          'column_b': TrinaCell(value: 'b1'),
+          'column_c': TrinaCell(value: 'c1'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a2'),
+          'column_b': TrinaCell(value: 'b2'),
+          'column_c': TrinaCell(value: 'c2'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a3'),
+          'column_b': TrinaCell(value: 'b3'),
+          'column_c': TrinaCell(value: 'c3'),
+        },
+      ),
+    ]);
+  }
+
+  void _moveColumnProgrammatically() {
+    // Move Column A to the position of Column C
+    final columnA = columns.firstWhere((col) => col.field == 'column_a');
+    final columnC = columns.firstWhere((col) => col.field == 'column_c');
+    
+    stateManager.moveColumn(
+      column: columnA,
+      targetColumn: columnC,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Moving Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _moveColumnProgrammatically,
+                  child: Text('Move Column A to Column C Position'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              onColumnsMoved: (TrinaGridOnColumnsMovedEvent event) {
+                print('Column moved to index: ${event.idx}');
+                print('Column moved to visual index: ${event.visualIdx}');
+                print('Moved columns: ${event.columns}');
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Provide Visual Feedback**: Ensure that your grid provides clear visual feedback during drag operations to help users understand where columns will be placed.
+
+2. **Consider Frozen Columns**: Be mindful of the interaction between column moving and frozen columns. Moving columns between frozen and non-frozen areas changes their frozen state.
+
+3. **Handle Events**: Listen to column moved events to update any dependent UI or data structures when columns are rearranged.
+
+4. **Auto-Size Configuration**: Decide whether to restore auto-sizing after column moves based on your application's needs. For data-dense grids, you might want to maintain user-defined column sizes.
+
+5. **Combine with Column Resizing**: Column moving works well in combination with column resizing, giving users complete control over the grid layout.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Freezing](column-freezing.md)
+- [Column Resizing](column-resizing.md)
+
+
+---
+
+## Column Hiding
+
+Column hiding is a feature that allows users to show or hide specific columns in TrinaGrid. This feature provides flexibility in displaying data and helps users focus on the most relevant information by removing columns that are not currently needed.
+
+## Overview
+
+TrinaGrid provides a comprehensive column hiding system with both programmatic and UI-based methods for controlling column visibility. Users can hide columns through the column menu or a dedicated column visibility popup, and developers can hide columns programmatically through the state manager API.
+
+## How to Hide Columns
+
+### Using the Column Menu (UI)
+
+The most direct way for users to hide a column is through the column menu:
+
+1. Click on the menu icon (⋮) on the right side of a column header
+2. Select "Hide column" from the dropdown menu
+
+This will immediately hide the column from view.
+
+### Using the Set Columns Popup (UI)
+
+TrinaGrid provides a dedicated popup for managing column visibility:
+
+1. The popup can be triggered programmatically or through a UI element
+2. It displays a list of all columns with checkboxes
+3. Users can check or uncheck columns to show or hide them
+4. Users can also use the header checkbox to show or hide all columns at once
+
+### Using the State Manager (Programmatic)
+
+You can hide or show columns programmatically using the state manager:
+
+```dart
+// Hide a single column
+stateManager.hideColumn(column, true);
+
+// Show a previously hidden column
+stateManager.hideColumn(column, false);
+
+// Hide multiple columns at once
+stateManager.hideColumns(columnsList, true);
+
+// Show multiple columns at once
+stateManager.hideColumns(columnsList, false);
+
+// Show the column visibility popup
+stateManager.showSetColumnsPopup(context);
+```
+
+## Behavior with Frozen Columns
+
+Column hiding has special behavior when working with frozen columns:
+
+1. When unhiding a frozen column, the system checks if there's enough space in the frozen area
+2. If there isn't enough space, the column will be unfrozen automatically (its frozen state will be set to `TrinaColumnFrozen.none`)
+3. This ensures that the frozen area doesn't exceed the available space
+
+## Auto-Size Restoration
+
+By default, TrinaGrid will restore auto-sizing after hiding or showing columns. You can control this behavior through the configuration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    columnSize: TrinaGridColumnSizeConfig(
+      // Set to false to prevent auto-size restoration after hiding/showing columns
+      restoreAutoSizeAfterHideColumn: false,
+    ),
+  ),
+)
+```
+
+## Events
+
+When columns are hidden or shown, TrinaGrid dispatches a `TrinaGridColumnHiddenEvent` through the event manager. This allows your application to respond to visibility changes and persist user preferences.
+
+### Listening for Column Visibility Changes
+
+You can listen to column visibility events using the event manager:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (event) {
+    stateManager = event.stateManager;
+
+    // Listen to column visibility events
+    stateManager.eventManager!.listener((event) {
+      if (event is TrinaGridColumnHiddenEvent) {
+        print('Columns ${event.isHidden ? "hidden" : "shown"}: ${event.columns.length}');
+
+        // Store visibility state for next usage
+        saveColumnVisibility(event.columns, event.isHidden);
+      }
+    });
+  },
+)
+```
+
+### The TrinaGridColumnHiddenEvent Object
+
+The event contains the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `columns` | `List<TrinaColumn>` | The columns that were hidden or shown |
+| `isHidden` | `bool` | `true` if columns were hidden, `false` if shown |
+
+### Example: Persisting Column Visibility
+
+```dart
+// Save column visibility to SharedPreferences
+void saveColumnVisibility(List<TrinaColumn> columns, bool isHidden) {
+  final prefs = await SharedPreferences.getInstance();
+  final hiddenColumns = prefs.getStringList('hiddenColumns') ?? [];
+
+  for (final column in columns) {
+    if (isHidden) {
+      hiddenColumns.add(column.field);
+    } else {
+      hiddenColumns.remove(column.field);
+    }
+  }
+
+  prefs.setStringList('hiddenColumns', hiddenColumns);
+}
+```
+
+## Example
+
+Here's a complete example demonstrating column hiding:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnHidingExample extends StatefulWidget {
+  @override
+  _ColumnHidingExampleState createState() => _ColumnHidingExampleState();
+}
+
+class _ColumnHidingExampleState extends State<ColumnHidingExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'Column A',
+        field: 'column_a',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Column B',
+        field: 'column_b',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Column C',
+        field: 'column_c',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a1'),
+          'column_b': TrinaCell(value: 'b1'),
+          'column_c': TrinaCell(value: 'c1'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a2'),
+          'column_b': TrinaCell(value: 'b2'),
+          'column_c': TrinaCell(value: 'c2'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'column_a': TrinaCell(value: 'a3'),
+          'column_b': TrinaCell(value: 'b3'),
+          'column_c': TrinaCell(value: 'c3'),
+        },
+      ),
+    ]);
+  }
+
+  void _toggleColumnA() {
+    // Find Column A
+    TrinaColumn columnA = columns.firstWhere((col) => col.field == 'column_a');
+    
+    // Toggle its visibility
+    stateManager.hideColumn(columnA, !columnA.hide);
+  }
+
+  void _showColumnsPopup() {
+    stateManager.showSetColumnsPopup(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Hiding Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _toggleColumnA,
+                  child: Text('Toggle Column A'),
+                ),
+                SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: _showColumnsPopup,
+                  child: Text('Show Columns Popup'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Initializing Hidden Columns
+
+You can initialize columns as hidden when creating them:
+
+```dart
+TrinaColumn(
+  title: 'Hidden Column',
+  field: 'hidden_column',
+  type: TrinaColumnType.text(),
+  hide: true, // This column will be hidden initially
+)
+```
+
+## Customizing the Column Menu Text
+
+You can customize the text used for the "Hide column" option in the column menu:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    localeText: const TrinaGridLocaleText(
+      hideColumn: 'Hide this column', // Custom text for the hide column option
+    ),
+  ),
+)
+```
+
+## Best Practices
+
+1. **Provide Column Management UI**: Always provide users with a way to manage column visibility, either through the column menu or a dedicated UI element that triggers the `showSetColumnsPopup` method.
+
+2. **Consider Initial Visibility**: For grids with many columns, consider which columns should be visible by default. Hide less important columns initially to avoid overwhelming users.
+
+3. **Combine with Column Freezing**: When using column hiding with column freezing, be aware of the automatic unfreezing behavior when there's not enough space in the frozen area.
+
+4. **Auto-Size Configuration**: Decide whether to restore auto-sizing after hiding/showing columns based on your application's needs. For data-dense grids, you might want to maintain user-defined column sizes.
+
+5. **Save User Preferences**: Consider saving the user's column visibility preferences to restore them when they return to the grid.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Freezing](column-freezing.md)
+- [Column Resizing](column-resizing.md)
+- [Column Moving](column-moving.md)
+
+
+---
+
+## Column Sorting
+
+Column sorting is a feature that allows users to order data in TrinaGrid based on the values in a specific column. This feature enhances data analysis by enabling users to quickly identify patterns, find specific values, and organize data in a meaningful way.
+
+## Overview
+
+TrinaGrid provides a comprehensive column sorting system that supports both ascending and descending order. Users can sort columns by clicking on column headers, and developers can also programmatically sort columns using the state manager API.
+
+## Sorting Modes
+
+TrinaGrid supports three sorting modes, defined by the `TrinaColumnSort` enum:
+
+### 1. None (`TrinaColumnSort.none`)
+
+This is the default state where no sorting is applied to the column.
+
+### 2. Ascending (`TrinaColumnSort.ascending`)
+
+In this mode, data is sorted from smallest to largest (A to Z, oldest to newest, etc.). For text, this means alphabetical order.
+
+### 3. Descending (`TrinaColumnSort.descending`)
+
+In this mode, data is sorted from largest to smallest (Z to A, newest to oldest, etc.). For text, this means reverse alphabetical order.
+
+## How to Sort Columns
+
+### Using Column Headers (UI)
+
+The most intuitive way to sort columns is through the user interface:
+
+1. Click once on a column header to sort in ascending order
+2. Click again on the same column header to switch to descending order
+3. Click a third time to remove sorting and return to the original order
+
+As you click on a column header, a sort indicator (arrow) will appear to show the current sort direction.
+
+### Using the State Manager (Programmatic)
+
+You can also sort columns programmatically using the state manager:
+
+```dart
+// Sort a column in ascending order
+stateManager.sortAscending(column);
+
+// Sort a column in descending order
+stateManager.sortDescending(column);
+
+// Toggle sorting (cycles through none -> ascending -> descending -> none)
+stateManager.toggleSortColumn(column);
+```
+
+## Sorting Behavior
+
+### Type-Aware Sorting
+
+TrinaGrid sorts data based on the column's data type. This ensures that numbers, dates, and text are all sorted appropriately:
+
+- **Text columns**: Sorted alphabetically
+- **Number columns**: Sorted numerically
+- **Date columns**: Sorted chronologically
+- **Custom type columns**: Sorted based on the custom comparison logic defined in the column type
+
+### Row Groups
+
+When row grouping is enabled, sorting respects the group structure:
+
+1. Rows within each group are sorted according to the selected column
+2. The groups themselves maintain their original order
+
+## Events
+
+When columns are sorted, TrinaGrid fires events that you can listen to:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onSorted: (TrinaGridOnSortedEvent event) {
+    // Handle column sorted event
+    print('Column sorted: ${event.column.title}');
+    print('New sort order: ${event.column.sort}');
+    print('Previous sort order: ${event.oldSort}');
+  },
+)
+```
+
+The `TrinaGridOnSortedEvent` provides:
+
+- `column`: The column that was sorted
+- `oldSort`: The previous sort state before the change
+
+## Example
+
+Here's a complete example demonstrating column sorting:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnSortingExample extends StatefulWidget {
+  @override
+  _ColumnSortingExampleState createState() => _ColumnSortingExampleState();
+}
+
+class _ColumnSortingExampleState extends State<ColumnSortingExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Date',
+        field: 'date',
+        type: TrinaColumnType.date(),
+      ),
+    ]);
+
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Charlie'),
+          'date': TrinaCell(value: DateTime(2023, 3, 15)),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'Alice'),
+          'date': TrinaCell(value: DateTime(2023, 1, 10)),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Bob'),
+          'date': TrinaCell(value: DateTime(2023, 2, 20)),
+        },
+      ),
+    ]);
+  }
+
+  void _sortIdAscending() {
+    final idColumn = columns.firstWhere((col) => col.field == 'id');
+    stateManager.sortAscending(idColumn);
+  }
+
+  void _sortIdDescending() {
+    final idColumn = columns.firstWhere((col) => col.field == 'id');
+    stateManager.sortDescending(idColumn);
+  }
+
+  void _sortNameAscending() {
+    final nameColumn = columns.firstWhere((col) => col.field == 'name');
+    stateManager.sortAscending(nameColumn);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Sorting Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _sortIdAscending,
+                  child: Text('Sort ID Ascending'),
+                ),
+                SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: _sortIdDescending,
+                  child: Text('Sort ID Descending'),
+                ),
+                SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: _sortNameAscending,
+                  child: Text('Sort Name Ascending'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              onSorted: (TrinaGridOnSortedEvent event) {
+                print('Column sorted: ${event.column.title}');
+                print('New sort order: ${event.column.sort}');
+                print('Previous sort order: ${event.oldSort}');
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Customizing Sort Behavior
+
+### Disabling Sorting for Specific Columns
+
+You can disable sorting for specific columns by setting the `enableSorting` property to `false`:
+
+```dart
+TrinaColumn(
+  title: 'Actions',
+  field: 'actions',
+  type: TrinaColumnType.text(),
+  enableSorting: false, // Disable sorting for this column
+)
+```
+
+### Custom Sorting Logic
+
+You can implement custom sorting logic by creating a custom column type with a custom `compare` method:
+
+```dart
+class CustomColumnType extends TrinaColumnType {
+  const CustomColumnType();
+
+  @override
+  int compare(dynamic a, dynamic b) {
+    // Implement your custom comparison logic here
+    // Return negative if a < b, 0 if a == b, positive if a > b
+    return customCompare(a, b);
+  }
+  
+  // Other required overrides...
+}
+```
+
+## Multi-Column Sorting
+
+TrinaGrid currently supports single-column sorting. When a column is sorted, any previous sorting on other columns is cleared. If you need multi-column sorting (sorting by one column, then by another within the same values), you would need to implement custom sorting logic.
+
+## Best Practices
+
+1. **Choose Appropriate Column Types**: Make sure to set the appropriate column type (text, number, date, etc.) to ensure proper sorting behavior.
+
+2. **Provide Sort Indicators**: TrinaGrid automatically adds sort indicators to column headers, but make sure they are visible and clear to users.
+
+3. **Handle Sort Events**: Listen to sort events to update any dependent UI or perform additional actions when sorting changes.
+
+4. **Consider Performance**: For very large datasets, consider implementing server-side sorting to improve performance.
+
+5. **Combine with Filtering**: Sorting works well in combination with filtering, allowing users to find and organize data more efficiently.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Filtering](column-filtering.md)
+- [Column Resizing](column-resizing.md)
+- [Column Moving](column-moving.md)
+
+
+---
+
+## Column Filtering
+
+Column filtering is a powerful feature that allows users to display only the rows that match specific criteria. This feature enhances data analysis by enabling users to focus on relevant information and quickly find specific values within large datasets.
+
+## Overview
+
+TrinaGrid provides a comprehensive column filtering system that supports various filter types for different column data types. Users can filter data through a dedicated filter row that appears below the column headers, and developers can also programmatically apply filters using the state manager API.
+
+## Enabling Column Filtering
+
+To enable column filtering in your TrinaGrid, you need to set the `showColumnFilter` property to `true`:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    // Enable column filtering
+    event.stateManager.setShowColumnFilter(true);
+  },
+)
+```
+
+When column filtering is enabled, a filter row appears below the column headers, allowing users to enter filter criteria for each column.
+
+## Filter Types
+
+TrinaGrid includes several built-in filter types that can be used to filter data in different ways:
+
+### Text Filters
+
+- **Contains** (`TrinaFilterTypeContains`): Matches rows where the cell value contains the search text
+- **Equals** (`TrinaFilterTypeEquals`): Matches rows where the cell value exactly matches the search text
+- **Starts With** (`TrinaFilterTypeStartsWith`): Matches rows where the cell value starts with the search text
+- **Ends With** (`TrinaFilterTypeEndsWith`): Matches rows where the cell value ends with the search text
+- **Regex** (`TrinaFilterTypeRegex`): Matches rows where the cell value matches the regular expression pattern
+
+#### Regular Expression (Regex) Filter Example
+
+The Regex filter allows more advanced pattern matching:
+
+```dart
+// Example: Filter for email addresses
+// Pattern: .+@.+\..+
+// Matches: user@example.com, info@domain.co.uk
+
+// Example: Filter for numbers
+// Pattern: ^\d+$
+// Matches: 123, 456789
+
+// Example: Filter for specific patterns like product codes
+// Pattern: ^[A-Z]{3}\d{4}$
+// Matches: ABC1234, XYZ5678
+```
+
+### Numeric Filters
+
+- **Greater Than** (`TrinaFilterTypeGreaterThan`): Matches rows where the cell value is greater than the search value
+- **Greater Than or Equal To** (`TrinaFilterTypeGreaterThanOrEqualTo`): Matches rows where the cell value is greater than or equal to the search value
+- **Less Than** (`TrinaFilterTypeLessThan`): Matches rows where the cell value is less than the search value
+- **Less Than or Equal To** (`TrinaFilterTypeLessThanOrEqualTo`): Matches rows where the cell value is less than or equal to the search value
+
+## Filter UI
+
+The filter UI consists of:
+
+1. **Filter Row**: A row below the column headers where users can enter filter criteria
+2. **Filter Type Selector**: A dropdown menu that allows users to select the type of filter to apply
+3. **Filter Input Field**: A text field where users can enter the filter value
+
+Users can click on the filter icon in a column to open the filter type selector and choose the appropriate filter type for that column.
+
+## Filtering Behavior
+
+### Column-Specific Filtering
+
+By default, filters are applied to specific columns. When a user enters a filter value for a column, only that column's values are checked against the filter criteria.
+
+### All-Column Filtering
+
+TrinaGrid also supports filtering across all columns. This allows users to search for a value anywhere in the grid, regardless of which column it appears in.
+
+### Multiple Filters
+
+Users can apply multiple filters to different columns simultaneously. When multiple filters are applied, rows must match all filter criteria to be displayed (AND logic).
+
+## Configuring Column Filtering
+
+You can customize the column filtering behavior through the `columnFilter` configuration:
+
+```dart
+TrinaGridConfiguration(
+  columnFilter: TrinaGridColumnFilterConfig(
+    // Configuration options for filtering
+  ),
+  style: TrinaGridStyleConfig(
+    // Control visibility and appearance of filter icons
+    filterIcon: Icon(Icons.filter_list), // Custom filter icon
+    // or
+    filterIcon: null, // Hide filter icons
+  ),
+)
+```
+
+### Filter Icon Customization
+
+By default, when a filter is applied to a column, a filter icon appears next to the column title. You can customize or hide this icon with the `filterIcon` property in the style configuration:
+
+```dart
+TrinaGridConfiguration(
+  style: TrinaGridStyleConfig(
+    // Use a custom icon
+    filterIcon: Icon(Icons.search),
+    
+    // Or hide filter icons completely
+    filterIcon: null,
+  ),
+)
+```
+
+When `filterIcon` is set to `null`, filter icons will not be displayed in column titles, even when filters are applied. You can also provide a custom icon to change the appearance.
+
+### Disabling Filtering for Specific Columns
+
+You can disable filtering for specific columns by setting the `enableFilterMenuItem` property to `false`:
+
+```dart
+TrinaColumn(
+  title: 'Actions',
+  field: 'actions',
+  type: TrinaColumnType.text(),
+  enableFilterMenuItem: false, // Disable filtering for this column
+)
+```
+
+## Custom Filters
+
+You can create custom filter types by implementing the `TrinaFilterType` interface:
+
+```dart
+class CustomFilter implements TrinaFilterType {
+  @override
+  String get title => 'Custom Filter';
+
+  @override
+  get compare => ({
+        required String? base,
+        required String? search,
+        required TrinaColumn? column,
+      }) {
+        // Implement your custom filtering logic here
+        // Return true if the row should be included, false otherwise
+        return customFilterLogic(base, search);
+      };
+
+  const CustomFilter();
+}
+```
+
+Then add your custom filter to the `filters` list in the `columnFilter` configuration.
+
+## Multi-Items Filter (Multi-line/Comma-separated)
+
+![Multi-Items Filter Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/multi-items-filter.gif)
+
+TrinaGrid provides a built-in multi-items filter type for columns, allowing users to filter rows by matching any value from a list of items. This is useful for scenarios where you want to filter by multiple possible values at once, using either comma-separated or multi-line input.
+
+- **Filter type:** `TrinaFilterTypeMultiItems`
+- **Widget delegate:** `TrinaFilterColumnWidgetDelegate.multiItems`
+- **Case sensitivity:** Configurable (default: true)
+
+### How it works
+
+- The filter value is split by commas or newlines.
+- Each item is trimmed.
+- The cell value is compared to each item (case-sensitive by default).
+- If any item matches, the row is included.
+
+### Example: Case-insensitive multi-items filter
+
+```dart
+TrinaColumn(
+  title: 'Tags',
+  field: 'tags',
+  type: TrinaColumnType.text(),
+  filterWidgetDelegate: const TrinaFilterColumnWidgetDelegate.multiItems(caseSensitive: false),
+)
+
+// In your grid configuration:
+TrinaGridConfiguration(
+  columnFilter: TrinaGridColumnFilterConfig(
+    filters: const [
+      ...FilterHelper.defaultFilters,
+      TrinaFilterTypeMultiItems(caseSensitive: false),
+    ],
+    resolveDefaultColumnFilter: (column, resolver) {
+      if (column.field == 'tags') {
+        return const TrinaFilterTypeMultiItems(caseSensitive: false);
+      }
+      return resolver<TrinaFilterTypeContains>();
+    },
+  ),
+)
+```
+
+### Setting case sensitivity
+
+- Pass `caseSensitive: false` to make the filter ignore case.
+- The option is available both in the filter type and the widget delegate.
+
+### UI
+
+- The multi-items filter uses a multi-line text field by default.
+- Users can enter values separated by commas or new lines.
+
+### When to use
+
+- When you want to allow users to filter by multiple possible values in a single column.
+- For tag, category, or label columns, or any scenario where multi-value matching is needed.
+
+See also: [Column Types](column-types.md), [Custom Filters](#custom-filters)
+
+## Programmatic Filtering
+
+TrinaGrid provides two approaches for programmatically applying filters: the new simplified API methods and the traditional filter row approach.
+
+### New Simplified API (Recommended)
+
+The state manager now provides convenient methods for managing column filters programmatically:
+
+#### Setting Column Filters
+
+```dart
+// Set or update a specific column filter
+stateManager.setColumnFilter(
+  columnField: 'department',
+  filterType: const TrinaFilterTypeEquals(),
+  filterValue: 'Engineering',
+);
+
+// Set boolean filters
+stateManager.setColumnFilter(
+  columnField: 'active',
+  filterType: const TrinaFilterTypeEquals(),
+  filterValue: true,
+);
+
+// Set numeric filters
+stateManager.setColumnFilter(
+  columnField: 'salary',
+  filterType: const TrinaFilterTypeGreaterThan(),
+  filterValue: 60000,
+);
+
+// Set text contains filters
+stateManager.setColumnFilter(
+  columnField: 'name',
+  filterType: const TrinaFilterTypeContains(),
+  filterValue: 'John',
+);
+```
+
+#### Removing Column Filters
+
+```dart
+// Remove a specific column filter
+stateManager.removeColumnFilter('department');
+
+// Clear all column filters at once
+stateManager.clearAllColumnFilters();
+```
+
+#### Getting Current Filter Values
+
+```dart
+// Get the current filter value for a specific column
+dynamic currentValue = stateManager.getColumnFilterValue('department');
+if (currentValue != null) {
+  print('Department is filtered by: $currentValue');
+}
+
+// Get the current filter type for a specific column
+TrinaFilterType? currentFilterType = stateManager.getColumnFilterType('department');
+if (currentFilterType != null) {
+  if (currentFilterType is TrinaFilterTypeEquals) {
+    print('Department filter uses exact matching');
+  } else if (currentFilterType is TrinaFilterTypeContains) {
+    print('Department filter uses contains matching');
+  }
+}
+
+// Check if a column has any filter applied
+bool isDepartmentFiltered = stateManager.getColumnFilterValue('department') != null;
+
+// Example: Toggle a filter based on current state
+void toggleActiveFilter() {
+  dynamic currentValue = stateManager.getColumnFilterValue('active');
+  if (currentValue == null) {
+    // No filter applied, filter for active records
+    stateManager.setColumnFilter(
+      columnField: 'active',
+      filterType: const TrinaFilterTypeEquals(),
+      filterValue: true,
+    );
+  } else {
+    // Filter already applied, remove it
+    stateManager.removeColumnFilter('active');
+  }
+}
+```
+
+#### Practical Example
+
+```dart
+// Apply multiple filters programmatically
+void applyBusinessLogicFilters() {
+  // Filter for active employees only
+  stateManager.setColumnFilter(
+    columnField: 'active',
+    filterType: const TrinaFilterTypeEquals(),
+    filterValue: true,
+  );
+  
+  // Filter for engineering department
+  stateManager.setColumnFilter(
+    columnField: 'department',
+    filterType: const TrinaFilterTypeEquals(),
+    filterValue: 'Engineering',
+  );
+  
+  // Filter for high salaries
+  stateManager.setColumnFilter(
+    columnField: 'salary',
+    filterType: const TrinaFilterTypeGreaterThan(),
+    filterValue: 80000,
+  );
+}
+
+// Clear specific filters
+void clearDepartmentFilter() {
+  stateManager.removeColumnFilter('department');
+}
+
+// Reset all filters
+void resetAllFilters() {
+  stateManager.clearAllColumnFilters();
+}
+```
+
+### Traditional Filter Row Approach
+
+You can also programmatically apply filters using the traditional filter row approach:
+
+```dart
+// Create a filter row
+TrinaRow filterRow = FilterHelper.createFilterRow(
+  columnField: 'column_field',
+  filterType: const TrinaFilterTypeContains(),
+  filterValue: 'search_value',
+);
+
+// Apply the filter
+stateManager.setFilterRows([filterRow]);
+```
+
+To filter across all columns:
+
+```dart
+TrinaRow filterRow = FilterHelper.createFilterRow(
+  columnField: FilterHelper.filterFieldAllColumns,
+  filterType: const TrinaFilterTypeContains(),
+  filterValue: 'search_value',
+);
+
+stateManager.setFilterRows([filterRow]);
+```
+
+To clear all filters:
+
+```dart
+stateManager.setFilterRows([]);
+```
+
+## Events
+
+When filters are applied, TrinaGrid updates its display and notifies listeners. You can listen to these changes through the `onChanged` callback:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (TrinaGridOnChangedEvent event) {
+    // Handle grid changes, including filtering
+    if (event.type == TrinaGridChangeEventType.filterRows) {
+      print('Filters changed');
+    }
+  },
+)
+```
+
+## Example
+
+Here's a complete example demonstrating column filtering:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnFilteringExample extends StatefulWidget {
+  @override
+  _ColumnFilteringExampleState createState() => _ColumnFilteringExampleState();
+}
+
+class _ColumnFilteringExampleState extends State<ColumnFilteringExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Department',
+        field: 'department',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Salary',
+        field: 'salary',
+        type: TrinaColumnType.number(),
+      ),
+    ]);
+
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'John Smith'),
+          'department': TrinaCell(value: 'Engineering'),
+          'salary': TrinaCell(value: 85000),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Jane Doe'),
+          'department': TrinaCell(value: 'Marketing'),
+          'salary': TrinaCell(value: 75000),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Bob Johnson'),
+          'department': TrinaCell(value: 'Engineering'),
+          'salary': TrinaCell(value: 90000),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 4),
+          'name': TrinaCell(value: 'Alice Williams'),
+          'department': TrinaCell(value: 'Sales'),
+          'salary': TrinaCell(value: 80000),
+        },
+      ),
+    ]);
+  }
+
+  void _filterEngineering() {
+    // Filter for Engineering department using the new simplified API
+    stateManager.setColumnFilter(
+      columnField: 'department',
+      filterType: const TrinaFilterTypeEquals(),
+      filterValue: 'Engineering',
+    );
+  }
+
+  void _filterHighSalary() {
+    // Filter for salaries > 80000 using the new simplified API
+    stateManager.setColumnFilter(
+      columnField: 'salary',
+      filterType: const TrinaFilterTypeGreaterThan(),
+      filterValue: 80000, // Note: numeric value, not string
+    );
+  }
+
+  void _clearFilters() {
+    // Clear all filters using the new simplified API
+    stateManager.clearAllColumnFilters();
+  }
+
+  void _filterMultiple() {
+    // Example of applying multiple filters
+    stateManager.setColumnFilter(
+      columnField: 'department',
+      filterType: const TrinaFilterTypeEquals(),
+      filterValue: 'Engineering',
+    );
+    
+    stateManager.setColumnFilter(
+      columnField: 'salary',
+      filterType: const TrinaFilterTypeGreaterThan(),
+      filterValue: 80000,
+    );
+  }
+
+  void _removeSpecificFilter() {
+    // Remove only the department filter
+    stateManager.removeColumnFilter('department');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Filtering Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                ElevatedButton(
+                  onPressed: _filterEngineering,
+                  child: Text('Filter Engineering'),
+                ),
+                ElevatedButton(
+                  onPressed: _filterHighSalary,
+                  child: Text('Filter Salary > 80000'),
+                ),
+                ElevatedButton(
+                  onPressed: _filterMultiple,
+                  child: Text('Multiple Filters'),
+                ),
+                ElevatedButton(
+                  onPressed: _removeSpecificFilter,
+                  child: Text('Remove Dept Filter'),
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
+                ),
+                ElevatedButton(
+                  onPressed: _clearFilters,
+                  child: Text('Clear All Filters'),
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+                // Enable column filtering
+                stateManager.setShowColumnFilter(true);
+              },
+              onChanged: (TrinaGridOnChangedEvent event) {
+                print('Grid changed: ${event.type}');
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Controlling Keyboard Navigation in Column Filters
+
+By default, when users press the Enter key in a column filter, the focus moves to the next field (usually the grid cell below). This behavior follows the grid's global `enterKeyAction` configuration.
+
+However, in some scenarios you might want to prevent this behavior for specific columns. For example, when a column filter needs to capture the Enter key for submitting a search or when working with multi-line filters.
+
+### Column-Specific Enter Key Behavior
+
+TrinaGrid allows you to override the default Enter key behavior for individual column filters using the `filterEnterKeyAction` property:
+
+```dart
+TrinaColumn(
+  title: 'Description',
+  field: 'description',
+  type: TrinaColumnType.text(),
+  // Prevent Enter key from moving focus in this column's filter
+  filterEnterKeyAction: TrinaGridEnterKeyAction.none,
+)
+```
+
+### Available Options
+
+The `filterEnterKeyAction` property accepts the same values as the grid-level `enterKeyAction` configuration:
+
+- **`TrinaGridEnterKeyAction.editingAndMoveDown`**: (Default) Moves focus to the cell below when Enter is pressed
+- **`TrinaGridEnterKeyAction.editingAndMoveRight`**: Moves focus to the cell to the right when Enter is pressed
+- **`TrinaGridEnterKeyAction.toggleEditing`**: Toggles editing state without moving focus
+- **`TrinaGridEnterKeyAction.none`**: Disables Enter key navigation, allowing the key press to be handled by other listeners
+
+### Example: Preventing Enter Key Navigation for a Specific Column
+
+```dart
+List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'ID',
+    field: 'id',
+    type: TrinaColumnType.number(),
+    // Uses the default Enter key behavior from grid configuration
+  ),
+  TrinaColumn(
+    title: 'Name',
+    field: 'name',
+    type: TrinaColumnType.text(),
+    // Uses the default Enter key behavior from grid configuration
+  ),
+  TrinaColumn(
+    title: 'Description',
+    field: 'description',
+    type: TrinaColumnType.text(),
+    // Override Enter key behavior for this column's filter only
+    filterEnterKeyAction: TrinaGridEnterKeyAction.none,
+    // This allows the filter to handle the Enter key internally
+    // without moving focus to the next field
+  ),
+];
+
+// Grid configuration with default Enter key behavior
+TrinaGridConfiguration configuration = TrinaGridConfiguration(
+  enterKeyAction: TrinaGridEnterKeyAction.editingAndMoveDown,
+  // Other configuration options...
+);
+```
+
+In this example, pressing Enter in the ID or Name column filters will move focus to the cell below, following the grid's default configuration. However, pressing Enter in the Description column filter will not move focus, allowing for custom handling of the Enter key.
+
+## Best Practices
+
+1. **Use the New Simplified API**: Prefer `setColumnFilter()`, `removeColumnFilter()`, and `clearAllColumnFilters()` methods over the traditional filter row approach for cleaner, more maintainable code.
+
+2. **Enable Filtering Selectively**: Only enable filtering for columns where it makes sense. For action columns or columns with complex widgets, filtering may not be relevant.
+
+3. **Choose Appropriate Default Filters**: Set default filter types that make sense for each column's data type. For example, use "Contains" for text columns and "Greater Than" for numeric columns.
+
+4. **Provide Clear UI Indicators**: Ensure that users can easily see which filters are currently applied. TrinaGrid automatically highlights filtered columns.
+
+5. **Use Proper Data Types**: When using `setColumnFilter()`, use the appropriate data types (e.g., numeric values for number columns, boolean values for boolean columns) rather than always using strings.
+
+6. **Consider Performance**: For very large datasets, consider implementing server-side filtering to improve performance.
+
+7. **Combine with Sorting**: Filtering works well in combination with sorting, allowing users to find and organize data more efficiently.
+
+8. **Provide Filter Management UI**: Consider adding buttons or controls that allow users to easily clear specific filters or all filters at once using the new API methods.
+
+9. **Save User Preferences**: Consider saving the user's filter preferences to restore them when they return to the grid.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Sorting](column-sorting.md)
+- [Column Resizing](column-resizing.md)
+- [Column Moving](column-moving.md)
+- [Column Hiding](column-hiding.md)
+
+
+---
+
+## Column Groups
+
+Column groups are a feature that allows you to organize columns into hierarchical groups, providing a more structured and intuitive way to present complex data in TrinaGrid.
+
+## Overview
+
+Column groups enable you to create a multi-level header structure by grouping related columns together. This helps users understand the relationship between different columns and makes it easier to navigate and comprehend large datasets with many columns.
+
+## Creating Column Groups
+
+Column groups are defined using the `TrinaColumnGroup` class. You can create a column group in two ways:
+
+1. By specifying a list of column fields that belong to the group
+2. By specifying a list of child column groups to create a nested hierarchy
+
+### Basic Column Group
+
+To create a basic column group that contains specific columns:
+
+```dart
+TrinaColumnGroup(
+  title: 'Personal Information',
+  fields: ['firstName', 'lastName', 'email'],
+)
+```
+
+This creates a group titled "Personal Information" that spans the columns with fields 'firstName', 'lastName', and 'email'.
+
+### Nested Column Groups
+
+You can create a hierarchical structure by nesting column groups:
+
+```dart
+TrinaColumnGroup(
+  title: 'Contact Information',
+  children: [
+    TrinaColumnGroup(
+      title: 'Name',
+      fields: ['firstName', 'lastName'],
+    ),
+    TrinaColumnGroup(
+      title: 'Communication',
+      fields: ['email', 'phone'],
+    ),
+  ],
+)
+```
+
+This creates a parent group "Contact Information" with two child groups: "Name" and "Communication".
+
+## Expanded Columns
+
+You can designate a column as an "expanded column" within a group. This is useful for columns that should take up more visual space:
+
+```dart
+TrinaColumnGroup(
+  title: 'Description',
+  fields: ['description'],
+  expandedColumn: true,
+)
+```
+
+When a column group has `expandedColumn` set to `true`:
+
+- The group must contain exactly one column
+- The column will expand to fill available space
+- The group title is not shown
+- The height is set to the maximum depth of the group hierarchy
+
+## Styling Column Groups
+
+You can customize the appearance of column groups:
+
+```dart
+TrinaColumnGroup(
+  title: 'Financial Data',
+  fields: ['revenue', 'expenses', 'profit'],
+  backgroundColor: Colors.lightBlue.shade100,
+  titleTextAlign: TrinaColumnTextAlign.center,
+  titlePadding: EdgeInsets.symmetric(vertical: 8.0),
+)
+```
+
+### Available Styling Options
+
+- **backgroundColor**: Sets the background color of the group header
+- **titleTextAlign**: Controls the alignment of the title text (left, center, right)
+- **titlePadding**: Adjusts the padding around the title
+- **titleSpan**: Allows for rich text formatting using TextSpan or WidgetSpan
+
+## Using Column Groups in TrinaGrid
+
+To use column groups in your TrinaGrid, pass a list of column groups to the `columnGroups` parameter:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  columnGroups: columnGroups,
+  // other parameters...
+)
+```
+
+## Column Group Behavior
+
+### Column Movement
+
+When columns are moved:
+
+- If a column is moved outside its group, it is removed from the group
+- If all columns are removed from a group, the group is automatically removed
+- Columns can be moved between groups, which will update the group structure accordingly
+
+### Column Hiding
+
+When columns are hidden:
+
+- If all columns in a group are hidden, the group is not displayed
+- When a hidden column is shown again, it returns to its original group
+
+### Column Resizing
+
+Column resizing works normally within column groups:
+
+- Resizing a column affects only that column, not the entire group
+- The group width automatically adjusts to accommodate the total width of its columns
+
+## Example
+
+Here's a complete example demonstrating column groups:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnGroupExample extends StatefulWidget {
+  @override
+  _ColumnGroupExampleState createState() => _ColumnGroupExampleState();
+}
+
+class _ColumnGroupExampleState extends State<ColumnGroupExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  final List<TrinaColumnGroup> columnGroups = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'First Name',
+        field: 'firstName',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Last Name',
+        field: 'lastName',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Email',
+        field: 'email',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Phone',
+        field: 'phone',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Department',
+        field: 'department',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Position',
+        field: 'position',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Notes',
+        field: 'notes',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+    ]);
+
+    // Define rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'firstName': TrinaCell(value: 'John'),
+          'lastName': TrinaCell(value: 'Smith'),
+          'email': TrinaCell(value: 'john.smith@example.com'),
+          'phone': TrinaCell(value: '555-123-4567'),
+          'department': TrinaCell(value: 'Engineering'),
+          'position': TrinaCell(value: 'Senior Developer'),
+          'notes': TrinaCell(value: 'Team lead for Project X'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'firstName': TrinaCell(value: 'Jane'),
+          'lastName': TrinaCell(value: 'Doe'),
+          'email': TrinaCell(value: 'jane.doe@example.com'),
+          'phone': TrinaCell(value: '555-987-6543'),
+          'department': TrinaCell(value: 'Marketing'),
+          'position': TrinaCell(value: 'Marketing Manager'),
+          'notes': TrinaCell(value: 'Handles social media campaigns'),
+        },
+      ),
+      // Add more rows as needed
+    ]);
+
+    // Define column groups
+    columnGroups.addAll([
+      TrinaColumnGroup(
+        title: 'ID',
+        fields: ['id'],
+      ),
+      TrinaColumnGroup(
+        title: 'Personal Information',
+        backgroundColor: Colors.lightBlue.shade100,
+        children: [
+          TrinaColumnGroup(
+            title: 'Name',
+            fields: ['firstName', 'lastName'],
+            backgroundColor: Colors.lightBlue.shade50,
+          ),
+          TrinaColumnGroup(
+            title: 'Contact',
+            fields: ['email', 'phone'],
+            backgroundColor: Colors.lightBlue.shade50,
+          ),
+        ],
+      ),
+      TrinaColumnGroup(
+        title: 'Job Information',
+        backgroundColor: Colors.amber.shade100,
+        fields: ['department', 'position'],
+      ),
+      TrinaColumnGroup(
+        title: 'Additional Information',
+        fields: ['notes'],
+        expandedColumn: true,
+      ),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Groups Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        columnGroups: columnGroups,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          stateManager = event.stateManager;
+        },
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Logical Grouping**: Group columns based on logical relationships or categories that make sense for your data.
+
+2. **Limit Nesting Depth**: While you can nest groups to any depth, too many levels can become confusing. Try to limit nesting to 2-3 levels for better usability.
+
+3. **Consistent Styling**: Use consistent styling for groups of the same level to create a visual hierarchy. For example, use darker colors for top-level groups and lighter shades for nested groups.
+
+4. **Clear Naming**: Use clear, concise titles for your column groups that accurately describe the data they contain.
+
+5. **Consider Expanded Columns**: Use the `expandedColumn` property for columns that contain lengthy text or detailed information that benefits from additional space.
+
+6. **Combine with Freezing**: Consider freezing important column groups on the left side of the grid to keep them visible while scrolling horizontally.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Resizing](column-resizing.md)
+- [Column Moving](column-moving.md)
+- [Column Hiding](column-hiding.md)
+- [Column Freezing](column-freezing.md)
+
+
+---
+
+## Column Renderer
+
+The column renderer feature allows you to customize the appearance and behavior of entire columns in TrinaGrid. This is particularly useful when you want to:
+
+- Apply consistent formatting to all cells in a column
+- Create specialized visualizations for specific data types
+- Implement interactive column-wide features
+- Maintain a consistent look and feel for related data
+
+## Overview
+
+Column renderers provide a way to define how all cells within a column should be displayed. This is different from cell-level renderers, which apply to individual cells. Column renderers are:
+
+- Applied to all cells in the column
+- Defined at the column level
+- Overridden by cell-level renderers when both are present
+
+## Basic Usage
+
+To apply a custom renderer to a column, provide a `renderer` function when creating the `TrinaColumn`:
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  renderer: (rendererContext) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: _getStatusColor(rendererContext.cell.value),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        rendererContext.cell.value.toString(),
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  },
+)
+```
+
+## The TrinaColumnRendererContext
+
+The renderer function receives a `TrinaColumnRendererContext` object that provides access to:
+
+- `column`: The column definition
+- `rowIdx`: The row index
+- `row`: The row data
+- `cell`: The cell being rendered
+- `stateManager`: The grid's state manager
+
+This context is similar to the cell renderer context but is applied at the column level.
+
+## Examples
+
+### Progress Bar Column
+
+Create a column that displays progress bars for percentage values:
+
+```dart
+TrinaColumn(
+  title: 'Progress',
+  field: 'progress',
+  renderer: (rendererContext) {
+    final progress = (rendererContext.cell.value as num).toDouble();
+    
+    return Stack(
+      children: [
+        Container(
+          width: double.infinity,
+          height: 20,
+          decoration: BoxDecoration(
+            color: Colors.grey[200],
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+        Container(
+          width: (progress / 100) * rendererContext.column.width,
+          height: 20,
+          decoration: BoxDecoration(
+            color: _getProgressColor(progress),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+        Center(
+          child: Text(
+            '${progress.toStringAsFixed(1)}%',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: progress > 50 ? Colors.white : Colors.black,
+            ),
+          ),
+        ),
+      ],
+    );
+  },
+)
+
+Color _getProgressColor(double progress) {
+  if (progress < 30) return Colors.red;
+  if (progress < 70) return Colors.orange;
+  return Colors.green;
+}
+```
+
+### Rating Stars Column
+
+Create a column that displays star ratings:
+
+```dart
+TrinaColumn(
+  title: 'Rating',
+  field: 'rating',
+  renderer: (rendererContext) {
+    final rating = (rendererContext.cell.value as num).toDouble();
+    
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(5, (index) {
+        return Icon(
+          index < rating ? Icons.star : Icons.star_border,
+          color: Colors.amber,
+          size: 16,
+        );
+      }),
+    );
+  },
+)
+```
+
+### Trend Indicator Column
+
+Create a column that shows trend indicators with arrows:
+
+```dart
+TrinaColumn(
+  title: 'Trend',
+  field: 'trend',
+  renderer: (rendererContext) {
+    final trend = rendererContext.cell.value as double;
+    
+    IconData iconData;
+    Color iconColor;
+    String trendText;
+    
+    if (trend > 10) {
+      iconData = Icons.trending_up;
+      iconColor = Colors.green;
+      trendText = '+${trend.toStringAsFixed(1)}%';
+    } else if (trend < -10) {
+      iconData = Icons.trending_down;
+      iconColor = Colors.red;
+      trendText = '${trend.toStringAsFixed(1)}%';
+    } else {
+      iconData = Icons.trending_flat;
+      iconColor = Colors.grey;
+      trendText = '${trend.toStringAsFixed(1)}%';
+    }
+    
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Icon(
+          iconData,
+          color: iconColor,
+          size: 20,
+        ),
+        const SizedBox(width: 4),
+        Text(
+          trendText,
+          style: TextStyle(
+            color: iconColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  },
+)
+```
+
+### Interactive Toggle Column
+
+Create a column with interactive toggle switches:
+
+```dart
+TrinaColumn(
+  title: 'Enabled',
+  field: 'enabled',
+  renderer: (rendererContext) {
+    return Switch(
+      value: rendererContext.cell.value as bool,
+      onChanged: (newValue) {
+        rendererContext.stateManager.changeCellValue(
+          rendererContext.cell,
+          newValue,
+        );
+      },
+      activeColor: Colors.green,
+    );
+  },
+)
+```
+
+### Conditional Formatting Column
+
+Apply different styles based on thresholds:
+
+```dart
+TrinaColumn(
+  title: 'Score',
+  field: 'score',
+  renderer: (rendererContext) {
+    final score = rendererContext.cell.value as int;
+    
+    Color backgroundColor;
+    Color textColor = Colors.white;
+    
+    if (score >= 90) {
+      backgroundColor = Colors.green;
+    } else if (score >= 70) {
+      backgroundColor = Colors.blue;
+    } else if (score >= 50) {
+      backgroundColor = Colors.orange;
+    } else {
+      backgroundColor = Colors.red;
+    }
+    
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        score.toString(),
+        style: TextStyle(
+          color: textColor,
+          fontWeight: FontWeight.bold,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  },
+)
+```
+
+## Combining with Column Types
+
+Column renderers can be combined with column types to leverage both type-specific behavior and custom rendering:
+
+```dart
+TrinaColumn(
+  title: 'Price',
+  field: 'price',
+  type: TrinaColumnType.currency(
+    symbol: '\$',
+    decimalDigits: 2,
+  ),
+  renderer: (rendererContext) {
+    final price = rendererContext.cell.value as double;
+    final formattedPrice = '\$${price.toStringAsFixed(2)}';
+    
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: price > 1000 ? Colors.amber[100] : Colors.transparent,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        formattedPrice,
+        style: TextStyle(
+          fontWeight: price > 1000 ? FontWeight.bold : FontWeight.normal,
+        ),
+        textAlign: TextAlign.right,
+      ),
+    );
+  },
+)
+```
+
+## Reusable Column Renderers
+
+For better code organization and reusability, you can define renderer functions separately:
+
+```dart
+Widget statusRenderer(TrinaColumnRendererContext context) {
+  Color backgroundColor;
+  Color textColor = Colors.white;
+
+  switch (context.cell.value) {
+    case 'Completed':
+      backgroundColor = Colors.green;
+      break;
+    case 'In Progress':
+      backgroundColor = Colors.orange;
+      break;
+    case 'Pending':
+      backgroundColor = Colors.blue;
+      break;
+    case 'Cancelled':
+      backgroundColor = Colors.red;
+      break;
+    default:
+      backgroundColor = Colors.grey;
+  }
+
+  return Container(
+    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    decoration: BoxDecoration(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Text(
+      context.cell.value.toString(),
+      style: TextStyle(
+        color: textColor,
+        fontWeight: FontWeight.bold,
+      ),
+      textAlign: TextAlign.center,
+    ),
+  );
+}
+
+// Then use it in your column definition
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  renderer: statusRenderer,
+)
+```
+
+## Best Practices
+
+1. **Performance**: Keep your renderer functions efficient to maintain smooth scrolling
+2. **Reusability**: Create reusable renderer functions for common patterns
+3. **Responsiveness**: Make your custom widgets adapt to different column widths
+4. **Consistency**: Maintain a consistent look and feel across your grid
+5. **Accessibility**: Ensure your custom renderers maintain accessibility features
+6. **Cell vs. Column Renderers**: Use column renderers for consistent formatting across a column, and cell renderers for exceptions
+
+## Comparison with Cell Renderer
+
+| Feature | Column Renderer | Cell Renderer |
+|---------|----------------|---------------|
+| **Scope** | Applied to all cells in a column | Applied to individual cells |
+| **Definition** | Defined at the column level | Defined at the cell level |
+| **Precedence** | Lower precedence | Higher precedence (overrides column renderer) |
+| **Use Case** | Consistent formatting for a data type | Special cases and exceptions |
+| **Performance** | More efficient for columns with similar formatting | More flexible but potentially less efficient |
+
+## Related Features
+
+- [Cell Renderers](cell-renderer.md) - For customizing individual cells
+- [Column Types](column-types.md) - For type-specific behavior
+- [Custom Styling](custom-styling.md) - For global styling options
+- [Themes](themes.md) - For applying consistent themes across the grid
+
+
+---
+
+## Column Title Renderer
+
+The column title renderer feature allows you to fully customize the appearance and behavior of column titles in TrinaGrid. This is useful when you want to:
+
+- Create visually distinctive column headers
+- Add custom icons or badges to column titles
+- Use multi-line text or rich formatting in titles
+- Implement interactive elements in column headers
+- Maintain full control over title styling while preserving functionality
+
+![Column Title Renderer Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/column-title-renderer.gif)
+
+## Overview
+
+Column title renderers provide a way to define how the title of a column should be displayed. Unlike the standard title or titleSpan properties, the titleRenderer gives you complete control over the appearance while still integrating with core grid functionality like:
+
+- Column sorting
+- Context menus
+- Column dragging/moving
+- Column resizing
+
+## Basic Usage
+
+To apply a custom title renderer to a column, provide a `titleRenderer` function when creating the `TrinaColumn`:
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.text(),
+  titleRenderer: (rendererContext) {
+    return Container(
+      width: rendererContext.column.width,
+      height: rendererContext.height,
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      decoration: BoxDecoration(
+        color: Colors.blue.shade100,
+        border: Border(
+          right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.info_outline, color: Colors.blue),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              rendererContext.column.title,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (rendererContext.showContextIcon) 
+            rendererContext.contextMenuIcon,
+        ],
+      ),
+    );
+  },
+)
+```
+
+## The TrinaColumnTitleRendererContext
+
+The titleRenderer function receives a `TrinaColumnTitleRendererContext` object that provides access to:
+
+- `column`: The column definition
+- `stateManager`: The grid's state manager
+- `height`: The height of the column title
+- `showContextIcon`: Whether the context menu icon should be shown
+- `contextMenuIcon`: The default context menu icon widget
+- `isFiltered`: Whether the column is filtered
+- `showContextMenu`: Function to show the context menu
+
+This context provides all the information and functions needed to create fully custom title widgets while preserving built-in functionality.
+
+## Working with Context Menu
+
+When customizing column titles, it's important to maintain the context menu functionality if your users depend on it. The renderer context includes both information about whether to show the icon and the icon widget itself:
+
+```dart
+titleRenderer: (rendererContext) {
+  return Container(
+    // ... container properties ...
+    child: Row(
+      children: [
+        // ... your custom title content ...
+        
+        // Add the context menu icon if needed
+        if (rendererContext.showContextIcon) 
+          rendererContext.contextMenuIcon,
+      ],
+    ),
+  );
+}
+```
+
+## Examples
+
+### Gradient Background Title
+
+Create a column title with a gradient background:
+
+```dart
+TrinaColumn(
+  title: 'Custom Title',
+  field: 'customField',
+  titleRenderer: (rendererContext) {
+    return Container(
+      width: rendererContext.column.width,
+      height: rendererContext.height,
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.blue.shade200, Colors.blue.shade500],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        border: Border(
+          right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.star, color: Colors.amber),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              rendererContext.column.title,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (rendererContext.showContextIcon) 
+            rendererContext.contextMenuIcon,
+        ],
+      ),
+    );
+  },
+)
+```
+
+### Multi-line Title
+
+Create a title with multiple lines of text:
+
+```dart
+TrinaColumn(
+  title: 'Multi-line Title',
+  field: 'multilineField',
+  titleRenderer: (rendererContext) {
+    return Container(
+      width: rendererContext.column.width,
+      height: rendererContext.height,
+      padding: const EdgeInsets.all(4.0),
+      decoration: BoxDecoration(
+        color: Colors.green.shade50,
+        border: Border(
+          right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+        ),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Multi-line',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 13,
+            ),
+          ),
+          Text(
+            'Title',
+            style: TextStyle(
+              fontSize: 11,
+              color: Colors.grey.shade700,
+            ),
+          ),
+        ],
+      ),
+    );
+  },
+)
+```
+
+### Badge Title
+
+Create a title with a badge indicator:
+
+```dart
+TrinaColumn(
+  title: 'With Badge',
+  field: 'badgeField',
+  titleRenderer: (rendererContext) {
+    return Container(
+      width: rendererContext.column.width,
+      height: rendererContext.height,
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        border: Border(
+          right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              rendererContext.column.title,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.red,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              'NEW',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          if (rendererContext.showContextIcon) SizedBox(width: 8),
+          if (rendererContext.showContextIcon) rendererContext.contextMenuIcon,
+        ],
+      ),
+    );
+  },
+)
+```
+
+### Interactive Filter Title
+
+Create a title with a filter icon that opens the filter menu:
+
+```dart
+TrinaColumn(
+  title: 'Interactive Filter',
+  field: 'filterField',
+  titleRenderer: (rendererContext) {
+    return Container(
+      width: rendererContext.column.width,
+      height: rendererContext.height,
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              rendererContext.column.title,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (rendererContext.isFiltered)
+            IconButton(
+              icon: Icon(Icons.filter_alt, color: Colors.blue),
+              onPressed: () {
+                rendererContext.stateManager.showFilterPopup(
+                  context, 
+                  calledColumn: rendererContext.column,
+                );
+              },
+              constraints: BoxConstraints(
+                minHeight: 36,
+                minWidth: 36,
+              ),
+              padding: EdgeInsets.zero,
+              iconSize: 20,
+            ),
+          if (rendererContext.showContextIcon) rendererContext.contextMenuIcon,
+        ],
+      ),
+    );
+  },
+)
+```
+
+## Considerations
+
+When using column title renderers, keep these points in mind:
+
+1. **Width and Height**: Always use the width and height provided in the context to ensure proper sizing.
+2. **Border Styling**: Include border styling in your container to maintain visual consistency.
+3. **Context Menu Icon**: If your users rely on the context menu, make sure to include the icon in your custom renderer.
+4. **Overflow Handling**: Implement proper overflow handling for text to prevent layout issues.
+5. **Preserving Functionality**: The feature preserves column dragging and other functionality automatically.
+
+## Complete Example
+
+Here's a comprehensive example showing multiple custom title renderers:
+
+```dart
+TrinaGrid(
+  columns: [
+    TrinaColumn(
+      title: 'Standard Column',
+      field: 'column1',
+      type: TrinaColumnType.text(),
+    ),
+    TrinaColumn(
+      title: 'Custom Title',
+      field: 'column2',
+      type: TrinaColumnType.text(),
+      backgroundColor: Colors.blue.shade50,
+      titleRenderer: (rendererContext) {
+        return Container(
+          width: rendererContext.column.width,
+          height: rendererContext.height,
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Colors.blue.shade200, Colors.blue.shade500],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            border: Border(
+              right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.star, color: Colors.amber),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  'Custom Title',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (rendererContext.showContextIcon) rendererContext.contextMenuIcon,
+            ],
+          ),
+        );
+      },
+    ),
+    TrinaColumn(
+      title: 'With Icon',
+      field: 'column3',
+      type: TrinaColumnType.text(),
+      titleRenderer: (rendererContext) {
+        return Container(
+          width: rendererContext.column.width,
+          height: rendererContext.height,
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          decoration: BoxDecoration(
+            color: Colors.grey.shade100,
+            border: Border(
+              right: BorderSide(color: Colors.grey.shade300, width: 1.0),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, color: Colors.blue),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  rendererContext.column.title,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (rendererContext.showContextIcon) rendererContext.contextMenuIcon,
+            ],
+          ),
+        );
+      },
+    ),
+  ],
+  rows: rows,
+  // ... other grid properties
+)
+```
+
+
+---
+
+## Column Footer
+
+Column footers provide a way to display aggregated information at the bottom of each column in TrinaGrid, such as sum, average, minimum, maximum, or count of values.
+
+## Overview
+
+The column footer feature allows you to add a footer section to each column in your grid, which can be used to display summary information about the data in that column. This is particularly useful for numerical data where you want to show totals or other statistical information.
+
+## Enabling Column Footers
+
+Column footers are enabled on a per-column basis by setting the `footerRenderer` property of a `TrinaColumn`. The `footerRenderer` is a callback function that returns a widget to be displayed in the footer of the column.
+
+```dart
+TrinaColumn(
+  title: 'Revenue',
+  field: 'revenue',
+  type: TrinaColumnType.number(format: '#,###.##'),
+  footerRenderer: (rendererContext) {
+    // Return a widget to be displayed in the footer
+    return TrinaAggregateColumnFooter(
+      rendererContext: rendererContext,
+      type: TrinaAggregateColumnType.sum,
+      numberFormat: NumberFormat('Total: #,###.##'),
+      alignment: Alignment.center,
+    );
+  },
+)
+```
+
+## Using the TrinaAggregateColumnFooter Widget
+
+TrinaGrid provides a built-in widget called `TrinaAggregateColumnFooter` that makes it easy to display aggregated values in column footers. This widget can calculate and display various types of aggregations:
+
+### Aggregation Types
+
+The `TrinaAggregateColumnFooter` widget supports the following aggregation types:
+
+- **Sum**: Calculates the sum of all values in the column
+- **Average**: Calculates the average of all values in the column
+- **Min**: Displays the minimum value in the column
+- **Max**: Displays the maximum value in the column
+- **Count**: Counts the number of rows that match a specified condition
+
+### Basic Usage
+
+Here's a basic example of using `TrinaAggregateColumnFooter` to display the sum of values in a column:
+
+```dart
+TrinaColumn(
+  title: 'Revenue',
+  field: 'revenue',
+  type: TrinaColumnType.number(format: '#,###.##'),
+  footerRenderer: (rendererContext) {
+    return TrinaAggregateColumnFooter(
+      rendererContext: rendererContext,
+      type: TrinaAggregateColumnType.sum,
+      numberFormat: NumberFormat('#,###.##'),
+      alignment: Alignment.center,
+    );
+  },
+)
+```
+
+### Customizing the Display Format
+
+You can customize the format of the displayed value using the `numberFormat` parameter:
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.sum,
+  numberFormat: NumberFormat('Total: #,###.##'),  
+  alignment: Alignment.center,
+)
+```
+
+For example, to format the aggregated value as currency, you can use:
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.sum,
+  numberFormat: NumberFormat.simpleCurrency(),
+  alignment: Alignment.center,
+)
+```
+
+### Filtering Values for Aggregation
+
+You can use the `filter` parameter to specify which cells should be included in the aggregation:
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.count,
+  numberFormat: NumberFormat('checked: #,###'),
+  filter: (cell) => cell.row.checked == true,
+  alignment: Alignment.center,
+)
+```
+
+### Customizing the Text Appearance
+
+You can customize the appearance of the text using the `titleSpanBuilder` parameter:
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.sum,
+  numberFormat: NumberFormat('#,###.##'),
+  alignment: Alignment.center,
+  titleSpanBuilder: (text) {
+    return [
+      const TextSpan(
+        text: 'Total: ',
+        style: TextStyle(color: Colors.red, fontWeight: FontWeight.bold),
+      ),
+      TextSpan(text: text),
+    ];
+  },
+)
+```
+
+## Controlling Which Rows are Included in Aggregation
+
+### Row Iteration Type
+
+The `iterateRowType` parameter controls which rows are included in the aggregation:
+
+- **All**: Includes all rows in the grid, regardless of filtering or pagination
+- **Filtered**: Includes only rows that match the current filter criteria
+- **FilteredAndPaginated**: Includes only rows that are both filtered and visible on the current page (default)
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.sum,
+  iterateRowType: TrinaAggregateColumnIterateRowType.all,
+  numberFormat: NumberFormat('Total (All): #,###.##'),
+)
+```
+
+### Row Grouping Type
+
+When row grouping is enabled, the `groupedRowType` parameter controls how grouped rows are handled:
+
+- **All**: Processes both groups and rows (default)
+- **ExpandedAll**: Processes only the group and the children of expanded groups
+- **Rows**: Processes non-group rows only
+- **ExpandedRows**: Processes only expanded rows, not groups
+
+```dart
+TrinaAggregateColumnFooter(
+  rendererContext: rendererContext,
+  type: TrinaAggregateColumnType.sum,
+  groupedRowType: TrinaAggregateColumnGroupedRowType.rows,
+  numberFormat: NumberFormat('Total (Non-Group): #,###.##'),
+)
+```
+
+## Creating Custom Footer Widgets
+
+While `TrinaAggregateColumnFooter` provides a convenient way to display aggregated values, you can also create your own custom footer widgets. The `footerRenderer` callback provides a `TrinaColumnFooterRendererContext` that contains the column and state manager, which you can use to access the grid's data and state.
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  footerRenderer: (rendererContext) {
+    // Create a custom footer widget
+    return Container(
+      padding: const EdgeInsets.all(8.0),
+      alignment: Alignment.center,
+      child: Text(
+        'Custom Footer',
+        style: TextStyle(fontWeight: FontWeight.bold),
+      ),
+    );
+  },
+)
+```
+
+When creating custom footer widgets, you'll need to handle updates to the widget when the grid's data changes. Consider extending `TrinaStatefulWidget` and implementing `TrinaStateWithChange` to properly handle updates.
+
+## Example
+
+Here's a complete example demonstrating various types of column footers:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ColumnFooterExample extends StatefulWidget {
+  @override
+  _ColumnFooterExampleState createState() => _ColumnFooterExampleState();
+}
+
+class _ColumnFooterExampleState extends State<ColumnFooterExample> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        enableRowChecked: true,
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.count,
+            numberFormat: NumberFormat('Checked: #,###'),
+            filter: (cell) => cell.row.checked == true,
+            alignment: Alignment.center,
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Revenue',
+        field: 'revenue',
+        type: TrinaColumnType.number(),
+        textAlign: TrinaColumnTextAlign.right,
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.sum,
+            numberFormat: NumberFormat('#,###'),
+            alignment: Alignment.center,
+            titleSpanBuilder: (text) {
+              return [
+                const TextSpan(
+                  text: 'Sum',
+                  style: TextStyle(color: Colors.red),
+                ),
+                const TextSpan(text: ' : '),
+                TextSpan(text: text),
+              ];
+            },
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Profit',
+        field: 'profit',
+        type: TrinaColumnType.number(format: '#,###.###'),
+        textAlign: TrinaColumnTextAlign.right,
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.average,
+            numberFormat: NumberFormat('#,###.###'),
+            alignment: Alignment.center,
+            titleSpanBuilder: (text) {
+              return [
+                const TextSpan(text: 'Average: '),
+                TextSpan(text: text),
+              ];
+            },
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Quantity',
+        field: 'quantity',
+        type: TrinaColumnType.number(),
+        textAlign: TrinaColumnTextAlign.right,
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.min,
+            numberFormat: NumberFormat('#,###'),
+            alignment: Alignment.center,
+            titleSpanBuilder: (text) {
+              return [
+                const TextSpan(text: 'Min: '),
+                TextSpan(text: text),
+              ];
+            },
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Price',
+        field: 'price',
+        type: TrinaColumnType.number(),
+        textAlign: TrinaColumnTextAlign.right,
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.max,
+            numberFormat: NumberFormat('#,###'),
+            alignment: Alignment.center,
+            titleSpanBuilder: (text) {
+              return [
+                const TextSpan(text: 'Max: '),
+                TextSpan(text: text),
+              ];
+            },
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Category',
+        field: 'category',
+        type: TrinaColumnType.select(['Electronics', 'Clothing', 'Food', 'Books']),
+        footerRenderer: (rendererContext) {
+          return TrinaAggregateColumnFooter(
+            rendererContext: rendererContext,
+            type: TrinaAggregateColumnType.count,
+            filter: (cell) => cell.value == 'Electronics',
+            numberFormat: NumberFormat('Electronics: #,###'),
+            alignment: Alignment.center,
+          );
+        },
+      ),
+    ];
+
+    // Create sample data
+    rows = List.generate(100, (index) => 
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: index + 1),
+          'revenue': TrinaCell(value: (index + 1) * 1000),
+          'profit': TrinaCell(value: (index + 1) * 100 + (index % 10) * 0.5),
+          'quantity': TrinaCell(value: (index % 10) + 1),
+          'price': TrinaCell(value: (index % 5) * 100 + 50),
+          'category': TrinaCell(value: ['Electronics', 'Clothing', 'Food', 'Books'][index % 4]),
+        },
+      )
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Column Footer Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          stateManager = event.stateManager;
+          stateManager.setShowColumnFilter(true);
+        },
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Use Appropriate Aggregation Types**: Choose the aggregation type that makes the most sense for your data. For example, use `sum` for financial data, `average` for performance metrics, and `count` for tracking occurrences.
+
+2. **Format Values Clearly**: Use clear and consistent formatting for your aggregated values. Include appropriate prefixes or suffixes to make the meaning of the values obvious.
+
+3. **Consider Performance**: When working with large datasets, be mindful of the performance impact of complex aggregations. Consider using the `iterateRowType` parameter to limit the scope of the aggregation.
+
+4. **Provide Visual Cues**: Use styling and alignment to visually distinguish footer values from regular cell values. This helps users quickly identify summary information.
+
+5. **Combine with Filtering**: Column footers work well with column filtering, allowing users to see aggregated values for filtered subsets of data.
+
+6. **Update Dynamically**: Remember that column footers automatically update when the grid's data changes, including when rows are filtered, sorted, or modified.
+
+## Related Features
+
+- [Column Types](column-types.md)
+- [Column Filtering](column-filtering.md)
+- [Column Sorting](column-sorting.md)
+- [Column Groups](column-groups.md)
+
+
+---
+
+## Column Viewport Visibility
+
+TrinaGrid provides functionality to check which columns are currently visible in the viewport and to determine if a specific column is within the viewable area. This is particularly useful for optimizing rendering performance and implementing features that need to react to visible columns.
+
+## Checking Visible Columns
+
+### Get Viewport Visible Columns
+
+The `getViewPortVisibleColumns()` method returns a list of columns that are currently visible in the viewport. This allows you to operate only on columns that the user can actually see.
+
+```dart
+// Get all columns currently visible in the viewport
+List<TrinaColumn> visibleColumns = stateManager.getViewPortVisibleColumns();
+
+// Now you can work with only the visible columns
+for (final column in visibleColumns) {
+  // Do something with the visible column
+}
+```
+
+This method is useful when you need to:
+
+- Perform operations only on visible columns to improve performance
+- Update only the columns that are currently in view
+- Implement custom rendering logic based on visible columns
+
+### Check if a Column is Visible
+
+You can also check if a specific column is currently visible in the viewport using the `isColumnVisibleInViewport()` method:
+
+```dart
+// Check if a specific column is visible
+bool isVisible = stateManager.isColumnVisibleInViewport(myColumn);
+
+if (isVisible) {
+  // Perform actions for visible column
+} else {
+  // Handle case when column is out of view
+}
+```
+
+This method is particularly helpful for:
+
+- Conditional rendering based on column visibility
+- Optimizing event handlers to ignore off-screen columns
+- Implementing viewport-aware behaviors
+
+## Implementation Details
+
+The visibility detection works by:
+
+1. Checking if the column is hidden (`column.hide`)
+2. Getting the current grid render box dimensions
+3. Calculating the current scroll position and viewport boundaries
+4. Determining if the column's position overlaps with the viewport
+
+A column is considered visible if any part of it intersects with the current viewport. This means that partially visible columns (those cut off at the edge of the screen) are also included in the visibility results.
+
+## Example: Viewport-Aware Updates
+
+Here's an example of how to use these methods to implement viewport-aware updates:
+
+```dart
+void updateOnlyVisibleColumns() {
+  // Get all columns currently visible in the viewport
+  final visibleColumns = stateManager.getViewPortVisibleColumns();
+  
+  // Update only visible columns
+  for (final column in visibleColumns) {
+    // Apply updates to visible columns only
+    updateColumnData(column);
+  }
+}
+```
+
+## Example: Scrolling to Make a Column Visible
+
+You can combine visibility checking with scrolling functionality:
+
+```dart
+void ensureColumnIsVisible(TrinaColumn column) {
+  // Check if the column is already visible
+  if (!stateManager.isColumnVisibleInViewport(column)) {
+    // If not visible, scroll to make it visible
+    stateManager.scrollToColumn(column);
+  }
+}
+```
+
+## Related Features
+
+- [Column Freezing](column-freezing.md) - Learn about freezing columns in position
+- [Column Hiding](column-hiding.md) - Understand how to show and hide columns
+- [Scrollbars](scrollbars.md) - Customize scrolling behavior
+
+
+---
+
+## Row Selection
+
+Row selection is a feature in TrinaGrid that allows users to select one or multiple rows for various operations such as copying, exporting, or performing batch actions.
+
+## Overview
+
+The row selection feature enables users to interact with rows as complete units rather than individual cells. This is particularly useful for operations that apply to entire records, such as deleting, duplicating, or exporting data.
+
+## Enabling Row Selection
+
+To enable row selection in TrinaGrid, you need to set the selecting mode to `TrinaGridSelectingMode.row` using the state manager:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    // Enable row selection mode
+    event.stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+  },
+)
+```
+
+## Selection Modes
+
+TrinaGrid supports three selection modes:
+
+1. **Row Selection Mode** (`TrinaGridSelectingMode.row`): Allows users to select entire rows.
+2. **Cell Selection Mode** (`TrinaGridSelectingMode.cell`): Allows users to select individual cells or ranges of cells.
+3. **No Selection Mode** (`TrinaGridSelectingMode.none`): Disables selection functionality.
+
+## User Interactions for Row Selection
+
+When row selection mode is enabled, users can select rows using the following interactions:
+
+### Single Row Selection
+
+- **Click**: Click on any cell in a row to select it.
+- **Keyboard Navigation**: Use arrow keys to navigate to a row and press Space or Enter to select it.
+
+### Multiple Row Selection
+
+- **Shift + Click**: Select a range of rows from the currently selected row to the clicked row.
+- **Ctrl/Cmd + Click**: Add or remove individual rows from the selection without affecting other selected rows.
+- **Long Press and Drag**: Press and hold on a row, then drag to select multiple consecutive rows.
+
+## Programmatic Row Selection
+
+You can programmatically select rows using the TrinaGrid state manager:
+
+### Selecting Rows by Range
+
+```dart
+// Select rows from index 2 to index 5
+stateManager.setCurrentSelectingRowsByRange(2, 5);
+```
+
+### Toggling Row Selection
+
+```dart
+// Toggle selection state of the row at index 3
+stateManager.toggleSelectingRow(3);
+```
+
+### Clearing Selection
+
+```dart
+// Clear all selected rows
+stateManager.clearCurrentSelecting();
+```
+
+## Accessing Selected Rows
+
+You can access the currently selected rows through the state manager:
+
+```dart
+// Get all currently selected rows
+List<TrinaRow> selectedRows = stateManager.currentSelectingRows;
+
+// Process selected rows
+for (var row in selectedRows) {
+  // Access row data
+  var cellValue = row.cells['fieldName'].value;
+  // Perform operations with the selected row
+}
+```
+
+## Selection Events
+
+TrinaGrid provides events to respond to selection changes:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onSelected: (TrinaGridOnSelectedEvent event) {
+    // Handle selection change
+    print('Selected rows: ${event.row}');
+    print('Selected cell: ${event.cell}');
+    print('Selected column: ${event.column}');
+  },
+)
+```
+
+## Visual Feedback
+
+When a row is selected, TrinaGrid provides visual feedback by highlighting the entire row. The default styling can be customized through the TrinaGrid configuration.
+
+## Best Practices
+
+1. **Clear Communication**: Provide visual cues and instructions to users about how to select rows, especially for multiple selection.
+
+2. **Batch Operations**: When implementing actions that operate on selected rows, ensure they handle both single and multiple selections appropriately.
+
+3. **Selection Persistence**: Consider whether selection should persist across pagination or filtering operations based on your application's needs.
+
+4. **Keyboard Accessibility**: Ensure that row selection can be performed using keyboard navigation for accessibility.
+
+5. **Selection Feedback**: Provide clear visual feedback when rows are selected, and consider adding a count of selected rows when multiple rows are selected.
+
+6. **Performance Considerations**: Be mindful of performance when handling large numbers of selected rows, especially when performing operations on the selection.
+
+## Example
+
+Here's a complete example demonstrating row selection:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class RowSelectionExample extends StatefulWidget {
+  @override
+  _RowSelectionExampleState createState() => _RowSelectionExampleState();
+}
+
+class _RowSelectionExampleState extends State<RowSelectionExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Email',
+        field: 'email',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Role',
+        field: 'role',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    // Define rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'John Smith'),
+          'email': TrinaCell(value: 'john.smith@example.com'),
+          'role': TrinaCell(value: 'Developer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Jane Doe'),
+          'email': TrinaCell(value: 'jane.doe@example.com'),
+          'role': TrinaCell(value: 'Designer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Bob Johnson'),
+          'email': TrinaCell(value: 'bob.johnson@example.com'),
+          'role': TrinaCell(value: 'Manager'),
+        },
+      ),
+      // Add more rows as needed
+    ]);
+  }
+
+  void showSelectedRows() {
+    if (stateManager.currentSelectingRows.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No rows selected')),
+      );
+      return;
+    }
+
+    // Build a string with information about selected rows
+    String message = 'Selected rows:\n';
+    for (var row in stateManager.currentSelectingRows) {
+      message += 'ID: ${row.cells['id'].value}, Name: ${row.cells['name'].value}\n';
+    }
+
+    // Show the selected rows in a dialog
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Selected Rows'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Row Selection Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: showSelectedRows,
+              child: Text('Show Selected Rows'),
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+                // Enable row selection mode
+                stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+              },
+              onSelected: (TrinaGridOnSelectedEvent event) {
+                // Optional: Handle selection changes
+                print('Selection changed');
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+## Related Features
+
+- [Cell Selection](cell-selection.md)
+- [Row Checking](row-checking.md)
+- [Clipboard Operations](clipboard-operations.md)
+- [Row Editing](row-editing.md)
+
+
+---
+
+## Row Moving
+
+Row moving is a feature in TrinaGrid that allows users to reorder rows by dragging them to a new position. This feature enhances the user experience by providing an intuitive way to reorganize data within the grid.
+
+## Overview
+
+The row moving feature enables users to change the order of rows in the grid through drag-and-drop interactions. This is particularly useful when users need to prioritize certain data or create a custom ordering that differs from the default.
+
+## Enabling Row Moving
+
+To enable row moving in TrinaGrid, you need to set the `enableRowDrag` property to `true` for at least one column:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableRowDrag: true,  // Enable row dragging for this column
+)
+```
+
+When `enableRowDrag` is set to `true`, a drag handle icon appears in the cells of that column, allowing users to drag the row.
+
+## User Interactions
+
+### Dragging Rows
+
+When row moving is enabled:
+
+1. Users can click and hold on the drag handle icon in a cell.
+2. While holding, they can drag the row up or down to the desired position.
+3. Upon releasing, the row will be moved to the new position.
+
+### Moving Multiple Rows
+
+When using row selection mode (`TrinaGridSelectingMode.row`), users can:
+
+1. Select multiple rows using Shift+Click or Ctrl/Cmd+Click.
+2. Drag any of the selected rows to move all selected rows together to a new position.
+
+## Programmatic Row Moving
+
+You can also move rows programmatically using the TrinaGrid state manager:
+
+### Moving Rows by Index
+
+```dart
+// Move specified rows to index 5
+stateManager.moveRowsByIndex(rowsToMove, 5);
+```
+
+### Moving Rows by Offset
+
+```dart
+// Move specified rows to the position at the given vertical offset
+stateManager.moveRowsByOffset(rowsToMove, offsetValue);
+```
+
+## Handling Row Movement Events
+
+TrinaGrid provides an `onRowsMoved` callback that is triggered when rows are moved:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onRowsMoved: (TrinaGridOnRowsMovedEvent event) {
+    // Access the new index where rows were moved
+    print('Rows moved to index: ${event.idx}');
+    
+    // Access the moved rows
+    for (var row in event.rows) {
+      print('Moved row: ${row.cells['id']?.value}');
+    }
+    
+    // Perform any additional actions after rows are moved
+    updateExternalDataSource(event.rows, event.idx);
+  },
+)
+```
+
+## Example
+
+Here's a complete example demonstrating row moving functionality:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class RowMovingExample extends StatefulWidget {
+  @override
+  _RowMovingExampleState createState() => _RowMovingExampleState();
+}
+
+class _RowMovingExampleState extends State<RowMovingExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+        enableRowDrag: true,  // Enable row dragging
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Email',
+        field: 'email',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Role',
+        field: 'role',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    // Define rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'John Smith'),
+          'email': TrinaCell(value: 'john.smith@example.com'),
+          'role': TrinaCell(value: 'Developer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Jane Doe'),
+          'email': TrinaCell(value: 'jane.doe@example.com'),
+          'role': TrinaCell(value: 'Designer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Bob Johnson'),
+          'email': TrinaCell(value: 'bob.johnson@example.com'),
+          'role': TrinaCell(value: 'Manager'),
+        },
+      ),
+      // Add more rows as needed
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Row Moving Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              'Drag rows using the handle in the ID column to reorder them',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+                // Enable row selection mode to allow moving multiple rows
+                stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+              },
+              onRowsMoved: (TrinaGridOnRowsMovedEvent event) {
+                // Handle row movement
+                print('Rows moved to index: ${event.idx}');
+                for (var row in event.rows) {
+                  print('Moved row ID: ${row.cells['id']?.value}');
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+## Best Practices
+
+1. **Visual Feedback**: Ensure that the drag handle icon is clearly visible and distinguishable to provide users with a clear indication of where to click for dragging.
+
+2. **Row Selection Integration**: When implementing row moving, consider enabling row selection mode to allow users to move multiple rows simultaneously.
+
+3. **Data Synchronization**: If your grid data is connected to an external data source, make sure to update the source when rows are moved to maintain consistency.
+
+4. **Accessibility**: Provide alternative methods for reordering rows for users who may have difficulty with drag-and-drop interactions, such as keyboard shortcuts or context menu options.
+
+5. **Validation**: Consider implementing validation logic to restrict where certain rows can be moved if your application has specific business rules about row ordering.
+
+6. **Performance**: Be mindful of performance when moving large numbers of rows, especially in grids with many columns or complex cell renderers.
+
+## Related Features
+
+- [Row Selection](row-selection.md)
+- [Row Editing](row-editing.md)
+- [Drag and Drop](drag-and-drop.md)
+
+
+---
+
+## Row Coloring
+
+Row coloring is a feature in TrinaGrid that allows you to customize the background color of rows based on their content or state. This feature enhances data visualization by providing visual cues that help users quickly identify patterns, categories, or important information within the grid.
+
+## Overview
+
+The row coloring feature enables you to dynamically assign colors to rows based on custom logic. This is particularly useful for:
+
+- Highlighting rows that meet specific criteria
+- Creating alternating row colors for better readability
+- Visually categorizing data
+- Indicating status or priority levels
+- Enhancing the overall user experience with visual feedback
+
+## Implementing Row Coloring
+
+To implement row coloring in TrinaGrid, you need to use the `rowColorCallback` parameter when creating your TrinaGrid widget. This callback function receives a `RowColorContext` object and should return a `Color` object.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowColorCallback: (rowColorContext) {
+    // Your custom logic to determine row color
+    return yourColorValue;
+  },
+)
+```
+
+## The RowColorContext
+
+The `rowColorContext` parameter provides context information about the row being rendered, including:
+
+- `row`: The TrinaRow object containing the row's data
+- `rowIdx`: The index of the row in the current view
+- `stateManager`: The TrinaGridStateManager instance
+
+This context allows you to make color decisions based on row data, position, or grid state.
+
+## Examples
+
+### Basic Row Coloring
+
+Here's a simple example that colors rows based on a specific cell value:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowColorCallback: (rowColorContext) {
+    // Get the value of the 'status' cell
+    final status = rowColorContext.row.cells['status']?.value;
+    
+    // Return different colors based on status
+    if (status == 'Active') {
+      return Colors.green[100]!;
+    } else if (status == 'Pending') {
+      return Colors.yellow[100]!;
+    } else if (status == 'Inactive') {
+      return Colors.grey[100]!;
+    }
+    
+    // Default color for other cases
+    return Colors.white;
+  },
+)
+```
+
+### Alternating Row Colors
+
+You can create a zebra-striped pattern for better readability:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowColorCallback: (rowColorContext) {
+    // Use row index to determine color
+    return rowColorContext.rowIdx % 2 == 0
+        ? Colors.white
+        : Colors.grey[100]!;
+  },
+)
+```
+
+### Coloring Based on Multiple Conditions
+
+You can implement complex logic to determine row colors:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowColorCallback: (rowColorContext) {
+    final row = rowColorContext.row;
+    final priority = row.cells['priority']?.value;
+    final dueDate = row.cells['dueDate']?.value as DateTime?;
+    final isCompleted = row.cells['isCompleted']?.value as bool? ?? false;
+    
+    // First priority: completed items are light green
+    if (isCompleted) {
+      return Colors.green[50]!;
+    }
+    
+    // Second priority: overdue items are light red
+    if (dueDate != null && dueDate.isBefore(DateTime.now())) {
+      return Colors.red[50]!;
+    }
+    
+    // Third priority: color by priority level
+    if (priority == 'High') {
+      return Colors.orange[50]!;
+    } else if (priority == 'Medium') {
+      return Colors.yellow[50]!;
+    } else if (priority == 'Low') {
+      return Colors.blue[50]!;
+    }
+    
+    // Default color
+    return Colors.white;
+  },
+)
+```
+
+## Dynamic Row Coloring
+
+One of the powerful aspects of the `rowColorCallback` is that it's called whenever the grid is redrawn, which means row colors will update dynamically when:
+
+- Cell values change
+- Rows are added or removed
+- The grid is sorted or filtered
+- Any other operation that causes the grid to redraw
+
+This allows for responsive visual feedback as users interact with the grid.
+
+## Combining with Other Features
+
+Row coloring works well with other TrinaGrid features:
+
+### With Row Selection
+
+When combining row coloring with row selection, be aware that the selection highlight may override your custom row colors. You can adjust the selection colors to work harmoniously with your row coloring scheme.
+
+### With Row Hover
+
+Row hover effects may temporarily change the row color. Consider this when designing your color scheme to ensure good contrast and usability.
+
+## Best Practices
+
+1. **Use Subtle Colors**: Choose light background colors that don't interfere with text readability.
+
+2. **Maintain Contrast**: Ensure sufficient contrast between the text and background colors for accessibility.
+
+3. **Be Consistent**: Use colors consistently throughout your application to maintain a coherent user experience.
+
+4. **Consider Accessibility**: Keep in mind users with color vision deficiencies when choosing your color scheme.
+
+5. **Performance**: Keep your `rowColorCallback` logic efficient, especially for large datasets, as it will be called frequently during scrolling and updates.
+
+6. **Documentation**: Document the meaning of different colors in your application to help users understand the visual cues.
+
+## Complete Example
+
+Here's a complete example demonstrating row coloring in TrinaGrid:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class RowColorExample extends StatefulWidget {
+  @override
+  _RowColorExampleState createState() => _RowColorExampleState();
+}
+
+class _RowColorExampleState extends State<RowColorExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Category',
+        field: 'category',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    // Define rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'Project Alpha'),
+          'category': TrinaCell(value: 'Development'),
+          'status': TrinaCell(value: 'Active'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Project Beta'),
+          'category': TrinaCell(value: 'Design'),
+          'status': TrinaCell(value: 'Pending'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Project Gamma'),
+          'category': TrinaCell(value: 'Testing'),
+          'status': TrinaCell(value: 'Inactive'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 4),
+          'name': TrinaCell(value: 'Project Delta'),
+          'category': TrinaCell(value: 'Development'),
+          'status': TrinaCell(value: 'Active'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 5),
+          'name': TrinaCell(value: 'Project Epsilon'),
+          'category': TrinaCell(value: 'Marketing'),
+          'status': TrinaCell(value: 'Pending'),
+        },
+      ),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Row Coloring Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              'Rows are colored based on their status',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              rowColorCallback: (rowColorContext) {
+                // Color rows based on status
+                final status = rowColorContext.row.cells['status']?.value;
+                
+                switch (status) {
+                  case 'Active':
+                    return Colors.green[50]!;
+                  case 'Pending':
+                    return Colors.yellow[50]!;
+                  case 'Inactive':
+                    return Colors.grey[50]!;
+                  default:
+                    return Colors.white;
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Related Features
+
+- [Row Selection](row-selection.md)
+- [Row Moving](row-moving.md)
+- [Row Checking](row-checking.md)
+- [Row Groups](row-groups.md)
+
+
+---
+
+## Row Wrapper
+
+The `rowWrapper` feature in TrinaGrid allows you to customize the rendering of each row by wrapping the default row widget with your own widget or logic. This is useful for adding custom styling, interactivity, or additional UI elements to every row in the grid.
+
+## Overview
+
+- **Purpose:** Customize how each row is displayed with access to both the row widget and its data.
+- **Type:**
+
+  ```dart
+  typedef RowWrapper = Widget Function(
+    BuildContext context,
+    Widget rowWidget,
+    TrinaRow rowData,
+    TrinaGridStateManager stateManager,
+  );
+  ```
+
+- **Where to use:** Pass as the `rowWrapper` property to the `TrinaGrid` widget.
+
+## Example Usage
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowWrapper: (context, rowWidget, rowData, stateManager) {
+    // Example: Add a colored border to each row
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.blueAccent),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: rowWidget,
+    );
+  },
+)
+```
+
+### Advanced Example: Conditional Styling Based on Row Data
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowWrapper: (context, rowWidget, rowData, stateManager) {
+    // Access cell values from rowData to apply conditional styling
+    final statusValue = rowData.cells['status']?.value;
+    final isHighPriority = statusValue == 'urgent';
+    
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      decoration: BoxDecoration(
+        color: isHighPriority ? Colors.red.withOpacity(0.1) : null,
+        border: Border.all(
+          color: isHighPriority ? Colors.red : Colors.blueAccent,
+          width: isHighPriority ? 2 : 1,
+        ),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: rowWidget,
+    );
+  },
+)
+```
+
+## Use Cases
+
+- Add custom borders, backgrounds, or shadows to rows.
+- Apply conditional styling based on row data values.
+- Attach gesture detectors or context menus.
+- Animate row appearance or add tooltips.
+- Implement row-level status indicators or badges based on cell values.
+- Create row-specific hover effects or highlights.
+
+## Notes
+
+- If `rowWrapper` is not provided, the default row widget is used.
+- The wrapper receives:
+  - `context`: The build context
+  - `rowWidget`: The default row widget (previously named `row`)
+  - `rowData`: The TrinaRow instance containing all cell data
+  - `stateManager`: The grid state manager for maximum flexibility
+- You can access cell values through `rowData.cells[fieldName]?.value`
+- The `rowData` parameter enables data-driven row customization without requiring state manager queries.
+
+## Migration from Previous Versions
+
+If you're upgrading from a version prior to 2.1.0, update your rowWrapper callbacks:
+
+```dart
+// Old signature (before 2.1.0)
+rowWrapper: (context, row, stateManager) {
+  return Container(child: row);
+}
+
+// New signature (2.1.0+)
+rowWrapper: (context, rowWidget, rowData, stateManager) {
+  return Container(child: rowWidget);
+}
+```
+
+
+---
+
+## Row Checking
+
+Row checking is a feature in TrinaGrid that allows users to select rows using checkboxes. This feature is particularly useful for operations that need to be performed on multiple rows, such as bulk actions, data export, or batch processing.
+
+## Overview
+
+The row checking feature adds checkboxes to rows in your grid, enabling users to:
+
+- Select individual rows by checking their corresponding checkboxes
+- Select or deselect all rows at once using a header checkbox
+- Perform actions on the selected rows
+- Track the checked state of rows programmatically
+
+This feature is distinct from row selection (which highlights rows) and can be used independently or in conjunction with row selection.
+
+## Enabling Row Checking
+
+To enable row checking in TrinaGrid, you need to set the `enableRowChecked` property to `true` for at least one column:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableRowChecked: true,  // Enable checkbox for this column
+)
+```
+
+When `enableRowChecked` is set to `true`, a checkbox appears in the cells of that column, allowing users to check or uncheck rows.
+
+## User Interactions
+
+### Checking Individual Rows
+
+Users can check or uncheck individual rows by clicking on the checkbox in the row. When a row is checked:
+
+- The checkbox appears checked
+- The row is added to the `checkedRows` list in the state manager
+- The `onRowChecked` callback is triggered (if provided)
+
+### Checking All Rows
+
+If a column has `enableRowChecked` set to `true`, a checkbox also appears in the column header. This checkbox allows users to:
+
+- Check all visible rows when clicked if not all rows are currently checked
+- Uncheck all rows when clicked if all rows are currently checked
+
+## Handling Row Check Events
+
+TrinaGrid provides an `onRowChecked` callback that is triggered when rows are checked or unchecked:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onRowChecked: (TrinaGridOnRowCheckedEvent event) {
+    if (event.isRow) {
+      // A single row was checked/unchecked
+      print('Row checked: ${event.row?.cells['id']?.value}');
+      print('Checked state: ${event.checked}');
+    } else {
+      // All rows were checked/unchecked
+      print('All rows toggled');
+      print('Checked state: ${event.checked}');
+    }
+  },
+)
+```
+
+The `TrinaGridOnRowCheckedEvent` provides information about the check event:
+
+- `isRow`: Indicates whether a single row was checked (`true`) or all rows were toggled (`false`)
+- `isAll`: The opposite of `isRow`
+- `row`: The row that was checked or unchecked (null if `isAll` is true)
+- `checked`: The new checked state (true if checked, false if unchecked)
+
+## Accessing Checked Rows
+
+You can access the list of checked rows through the state manager:
+
+```dart
+// Get all checked rows
+List<TrinaRow> checkedRows = stateManager.checkedRows;
+
+// Perform operations on checked rows
+for (var row in checkedRows) {
+  // Process each checked row
+  print(row.cells['name']?.value);
+}
+```
+
+## Programmatic Control
+
+You can programmatically check or uncheck rows using the row's `checked` property:
+
+```dart
+// Check a specific row
+row.checked = true;
+
+// Uncheck a specific row
+row.checked = false;
+
+// Notify the grid to update the UI
+stateManager.notifyListeners();
+```
+
+## Example
+
+Here's a complete example demonstrating row checking functionality:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class RowCheckingExample extends StatefulWidget {
+  @override
+  _RowCheckingExampleState createState() => _RowCheckingExampleState();
+}
+
+class _RowCheckingExampleState extends State<RowCheckingExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+  
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+        enableRowChecked: true,  // Enable checkbox for this column
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Email',
+        field: 'email',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    // Define rows
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'John Smith'),
+          'email': TrinaCell(value: 'john.smith@example.com'),
+          'status': TrinaCell(value: 'Active'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Jane Doe'),
+          'email': TrinaCell(value: 'jane.doe@example.com'),
+          'status': TrinaCell(value: 'Inactive'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Bob Johnson'),
+          'email': TrinaCell(value: 'bob.johnson@example.com'),
+          'status': TrinaCell(value: 'Active'),
+        },
+      ),
+      // Add more rows as needed
+    ]);
+  }
+
+  void handleRowChecked(TrinaGridOnRowCheckedEvent event) {
+    if (event.isRow) {
+      // A single row was checked/unchecked
+      print('Row checked: ${event.row?.cells['id']?.value}');
+      print('Checked state: ${event.checked}');
+    } else {
+      // All rows were checked/unchecked
+      print('All rows toggled');
+      print('Checked state: ${event.checked}');
+      print('Number of checked rows: ${stateManager.checkedRows.length}');
+    }
+  }
+
+  void processCheckedRows() {
+    final checkedRows = stateManager.checkedRows;
+    
+    if (checkedRows.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No rows selected')),
+      );
+      return;
+    }
+    
+    // Example of processing checked rows
+    final rowIds = checkedRows.map((row) => row.cells['id']?.value).join(', ');
+    
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Processing rows with IDs: $rowIds')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Row Checking Example')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              'Check rows using the checkboxes in the ID column',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: processCheckedRows,
+              child: Text('Process Checked Rows'),
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              onRowChecked: handleRowChecked,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+## Combining with Row Selection
+
+Row checking can be used alongside row selection to provide multiple ways for users to interact with rows:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    // Enable row selection mode
+    event.stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+    stateManager = event.stateManager;
+  },
+  onRowChecked: handleRowChecked,
+  onSelected: handleRowSelected,
+)
+```
+
+When used together:
+
+- Row selection highlights the selected rows
+- Row checking maintains a separate list of checked rows
+- Users can select rows for immediate operations and check rows for batch operations
+
+## Best Practices
+
+1. **Clear Purpose**: Use row checking when you need to perform operations on multiple rows that may not be adjacent.
+
+2. **Visual Clarity**: Place the checkbox in a column that makes sense for your UI, typically the leftmost column or an ID column.
+
+3. **Batch Actions**: Provide clear actions that can be performed on checked rows, such as buttons for "Delete Selected", "Export Selected", etc.
+
+4. **Feedback**: Always provide feedback when users check/uncheck rows, especially when performing batch operations.
+
+5. **State Persistence**: Consider whether checked state should persist across pagination, sorting, or filtering operations based on your application's needs.
+
+6. **Accessibility**: Ensure that checkboxes are accessible to keyboard and screen reader users.
+
+## Related Features
+
+- [Row Selection](row-selection.md)
+- [Row Moving](row-moving.md)
+- [Row Coloring](row-color.md)
+- [Row Groups](row-groups.md)
+
+
+---
+
+## Row Groups
+
+Row grouping is a powerful feature in TrinaGrid that allows you to organize and categorize your data in a hierarchical structure. This feature enhances data visualization and analysis by providing a structured view of your data.
+
+## Overview
+
+The row grouping feature enables you to:
+
+- Group rows based on common values in specified columns
+- Create hierarchical tree structures for nested data
+- Collapse and expand groups to focus on relevant data
+- Apply custom styling to group headers
+- Show count indicators for the number of items in each group
+- Improve data organization and readability
+
+Row grouping is particularly useful when working with large datasets that can be naturally categorized into logical groups or when displaying hierarchical data structures.
+
+## Enabling Row Groups
+
+To enable row grouping in TrinaGrid, you need to set a row group delegate using the `setRowGroup` method on the state manager:
+
+```dart
+// After loading the grid
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (e) {
+    // Set up row grouping
+    e.stateManager.setRowGroup(
+      TrinaRowGroupByColumnDelegate(
+        columns: [
+          columns[0], // First column to group by
+          columns[1], // Second column to group by (for nested groups)
+        ],
+        showFirstExpandableIcon: false,
+      ),
+    );
+  },
+)
+```
+
+## Row Group Delegates
+
+TrinaGrid provides two types of row group delegates:
+
+### 1. TrinaRowGroupByColumnDelegate
+
+This delegate groups rows based on common values in specified columns, creating a hierarchical structure based on column values.
+
+```dart
+TrinaRowGroupByColumnDelegate(
+  columns: [
+    columns[0], // Primary grouping column
+    columns[1], // Secondary grouping column (for nested groups)
+  ],
+  showFirstExpandableIcon: false, // Whether to show expand/collapse icon for first level
+  showCount: true,                // Whether to show count of items in each group
+  enableCompactCount: true,       // Whether to use compact number format for count
+  onToggled: ({required row, required expanded}) {
+    // Optional callback when a group is expanded or collapsed
+    print('Group ${row.cells.values.first.value} is now ${expanded ? 'expanded' : 'collapsed'}');
+  },
+)
+```
+
+### 2. TrinaRowGroupTreeDelegate
+
+This delegate is used for pre-defined tree structures where the hierarchy is already defined in the data model.
+
+```dart
+TrinaRowGroupTreeDelegate(
+  resolveColumnDepth: (column) => stateManager.columnIndex(column),
+  showText: (cell) => true,
+  showFirstExpandableIcon: true,
+  showCount: true,
+  enableCompactCount: true,
+  onToggled: ({required row, required expanded}) {
+    // Optional callback when a group is expanded or collapsed
+  },
+)
+```
+
+## Configuration Options
+
+Both row group delegates can be configured with the following parameters:
+
+- `showFirstExpandableIcon`: Whether to show expand/collapse icon for the first level of groups
+- `showCount`: Whether to show the count of items in each group
+- `enableCompactCount`: Whether to use compact number format for the count display
+- `onToggled`: Callback function that is triggered when a group is expanded or collapsed
+
+Additionally, each delegate has its own specific parameters:
+
+### TrinaRowGroupByColumnDelegate Parameters
+
+- `columns`: List of columns to group by, in order of grouping hierarchy
+
+### TrinaRowGroupTreeDelegate Parameters
+
+- `resolveColumnDepth`: Function that determines the depth of a column in the tree structure
+- `showText`: Function that determines whether to show text for a given cell
+
+## Creating Row Groups
+
+### Column-Based Grouping
+
+To create column-based grouping, provide a list of columns to group by:
+
+```dart
+// Create columns
+final List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'Category',
+    field: 'category',
+    type: TrinaColumnType.text(),
+  ),
+  TrinaColumn(
+    title: 'Subcategory',
+    field: 'subcategory',
+    type: TrinaColumnType.text(),
+  ),
+  TrinaColumn(
+    title: 'Product',
+    field: 'product',
+    type: TrinaColumnType.text(),
+  ),
+];
+
+// Create rows with data
+final List<TrinaRow> rows = [
+  TrinaRow(cells: {
+    'category': TrinaCell(value: 'Electronics'),
+    'subcategory': TrinaCell(value: 'Phones'),
+    'product': TrinaCell(value: 'Smartphone X'),
+  }),
+  TrinaRow(cells: {
+    'category': TrinaCell(value: 'Electronics'),
+    'subcategory': TrinaCell(value: 'Phones'),
+    'product': TrinaCell(value: 'Smartphone Y'),
+  }),
+  TrinaRow(cells: {
+    'category': TrinaCell(value: 'Electronics'),
+    'subcategory': TrinaCell(value: 'Laptops'),
+    'product': TrinaCell(value: 'Laptop Z'),
+  }),
+];
+
+// Enable grouping in the grid
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (e) {
+    e.stateManager.setRowGroup(
+      TrinaRowGroupByColumnDelegate(
+        columns: [
+          columns[0], // Group by Category
+          columns[1], // Then by Subcategory
+        ],
+      ),
+    );
+  },
+)
+```
+
+### Tree-Based Grouping
+
+For tree-based grouping, you need to create a hierarchical structure in your rows:
+
+```dart
+// Create columns
+final List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'Files',
+    field: 'files',
+    type: TrinaColumnType.text(),
+    renderer: (c) {
+      IconData icon = c.row.type.isGroup ? Icons.folder : Icons.file_present;
+      return Row(
+        children: [
+          Icon(icon, size: 18, color: Colors.grey),
+          const SizedBox(width: 10),
+          Text(c.cell.value),
+        ],
+      );
+    },
+  ),
+];
+
+// Create hierarchical rows
+final List<TrinaRow> rows = [
+  TrinaRow(
+    cells: {'files': TrinaCell(value: 'Project')},
+    type: TrinaRowType.group(
+      children: FilteredList<TrinaRow>(
+        initialList: [
+          TrinaRow(
+            cells: {'files': TrinaCell(value: 'src')},
+            type: TrinaRowType.group(
+              children: FilteredList<TrinaRow>(
+                initialList: [
+                  TrinaRow(cells: {'files': TrinaCell(value: 'main.dart')}),
+                  TrinaRow(cells: {'files': TrinaCell(value: 'utils.dart')}),
+                ],
+              ),
+            ),
+          ),
+          TrinaRow(
+            cells: {'files': TrinaCell(value: 'test')},
+            type: TrinaRowType.group(
+              children: FilteredList<TrinaRow>(
+                initialList: [
+                  TrinaRow(cells: {'files': TrinaCell(value: 'test_app.dart')}),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  ),
+];
+
+// Enable tree-based grouping
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLoaded: (e) {
+    e.stateManager.setRowGroup(
+      TrinaRowGroupTreeDelegate(
+        resolveColumnDepth: (column) => e.stateManager.columnIndex(column),
+        showText: (cell) => true,
+        showFirstExpandableIcon: true,
+      ),
+    );
+  },
+)
+```
+
+## Styling Group Rows
+
+You can apply custom styling to group rows using the configuration options:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      cellColorGroupedRow: Color(0x80F6F6F6), // Background color for group rows
+      groupRowBorderColor: Colors.grey,        // Border color for group rows
+      groupRowBorderWidth: 1.0,                // Border width for group rows
+      groupRowTextStyle: TextStyle(           // Text style for group rows
+        fontWeight: FontWeight.bold,
+        color: Colors.blue,
+      ),
+    ),
+  ),
+  onLoaded: (e) {
+    e.stateManager.setRowGroup(
+      TrinaRowGroupByColumnDelegate(
+        columns: [columns[0]],
+      ),
+    );
+  },
+)
+```
+
+## Programmatic Control
+
+You can programmatically control row groups through the state manager:
+
+```dart
+// Toggle a specific group row (expand if collapsed, collapse if expanded)
+void toggleGroupExpansion(TrinaRow groupRow) {
+  if (groupRow.type.isGroup) {
+    stateManager.toggleExpandedRowGroup(rowGroup: groupRow);
+  }
+}
+
+// Explicitly expand a specific group row
+void expandGroup(TrinaRow groupRow) {
+  if (groupRow.type.isGroup) {
+    stateManager.toggleExpandedRowGroup(rowGroup: groupRow, expanded: true);
+  }
+}
+
+// Explicitly collapse a specific group row
+void collapseGroup(TrinaRow groupRow) {
+  if (groupRow.type.isGroup) {
+    stateManager.toggleExpandedRowGroup(rowGroup: groupRow, expanded: false);
+  }
+}
+
+// Expand all group rows
+void expandAllGroups() {
+  stateManager.expandAllRowGroups();
+}
+
+// Collapse all group rows
+void collapseAllGroups() {
+  stateManager.collapseAllRowGroups();
+}
+
+// Check if a row is a group row
+bool isGroupRow(TrinaRow row) {
+  return row.type.isGroup;
+}
+
+// Get all group rows
+List<TrinaRow> getAllGroupRows() {
+  return stateManager.rows.where((row) => row.type.isGroup).toList();
+}
+```
+
+## Complete Example
+
+Here's a complete example demonstrating both types of row grouping:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class RowGroupExample extends StatefulWidget {
+  @override
+  _RowGroupExampleState createState() => _RowGroupExampleState();
+}
+
+class _RowGroupExampleState extends State<RowGroupExample> {
+  final List<TrinaColumn> columnsA = [];
+  final List<TrinaRow> rowsA = [];
+  
+  final List<TrinaColumn> columnsB = [];
+  final List<TrinaRow> rowsB = [];
+  
+  late TrinaGridStateManager stateManagerA;
+  late TrinaGridStateManager stateManagerB;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Set up columns for column-based grouping
+    columnsA.addAll([
+      TrinaColumn(
+        title: 'Category',
+        field: 'category',
+        type: TrinaColumnType.select([
+          'Electronics',
+          'Clothing',
+          'Food',
+        ]),
+      ),
+      TrinaColumn(
+        title: 'Subcategory',
+        field: 'subcategory',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Product',
+        field: 'product',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Price',
+        field: 'price',
+        type: TrinaColumnType.number(format: '\$#,###.00'),
+      ),
+    ]);
+
+    // Add rows for column-based grouping
+    rowsA.addAll([
+      TrinaRow(cells: {
+        'category': TrinaCell(value: 'Electronics'),
+        'subcategory': TrinaCell(value: 'Phones'),
+        'product': TrinaCell(value: 'Smartphone X'),
+        'price': TrinaCell(value: 999.99),
+      }),
+      TrinaRow(cells: {
+        'category': TrinaCell(value: 'Electronics'),
+        'subcategory': TrinaCell(value: 'Phones'),
+        'product': TrinaCell(value: 'Smartphone Y'),
+        'price': TrinaCell(value: 799.99),
+      }),
+      TrinaRow(cells: {
+        'category': TrinaCell(value: 'Electronics'),
+        'subcategory': TrinaCell(value: 'Laptops'),
+        'product': TrinaCell(value: 'Laptop Z'),
+        'price': TrinaCell(value: 1299.99),
+      }),
+      TrinaRow(cells: {
+        'category': TrinaCell(value: 'Clothing'),
+        'subcategory': TrinaCell(value: 'Shirts'),
+        'product': TrinaCell(value: 'T-Shirt'),
+        'price': TrinaCell(value: 29.99),
+      }),
+      TrinaRow(cells: {
+        'category': TrinaCell(value: 'Clothing'),
+        'subcategory': TrinaCell(value: 'Pants'),
+        'product': TrinaCell(value: 'Jeans'),
+        'price': TrinaCell(value: 49.99),
+      }),
+    ]);
+
+    // Set up columns for tree-based grouping
+    columnsB.addAll([
+      TrinaColumn(
+        title: 'Files',
+        field: 'files',
+        type: TrinaColumnType.text(),
+        renderer: (c) {
+          IconData icon = c.row.type.isGroup ? Icons.folder : Icons.file_present;
+          return Row(
+            children: [
+              Icon(icon, size: 18, color: Colors.grey),
+              const SizedBox(width: 10),
+              Text(c.cell.value),
+            ],
+          );
+        },
+      ),
+    ]);
+
+    // Add rows for tree-based grouping
+    rowsB.addAll([
+      TrinaRow(
+        cells: {'files': TrinaCell(value: 'Project')},
+        type: TrinaRowType.group(
+          children: FilteredList<TrinaRow>(
+            initialList: [
+              TrinaRow(
+                cells: {'files': TrinaCell(value: 'src')},
+                type: TrinaRowType.group(
+                  children: FilteredList<TrinaRow>(
+                    initialList: [
+                      TrinaRow(cells: {'files': TrinaCell(value: 'main.dart')}),
+                      TrinaRow(cells: {'files': TrinaCell(value: 'utils.dart')}),
+                    ],
+                  ),
+                ),
+              ),
+              TrinaRow(
+                cells: {'files': TrinaCell(value: 'test')},
+                type: TrinaRowType.group(
+                  children: FilteredList<TrinaRow>(
+                    initialList: [
+                      TrinaRow(cells: {'files': TrinaCell(value: 'test_app.dart')}),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Row Group Example'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.unfold_more),
+            onPressed: () {
+              stateManagerA.expandAllRowGroups();
+              stateManagerB.expandAllRowGroups();
+            },
+            tooltip: 'Expand All Groups',
+          ),
+          IconButton(
+            icon: Icon(Icons.unfold_less),
+            onPressed: () {
+              stateManagerA.collapseAllRowGroups();
+              stateManagerB.collapseAllRowGroups();
+            },
+            tooltip: 'Collapse All Groups',
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    'Column-Based Grouping',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Expanded(
+                  child: TrinaGrid(
+                    columns: columnsA,
+                    rows: rowsA,
+                    configuration: const TrinaGridConfiguration(
+                      style: TrinaGridStyleConfig(
+                        cellColorGroupedRow: Color(0x80F6F6F6),
+                      ),
+                    ),
+                    onLoaded: (e) {
+                      stateManagerA = e.stateManager;
+                      e.stateManager.setRowGroup(
+                        TrinaRowGroupByColumnDelegate(
+                          columns: [
+                            columnsA[0], // Group by Category
+                            columnsA[1], // Then by Subcategory
+                          ],
+                          showFirstExpandableIcon: false,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    'Tree-Based Grouping',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Expanded(
+                  child: TrinaGrid(
+                    columns: columnsB,
+                    rows: rowsB,
+                    configuration: const TrinaGridConfiguration(
+                      style: TrinaGridStyleConfig(
+                        cellColorGroupedRow: Color(0x80F6F6F6),
+                      ),
+                      columnSize: TrinaGridColumnSizeConfig(
+                        autoSizeMode: TrinaAutoSizeMode.equal,
+                      ),
+                    ),
+                    onLoaded: (e) {
+                      stateManagerB = e.stateManager;
+                      e.stateManager.setRowGroup(
+                        TrinaRowGroupTreeDelegate(
+                          resolveColumnDepth: (column) => e.stateManager.columnIndex(column),
+                          showText: (cell) => true,
+                          showFirstExpandableIcon: true,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Choose the Right Delegate**: Use `TrinaRowGroupByColumnDelegate` for data that naturally groups by column values, and `TrinaRowGroupTreeDelegate` for pre-defined hierarchical structures.
+
+2. **Limit Group Depth**: While nesting is powerful, limit the depth to 2-3 levels to maintain usability and prevent excessive indentation.
+
+3. **Provide Visual Cues**: Use icons and styling to clearly distinguish between group rows and regular data rows.
+
+4. **Include Expand/Collapse Controls**: Add UI controls to expand or collapse all groups for better user experience.
+
+5. **Show Group Counts**: Enable the `showCount` option to give users a quick overview of how many items are in each group.
+
+6. **Optimize Performance**: For large datasets, consider loading data on-demand when groups are expanded to improve performance.
+
+## Related Features
+
+- [Frozen Rows](frozen-rows.md): Keep important rows visible while scrolling
+- [Row Selection](row-selection.md): Select rows for operations
+- [Row Coloring](row-color.md): Apply custom colors to rows
+- [Column Groups](column-groups.md): Group columns into categories
+
+
+---
+
+## Frozen Rows
+
+Frozen rows is a feature in TrinaGrid that allows you to keep specific rows visible at all times, even when scrolling through a large dataset. This feature is particularly useful for displaying header rows, summary rows, or any important information that needs to remain visible regardless of the user's scroll position.
+
+## Overview
+
+The frozen rows feature enables you to:
+
+- Pin specific rows to the top or bottom of the grid
+- Keep important information visible at all times
+- Improve user experience when working with large datasets
+- Apply different styling to frozen rows to distinguish them visually
+- Maintain context while scrolling through data
+
+Frozen rows remain fixed in position while the rest of the grid scrolls, providing users with constant access to critical information.
+
+## Enabling Frozen Rows
+
+To enable frozen rows in TrinaGrid, you can set the `frozen` property when creating your row:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: 'H1'),
+    'name': TrinaCell(value: 'Header Row'),
+    'status': TrinaCell(value: 'Always Visible'),
+  },
+  frozen: TrinaRowFrozen.start,  // Freeze this row at the top
+)
+```
+
+### Configuration Options
+
+The frozen rows feature can be configured with the following parameter:
+
+- `frozen`: Determines if and where the row should be frozen
+  - `TrinaRowFrozen.none`: The row is not frozen (default)
+  - `TrinaRowFrozen.start`: Freezes the row at the top of the grid
+  - `TrinaRowFrozen.end`: Freezes the row at the bottom of the grid
+
+## Creating Frozen Rows
+
+You can specify which rows should be frozen by setting the `frozen` property on individual rows:
+
+```dart
+// Create a frozen header row at the top
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: 'H1'),
+    'name': TrinaCell(value: 'Header Row'),
+    'status': TrinaCell(value: 'Always Visible'),
+  },
+  frozen: TrinaRowFrozen.start,  // Freeze this row at the top
+)
+
+// Create a frozen footer row at the bottom
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: 'F1'),
+    'name': TrinaCell(value: 'Footer Row'),
+    'status': TrinaCell(value: 'Always Visible'),
+  },
+  frozen: TrinaRowFrozen.end,  // Freeze this row at the bottom
+)
+```
+
+## Styling Frozen Rows
+
+You can apply custom styling to frozen rows to distinguish them visually from regular rows:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      frozenRowColor: Colors.lightBlue[50],
+      frozenRowBorderColor: Colors.blue,
+      frozenRowBorderWidth: 2.0,
+    ),
+  ),
+)
+```
+
+Available styling options include:
+
+- `frozenRowColor`: Background color for frozen rows (default: Color(0xFFF8F8F8) in light mode, Color(0xFF222222) in dark mode)
+- `frozenRowBorderColor`: Border color for frozen rows (default: Color(0xFFE0E0E0) in light mode, Color(0xFF666666) in dark mode)
+
+## Combining with Other Features
+
+Frozen rows can be combined with other TrinaGrid features for enhanced functionality:
+
+### Frozen Rows with Frozen Columns
+
+You can combine frozen rows with frozen columns to create a fixed section of the grid that always remains visible:
+
+```dart
+// Create a frozen column
+TrinaColumn(
+  title: 'ID',
+  field: 'id',
+  type: TrinaColumnType.text(),
+  frozen: TrinaColumnFrozen.start,  // Freeze this column
+)
+
+// Create a frozen row
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: 'H1'),
+    'name': TrinaCell(value: 'Header Row'),
+  },
+  frozen: TrinaRowFrozen.start,  // Freeze this row at the top
+)
+```
+
+This configuration creates a fixed corner section where the frozen row and frozen column intersect.
+
+### Frozen Rows with Row Groups
+
+When using row groups, you can freeze group header rows to keep them visible while scrolling through group contents:
+
+```dart
+// Create a group header row that is frozen
+TrinaRow(
+  cells: {
+    'category': TrinaCell(value: 'Electronics'),
+    'count': TrinaCell(value: '15 items'),
+  },
+  type: TrinaRowTypeGroup.instance,
+  frozen: TrinaRowFrozen.start,  // Freeze this group header at the top
+)
+```
+
+## Programmatic Control
+
+You can programmatically control frozen rows through the state manager:
+
+```dart
+// Create a new row
+final newRow = TrinaRow(
+  cells: {
+    'id': TrinaCell(value: 'H2'),
+    'name': TrinaCell(value: 'New Header Row'),
+  },
+);
+
+// Freeze a row at the top
+newRow.frozen = TrinaRowFrozen.start;
+
+// Add the row to the grid
+stateManager.addRow(newRow);
+
+// Get all rows with frozen status
+List<TrinaRow> frozenTopRows = stateManager.refRows.originalList
+    .where((row) => row.frozen == TrinaRowFrozen.start)
+    .toList();
+
+List<TrinaRow> frozenBottomRows = stateManager.refRows.originalList
+    .where((row) => row.frozen == TrinaRowFrozen.end)
+    .toList();
+```
+
+## Example
+
+Here's a complete example demonstrating frozen rows functionality:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class FrozenRowsExample extends StatefulWidget {
+  @override
+  _FrozenRowsExampleState createState() => _FrozenRowsExampleState();
+}
+
+class _FrozenRowsExampleState extends State<FrozenRowsExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+        frozen: TrinaColumnFrozen.start,  // Freeze this column
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Department',
+        field: 'department',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Salary',
+        field: 'salary',
+        type: TrinaColumnType.number(format: '\$#,###.00'),
+      ),
+    ]);
+
+    // Create a header row (will be frozen)
+    rows.add(
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 'H1'),
+          'name': TrinaCell(value: 'Employee Information'),
+          'department': TrinaCell(value: ''),
+          'salary': TrinaCell(value: ''),
+        },
+        height: 50,
+        backgroundColor: Colors.lightBlue[50],
+        frozen: TrinaRowFrozen.start,  // Freeze at the top
+      ),
+    );
+
+    // Add regular data rows
+    for (int i = 1; i <= 20; i++) {
+      rows.add(
+        TrinaRow(
+          cells: {
+            'id': TrinaCell(value: i),
+            'name': TrinaCell(value: 'Employee $i'),
+            'department': TrinaCell(value: i % 3 == 0 ? 'Engineering' : (i % 3 == 1 ? 'Marketing' : 'Sales')),
+            'salary': TrinaCell(value: 50000 + (i * 1000)),
+          },
+        ),
+      );
+    }
+
+    // Create a footer row (will be frozen)
+    rows.add(
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 'F1'),
+          'name': TrinaCell(value: 'Total'),
+          'department': TrinaCell(value: ''),
+          'salary': TrinaCell(value: '\$1,260,000.00'),
+        },
+        backgroundColor: Colors.amber[50],
+        frozen: TrinaRowFrozen.end,  // Freeze at the bottom
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Frozen Rows Example'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.add),
+            onPressed: () {
+              // Add a new frozen row at the top
+              final newRow = TrinaRow(
+                cells: {
+                  'id': TrinaCell(value: 'H2'),
+                  'name': TrinaCell(value: 'New Header Row'),
+                  'department': TrinaCell(value: ''),
+                  'salary': TrinaCell(value: ''),
+                },
+                backgroundColor: Colors.green[50],
+                frozen: TrinaRowFrozen.start,  // Freeze at the top
+              );
+              stateManager.addRow(newRow);
+            },
+            tooltip: 'Add Frozen Row',
+          ),
+        ],
+      ),
+      body: Container(
+        padding: EdgeInsets.all(16),
+        child: TrinaGrid(
+          columns: columns,
+          rows: rows,
+          configuration: TrinaGridConfiguration(
+            style: TrinaGridStyleConfig(
+              frozenRowBorderColor: Colors.blue,
+            ),
+          ),
+          onLoaded: (TrinaGridOnLoadedEvent event) {
+            stateManager = event.stateManager;
+          },
+        ),
+      ),
+    );
+  }
+}
+
+## Best Practices
+
+1. **Use Sparingly**: Limit the number of frozen rows to avoid taking up too much screen space. Usually, 1-2 rows at the top and/or bottom is sufficient.
+
+2. **Visual Distinction**: Apply distinct styling to frozen rows to help users understand which rows are fixed and which are scrollable.
+
+3. **Appropriate Content**: Use frozen rows for content that provides context or summary information that's useful to see at all times.
+
+4. **Row Height**: Consider adjusting the height of frozen rows to accommodate more content or to make them more prominent.
+
+5. **Performance**: Be aware that having many frozen rows might impact performance, especially on devices with limited resources.
+
+6. **Responsive Design**: Test how frozen rows behave on different screen sizes to ensure a good user experience across devices.
+
+## Related Features
+
+- [Column Freezing](column-freezing.md): Freeze columns to keep them visible while scrolling horizontally
+- [Row Groups](row-groups.md): Group rows based on common values
+- [Row Selection](row-selection.md): Select rows for operations
+- [Row Coloring](row-color.md): Apply custom colors to rows
+
+
+---
+
+## Dynamic Row Heights
+
+Dynamic row heights is a powerful feature in TrinaGrid that allows individual rows to have custom heights while maintaining backward compatibility with the global row height configuration.
+
+## Overview
+
+By default, TrinaGrid uses a uniform row height defined in `TrinaGridConfiguration.style.rowHeight`. The dynamic row heights feature extends this by allowing you to:
+
+- Set custom heights for specific rows
+- Mix rows with custom heights and default heights
+- Dynamically change row heights at runtime
+- Maintain all existing grid functionality with variable heights
+
+![Dynamic Row Heights Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/dynamic-row-heights.gif)
+
+## Basic Usage
+
+### Setting Custom Heights When Creating Rows
+
+You can set custom heights when creating `TrinaRow` instances:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: '1'),
+    'name': TrinaCell(value: 'Custom Height Row'),
+  },
+  height: 80.0, // Custom height in pixels
+)
+```
+
+### Setting Heights at Runtime
+
+Use the `TrinaGridStateManager` to modify row heights after the grid is created:
+
+```dart
+// Set a specific row height
+stateManager.setRowHeight(rowIndex, 100.0);
+
+// Reset a specific row to default height
+stateManager.resetRowHeight(rowIndex);
+
+// Reset all rows to default heights
+stateManager.resetAllRowHeights();
+
+// Get the effective height of a specific row
+double height = stateManager.getRowHeight(rowIndex);
+```
+
+## API Reference
+
+### TrinaRow.height
+
+```dart
+class TrinaRow<T> {
+  /// Custom height for this specific row
+  /// If null, uses the global rowHeight from configuration
+  final double? height;
+  
+  // ... other properties
+}
+```
+
+### TrinaGridStateManager Methods
+
+#### setRowHeight(int rowIndex, double height)
+
+Sets the height of a specific row by index.
+
+**Parameters:**
+- `rowIndex`: The index of the row to modify (0-based)
+- `height`: The new height in pixels (must be > 0)
+
+**Example:**
+```dart
+stateManager.setRowHeight(0, 80.0);
+```
+
+#### resetRowHeight(int rowIndex)
+
+Resets a specific row to use the default height from configuration.
+
+**Parameters:**
+- `rowIndex`: The index of the row to reset (0-based)
+
+**Example:**
+```dart
+stateManager.resetRowHeight(0);
+```
+
+#### resetAllRowHeights()
+
+Resets all rows to use the default height from configuration.
+
+**Example:**
+```dart
+stateManager.resetAllRowHeights();
+```
+
+#### getRowHeight(int rowIndex)
+
+Gets the effective height of a specific row.
+
+**Parameters:**
+- `rowIndex`: The index of the row (0-based)
+
+**Returns:** The effective height in pixels. If the row has a custom height, returns that value. Otherwise, returns the global `rowHeight` from configuration.
+
+**Example:**
+```dart
+double height = stateManager.getRowHeight(0);
+print('Row 0 height: ${height}px');
+```
+
+## Complete Example
+
+Here's a complete example demonstrating dynamic row heights:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class DynamicRowHeightExample extends StatefulWidget {
+  @override
+  _DynamicRowHeightExampleState createState() => _DynamicRowHeightExampleState();
+}
+
+class _DynamicRowHeightExampleState extends State<DynamicRowHeightExample> {
+  TrinaGridStateManager? stateManager;
+  
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeData();
+  }
+
+  void _initializeData() {
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+      TrinaColumn(
+        title: 'Description',
+        field: 'description',
+        type: TrinaColumnType.text(),
+        width: 300,
+      ),
+    ];
+
+    rows = [
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '1'),
+          'name': TrinaCell(value: 'Normal Row'),
+          'description': TrinaCell(value: 'This row uses the default height'),
+        },
+        // No height specified - uses default
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '2'),
+          'name': TrinaCell(value: 'Tall Row'),
+          'description': TrinaCell(value: 'This row has a custom height of 80px'),
+        },
+        height: 80.0, // Custom height
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '3'),
+          'name': TrinaCell(value: 'Very Tall Row'),
+          'description': TrinaCell(value: 'This row has a custom height of 120px'),
+        },
+        height: 120.0, // Custom height
+      ),
+    ];
+  }
+
+  void _setRowHeight(int rowIndex, double height) {
+    if (stateManager != null) {
+      stateManager!.setRowHeight(rowIndex, height);
+      setState(() {}); // Trigger rebuild to show changes
+    }
+  }
+
+  void _resetRowHeight(int rowIndex) {
+    if (stateManager != null) {
+      stateManager!.resetRowHeight(rowIndex);
+      setState(() {}); // Trigger rebuild to show changes
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Dynamic Row Heights Example')),
+      body: Column(
+        children: [
+          // Control Panel
+          Container(
+            padding: const EdgeInsets.all(16),
+            color: Colors.grey[100],
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Row Height Controls', 
+                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                SizedBox(height: 16),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => _setRowHeight(0, 60.0),
+                      child: Text('Set Row 0 to 60px'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _resetRowHeight(0),
+                      child: Text('Reset Row 0'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _setRowHeight(1, 100.0),
+                      child: Text('Set Row 1 to 100px'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _resetRowHeight(1),
+                      child: Text('Reset Row 1'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          
+          // Grid
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              rowColorCallback: (TrinaRowColorContext context) {
+                // Highlight rows with custom heights
+                if (context.row.height != null) {
+                  return Colors.blue.withValues(alpha: 0.1);
+                }
+                // Use default alternating row colors
+                return context.rowIdx % 2 == 0 ? Colors.white : Colors.grey[50]!;
+              },
+              configuration: TrinaGridConfiguration(
+                style: TrinaGridStyleConfig(
+                  rowHeight: 45.0, // Default height
+                  enableCellBorderHorizontal: true,
+                  enableCellBorderVertical: true,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Visual Indicators
+
+You can use the `rowColorCallback` to visually distinguish rows with custom heights:
+
+```dart
+rowColorCallback: (TrinaRowColorContext context) {
+  if (context.row.height != null) {
+    return Colors.blue.withValues(alpha: 0.1); // Custom height rows
+  }
+  return context.rowIdx % 2 == 0 ? Colors.white : Colors.grey[50]!; // Default
+},
+```
+
+## Performance Considerations
+
+### Current Implementation
+- **Pros**: Simple, clean API, maintains immutability
+- **Cons**: Creates new row instances when changing heights (memory allocation)
+
+### Best Practices
+1. **Set heights at creation time** when possible to avoid runtime modifications
+2. **Batch height changes** if modifying multiple rows
+3. **Use visual indicators** to help users understand which rows have custom heights
+4. **Consider the impact** on scrolling performance with many variable-height rows
+
+## Backward Compatibility
+
+✅ **Fully Maintained**
+- Existing code continues to work without changes
+- Global `rowHeight` configuration remains the default
+- New functionality is opt-in via `setRowHeight` calls
+- All existing features (frozen rows, grouping, etc.) work with variable heights
+
+## Use Cases
+
+### Content-Based Heights
+Set row heights based on content requirements:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: '1'),
+    'content': TrinaCell(value: 'Very long content that needs more space...'),
+  },
+  height: 80.0, // Extra height for content
+)
+```
+
+### Status-Based Heights
+Different heights for different row types:
+
+```dart
+TrinaRow(
+  cells: {
+    'id': TrinaCell(value: '1'),
+    'status': TrinaCell(value: 'expanded'),
+  },
+  height: context.row.cells['status']?.value == 'expanded' ? 100.0 : 45.0,
+)
+```
+
+### User Preferences
+Allow users to customize row heights:
+
+```dart
+void _setUserPreferredHeight(int rowIndex) {
+  final preferredHeight = getUserPreferredHeight(rowIndex);
+  stateManager.setRowHeight(rowIndex, preferredHeight);
+}
+```
+
+## Limitations
+
+1. **Height must be positive**: Negative or zero heights are not supported
+2. **Performance impact**: Variable heights disable the efficient `ListView.builder` with `itemExtent`
+3. **Scroll calculations**: More complex scroll calculations for variable heights
+4. **Memory allocation**: Creating new row instances when changing heights
+
+## Related Features
+
+- [Row Coloring](row-color.md) - Customize row background colors
+- [Row Selection](row-selection.md) - Select rows with custom heights
+- [Row Moving](row-moving.md) - Move rows while preserving custom heights
+- [Row Groups](row-groups.md) - Group rows with variable heights
+- [Frozen Rows](frozen-rows.md) - Freeze rows with custom heights
+
+## Migration Guide
+
+### For Existing Users
+1. **No changes required** - existing code continues to work
+2. **New functionality is opt-in** via `setRowHeight` calls
+3. **Global `rowHeight` configuration** remains the default
+
+### For New Users
+1. Use `stateManager.setRowHeight(rowIndex, height)` to set custom heights
+2. Use `stateManager.resetRowHeight(rowIndex)` to reset to default
+3. Use `stateManager.getRowHeight(rowIndex)` to get effective height
+4. Set `height` parameter when creating `TrinaRow` instances
+
+## Troubleshooting
+
+### Common Issues
+
+**Q: My row heights aren't updating visually**
+A: Make sure to call `setState()` after modifying row heights to trigger a rebuild.
+
+**Q: Scrolling seems slower with custom heights**
+A: This is expected behavior. Variable heights disable some scroll optimizations.
+
+**Q: Can I animate height changes?**
+A: Currently not supported, but this is a planned future enhancement.
+
+**Q: Do custom heights work with frozen rows?**
+A: Yes, frozen rows support custom heights just like regular rows.
+
+## Future Enhancements
+
+Planned improvements for future versions:
+1. **Content-aware height calculation** based on cell content
+2. **Animation support** for height transitions
+3. **Bulk height operations** for multiple rows
+4. **Height constraints** (min/max heights)
+5. **Height persistence** across grid sessions
+
+
+---
+
+## Row Custom Data
+
+TrinaGrid allows you to associate custom data with each row using the `TrinaRow.data<T>` property. This feature is useful for storing metadata, original values for change detection, or any application-specific data alongside your grid rows.
+
+## Overview
+
+Every `TrinaRow<T>` has a generic `data` property that can hold any object type. This property is separate from the cell values displayed in the grid and is not rendered.
+
+```dart
+class TrinaRow<T> {
+  T? data;  // Your custom data
+  // ...
+}
+```
+
+## Use Case: Storing Original Data for Change Detection
+
+A common use case is storing the original row data to detect whether users have modified values:
+
+```dart
+// Define your data model
+class Person {
+  final String name;
+  final int age;
+  final String email;
+
+  Person({required this.name, required this.age, required this.email});
+
+  Map<String, dynamic> toMap() => {
+    'name': name,
+    'age': age,
+    'email': email,
+  };
+}
+
+// Create rows with original data stored
+List<TrinaRow<Person>> createRows(List<Person> people) {
+  return people.map((person) => TrinaRow<Person>(
+    cells: {
+      'name': TrinaCell(value: person.name),
+      'age': TrinaCell(value: person.age),
+      'email': TrinaCell(value: person.email),
+    },
+    data: person,  // Store the original data
+  )).toList();
+}
+```
+
+### Detecting Changes
+
+You can compare current cell values with the stored original data:
+
+```dart
+bool hasRowChanged(TrinaRow<Person> row) {
+  final original = row.data;
+  if (original == null) return false;
+
+  return row.cells['name']?.value != original.name ||
+         row.cells['age']?.value != original.age ||
+         row.cells['email']?.value != original.email;
+}
+
+// Check all rows for changes
+List<TrinaRow<Person>> getModifiedRows(List<TrinaRow<Person>> rows) {
+  return rows.where((row) => hasRowChanged(row)).toList();
+}
+```
+
+### Updating Stored Data
+
+After saving changes, update the stored data to reflect the new "original" state:
+
+```dart
+void commitRowChanges(TrinaRow<Person> row) {
+  // Create new Person from current cell values
+  final updatedPerson = Person(
+    name: row.cells['name']?.value ?? '',
+    age: row.cells['age']?.value ?? 0,
+    email: row.cells['email']?.value ?? '',
+  );
+
+  // Update the stored data
+  row.setData(updatedPerson);
+}
+```
+
+## Using Map for Flexible Storage
+
+For simpler cases, you can use a `Map` instead of a custom class:
+
+```dart
+final row = TrinaRow<Map<String, dynamic>>(
+  cells: {
+    'name': TrinaCell(value: 'John'),
+    'age': TrinaCell(value: 30),
+  },
+  data: {'name': 'John', 'age': 30},  // Original values as Map
+);
+
+// Check if a specific field changed
+bool fieldChanged(TrinaRow<Map<String, dynamic>> row, String field) {
+  return row.cells[field]?.value != row.data?[field];
+}
+```
+
+## Alternative: Hidden Columns
+
+Another approach is using hidden columns with the `hide` property:
+
+```dart
+TrinaColumn(
+  title: 'Original Name',
+  field: 'original_name',
+  type: TrinaColumnType.text(),
+  hide: true,  // Column won't be rendered
+)
+```
+
+Hidden columns:
+- Are not displayed in the grid
+- Still store data in cells
+- Are accessible via `row.cells['original_name']`
+
+However, `TrinaRow.data<T>` is generally cleaner for storing complex objects or metadata that doesn't fit the column/cell model.
+
+## Best Practices
+
+1. **Type Safety**: Use a specific type parameter (`TrinaRow<Person>`) rather than `dynamic` for compile-time safety.
+
+2. **Immutable Original Data**: Consider making your stored data immutable to prevent accidental modifications.
+
+3. **Memory Considerations**: The `data` property stores a reference, so large objects increase memory usage per row.
+
+4. **Serialization**: When exporting/importing grid data, remember to handle the `data` property separately since `toJson()` only exports cell values.
+
+## Related Features
+
+- [Change Tracking](change-tracking.md) - Built-in cell-level dirty tracking with commit/revert
+- [Column Hiding](column-hiding.md) - Hide columns from rendering
+- [Row Selection](row-selection.md) - Select and work with rows
+
+
+---
+
+## Cell Selection
+
+Cell selection is a core feature in TrinaGrid that allows users to select individual cells or ranges of cells for operations such as copying, editing, or applying actions. This feature enhances user interaction with the grid and provides a familiar spreadsheet-like experience.
+
+## Overview
+
+The cell selection feature enables you to:
+
+- Select individual cells with a single click
+- Select ranges of cells by dragging or using keyboard shortcuts
+- Select cells in different modes (cell, row, or column)
+- Perform operations on selected cells
+- Customize the appearance of selected cells
+- Programmatically control cell selection
+
+Cell selection provides a foundation for many other features in TrinaGrid, such as copy and paste, cell editing, and keyboard navigation.
+
+## Selection Modes
+
+TrinaGrid supports multiple selection modes that can be configured based on your requirements:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    selectingMode: TrinaGridSelectingMode.cell, // Default
+  ),
+)
+```
+
+### Available Selection Modes
+
+- `TrinaGridSelectingMode.cell`: Allows selection of individual cells or ranges of cells
+- `TrinaGridSelectingMode.row`: Selects entire rows when clicking on any cell
+- `TrinaGridSelectingMode.horizontal`: Allows selection of cells only in the horizontal direction
+
+## Basic Usage
+
+### Single Cell Selection
+
+To select a single cell, simply click on it:
+
+```dart
+// The cell will be selected when clicked
+// No additional code required
+```
+
+### Range Selection
+
+To select a range of cells:
+
+1. Click on the first cell
+2. Drag to the last cell in the range
+3. Release to complete the selection
+
+Alternatively, you can use keyboard shortcuts:
+
+1. Click on the first cell
+2. Hold Shift
+3. Use arrow keys to extend the selection
+4. Release Shift when done
+
+## Styling Selected Cells
+
+You can customize the appearance of selected cells through the configuration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      activatedBorderColor: Colors.blue,
+      activatedColor: Colors.lightBlue.withOpacity(0.2),
+      inactivatedBorderColor: Colors.grey,
+      inactivatedColor: Colors.grey.withOpacity(0.1),
+    ),
+  ),
+)
+```
+
+Available styling options include:
+
+- `activatedBorderColor`: Border color for the currently active cell
+- `activatedColor`: Background color for the currently active cell
+- `inactivatedBorderColor`: Border color for selected but inactive cells
+- `inactivatedColor`: Background color for selected but inactive cells
+
+## Programmatic Control
+
+You can programmatically control cell selection through the state manager:
+
+```dart
+// Select a specific cell
+stateManager.setCurrentCell(
+  cell,
+  rowIdx,
+  notify: true,
+);
+
+// Check if a cell is selected
+bool isSelected = stateManager.isSelectedCell(cell, column, rowIdx);
+
+// Get current selection information
+TrinaGridCellPosition? currentPosition = stateManager.currentCellPosition;
+List<TrinaGridSelectingCellPosition> selectedPositions = 
+    stateManager.currentSelectingPositionList;
+
+// Clear selection
+stateManager.clearCurrentCell(notify: true);
+
+// Set selection mode
+stateManager.setSelectingMode(TrinaGridSelectingMode.cell);
+```
+
+## Handling Selection Events
+
+You can respond to cell selection events using the `onChanged` callback:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (PlutoGridOnChangedEvent event) {
+    // Check if this is a selection change event
+    if (event.type == PlutoGridEventType.selection) {
+      // Access the current selection
+      final currentCell = event.stateManager.currentCell;
+      final selectedPositions = event.stateManager.currentSelectingPositionList;
+      
+      // Perform actions based on selection
+      print('Selected cell: ${currentCell?.value}');
+      print('Number of cells in selection: ${selectedPositions.length}');
+    }
+  },
+)
+```
+
+## Combining with Other Features
+
+Cell selection integrates with other TrinaGrid features for enhanced functionality:
+
+### Cell Selection with Editing
+
+When a cell is selected, you can start editing by:
+
+- Double-clicking the cell
+- Pressing F2 or Enter
+- Starting to type (if configured)
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    enterKeyAction: PlutoGridEnterKeyAction.editingAndMoveDown,
+    enableMoveDownAfterSelecting: true,
+  ),
+)
+```
+
+### Cell Selection with Copy & Paste
+
+Selected cells can be copied and pasted using standard keyboard shortcuts:
+
+- Ctrl+C (Cmd+C on macOS) to copy
+- Ctrl+V (Cmd+V on macOS) to paste
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    enableClipboard: true,
+  ),
+)
+```
+
+## Example
+
+Here's a complete example demonstrating cell selection functionality:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class CellSelectionExample extends StatefulWidget {
+  @override
+  _CellSelectionExampleState createState() => _CellSelectionExampleState();
+}
+
+class _CellSelectionExampleState extends State<CellSelectionExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Define columns
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Age',
+        field: 'age',
+        type: TrinaColumnType.number(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select(
+          items: [
+            TrinaSelectItem(value: 'Active', title: 'Active'),
+            TrinaSelectItem(value: 'Inactive', title: 'Inactive'),
+          ],
+        ),
+      ),
+    ]);
+
+    // Create sample data
+    for (int i = 0; i < 10; i++) {
+      rows.add(
+        TrinaRow(
+          cells: {
+            'id': TrinaCell(value: i + 1),
+            'name': TrinaCell(value: 'Person ${i + 1}'),
+            'age': TrinaCell(value: 20 + i),
+            'status': TrinaCell(value: i % 2 == 0 ? 'Active' : 'Inactive'),
+          },
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Cell Selection Example'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.select_all),
+            onPressed: () {
+              // Programmatically select a cell
+              if (stateManager.rows.isNotEmpty && stateManager.columns.isNotEmpty) {
+                final firstCell = stateManager.rows.first.cells['id'];
+                stateManager.setCurrentCell(firstCell, 0);
+              }
+            },
+          ),
+          IconButton(
+            icon: Icon(Icons.clear_all),
+            onPressed: () {
+              // Clear selection
+              stateManager.clearCurrentCell();
+            },
+          ),
+        ],
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(16.0),
+        child: TrinaGrid(
+          columns: columns,
+          rows: rows,
+          onLoaded: (TrinaGridOnLoadedEvent event) {
+            stateManager = event.stateManager;
+          },
+          onChanged: (TrinaGridOnChangedEvent event) {
+            if (event.type == TrinaGridEventType.selection) {
+              // Handle selection changes
+              print('Selection changed');
+              
+              // Get current selection information
+              final currentCell = stateManager.currentCell;
+              if (currentCell != null) {
+                print('Current cell value: ${currentCell.value}');
+              }
+            }
+          },
+          configuration: TrinaGridConfiguration(
+            selectingMode: TrinaGridSelectingMode.cell,
+            style: TrinaGridStyleConfig(
+              activatedBorderColor: Colors.blue,
+              activatedColor: Colors.lightBlue.withOpacity(0.2),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Excel-like Selection Features
+
+TrinaGrid supports Excel-like selection behaviors for enhanced productivity.
+
+### Click-and-Drag Selection
+
+Enable drag selection with a configurable hold duration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    selectingMode: TrinaGridSelectingMode.cell,
+    enableDragSelection: true,  // Enable drag-to-select
+    dragSelectionDelayDuration: const Duration(milliseconds: 100),  // Optional: customize delay
+  ),
+)
+```
+
+With this enabled:
+- Press and hold for a brief moment, then drag to select a range
+- Configurable delay duration (default: 200ms, recommended: 100ms for responsive feel)
+- Works like Excel's selection behavior
+- Auto-scrolls when dragging near edges
+
+**Important: Scroll Conflict**
+
+Drag selection can conflict with drag-to-scroll gestures. To avoid this:
+
+1. **Option 1**: Keep the default delay (200ms) - provides clear distinction between scrolling and selecting
+2. **Option 2**: Use a faster delay (100ms) and disable drag-to-scroll:
+
+```dart
+TrinaGrid(
+  configuration: TrinaGridConfiguration(
+    selectingMode: TrinaGridSelectingMode.cell,
+    enableDragSelection: true,
+    dragSelectionDelayDuration: const Duration(milliseconds: 100),
+    scrollbar: const TrinaGridScrollbarConfig(
+      // Disable mouse drag for scrolling to avoid conflicts
+      dragDevices: {},  // Empty set disables drag-to-scroll
+    ),
+  ),
+)
+```
+
+Recommended delays:
+- **100ms**: Very responsive, but may conflict with fast scrolling
+- **200ms**: Balanced (default) - good distinction from scroll gestures
+- **300ms**: Clear separation, less chance of accidental activation
+
+### Ctrl+Click Multi-Select (Cmd+Click on Mac)
+
+Enable selecting individual cells with Ctrl+Click (or Cmd+Click on Mac):
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    selectingMode: TrinaGridSelectingMode.cell,
+    enableCtrlClickMultiSelect: true,  // Enable Ctrl+Click (Cmd+Click on Mac)
+  ),
+)
+```
+
+With this enabled:
+- Ctrl+Click (Cmd+Click on Mac) adds/removes individual cells
+- Build non-contiguous selections
+- Click without Ctrl/Cmd clears individual selections
+- Shift+Click still works for range selection
+- All individually selected cells are included in `currentSelectingPositionList`
+
+### Combined Excel-like Behavior
+
+For the full Excel experience, enable both features:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    selectingMode: TrinaGridSelectingMode.cell,
+    enableDragSelection: true,
+    enableCtrlClickMultiSelect: true,
+  ),
+)
+```
+
+### Keyboard Shortcuts
+
+The following keyboard combinations work with selection:
+
+| Shortcut | Behavior |
+|----------|----------|
+| Long Press + Drag | Select range (when enableDragSelection is true) |
+| Ctrl + Click (Cmd + Click on Mac) | Toggle individual cell (when enableCtrlClickMultiSelect is true) |
+| Shift + Click | Extend selection to clicked cell |
+| Ctrl + A (Cmd + A on Mac) | Select all cells |
+| Click (no modifier) | Clear individual selections and select single cell |
+
+## Configuration Reference
+
+### Selection Configuration Options
+
+```dart
+TrinaGridConfiguration(
+  // Basic selection mode
+  selectingMode: TrinaGridSelectingMode.cell,
+
+  // Excel-like features (default: false)
+  enableDragSelection: true,
+  enableCtrlClickMultiSelect: true,
+
+  // Drag selection delay (default: 200ms)
+  dragSelectionDelayDuration: const Duration(milliseconds: 100),
+)
+```
+
+**enableDragSelection**:
+- Type: `bool`
+- Default: `false`
+- When `true`: Long press (using `dragSelectionDelayDuration`) and drag to select a range of cells
+- When `false`: Traditional behavior - long press selects starting cell, then drag extends selection
+- Only works when `selectingMode` is `TrinaGridSelectingMode.cell`
+
+**enableCtrlClickMultiSelect**:
+- Type: `bool`
+- Default: `false`
+- When `true`: Ctrl+Click (Cmd+Click on Mac) toggles individual cells in/out of selection
+- When `false`: Ctrl+Click has no special behavior in cell mode
+- Only works when `selectingMode` is `TrinaGridSelectingMode.cell`
+- Cross-platform: Automatically uses Ctrl on Windows/Linux and Cmd on Mac
+
+**dragSelectionDelayDuration**:
+- Type: `Duration`
+- Default: `Duration(milliseconds: 200)`
+- The time to hold before drag selection activates
+- Lower values (100ms) = more responsive but may conflict with scrolling
+- Higher values (300ms) = clearer distinction from scroll gestures
+- Only applies when `enableDragSelection` is `true`
+
+## Best Practices
+
+- Use the appropriate selection mode for your use case
+- Provide visual feedback when cells are selected
+- Consider implementing keyboard shortcuts for selection operations
+- Handle selection events to update UI or perform actions
+- Use programmatic selection for guided user experiences
+- Combine with other features like copy/paste for enhanced functionality
+- Enable Excel-like features for desktop applications to improve user experience
+
+
+---
+
+## Cell Editing
+
+Cell editing is a fundamental feature in TrinaGrid that allows users to modify cell values directly within the grid. This feature provides a spreadsheet-like experience, enabling efficient data entry and manipulation.
+
+![Cell Editing Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/cell-editing.gif)
+
+## Overview
+
+The cell editing feature enables you to:
+
+- Edit cell values directly in the grid
+- Configure which columns are editable
+- Customize the editing experience for different data types
+- Validate input data before committing changes
+- Handle cell value changes through events
+- Integrate with keyboard navigation for efficient editing
+
+Cell editing works seamlessly with other TrinaGrid features such as cell selection, keyboard navigation, and data validation.
+
+## Enabling Cell Editing
+
+To enable cell editing for specific columns, set the `enableEditingMode` property to `true` in your column definition:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableEditingMode: true, // Enable editing for this column
+)
+```
+
+You can also make a column read-only by setting the `readOnly` property:
+
+```dart
+TrinaColumn(
+  title: 'ID',
+  field: 'id',
+  type: TrinaColumnType.text(),
+  readOnly: true, // This column cannot be edited
+)
+```
+
+### Dynamic Cell Read-Only Control
+
+For more advanced scenarios, you can make individual cells read-only dynamically using the `checkReadOnly` callback function. This allows you to control cell editability based on the row's data or other conditions:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableEditingMode: true,
+  checkReadOnly: (TrinaRow row, TrinaCell cell) {
+    // Return true to make the cell read-only, false to allow editing
+    // Example: Make cell read-only based on another cell's value
+    return row.cells['status']?.value == 'locked';
+  },
+)
+```
+
+The `checkReadOnly` function provides:
+- `row`: The current row containing the cell
+- `cell`: The current cell being evaluated
+
+This callback is evaluated dynamically each time the grid needs to determine if a cell is editable, and it takes precedence over the static `readOnly` property. This allows for real-time updates when the underlying data changes.
+
+**Common use cases:**
+- Make cells read-only based on row status
+- Conditional editing based on user permissions
+- Time-based restrictions
+- Complex business logic for field editability
+
+## Editing Modes
+
+### Manual Editing
+
+By default, cells enter edit mode when:
+
+1. The user selects a cell and presses Enter
+2. The user double-clicks on a cell
+
+### Auto Editing
+
+You can configure columns to automatically enter edit mode when selected:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableEditingMode: true,
+  enableAutoEditing: true, // Automatically enter edit mode when cell is selected
+)
+```
+
+Alternatively, you can set auto editing mode for the entire grid:
+
+```dart
+stateManager.setAutoEditing(true);
+```
+
+## Customizing Edit Cell Renderer
+
+You can customize the appearance and behavior of cells in edit mode using the `editCellRenderer` property. This can be set at either the grid level or the column level.
+
+### Column-Level Edit Cell Renderer
+
+To customize the edit cell renderer for a specific column:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableEditingMode: true,
+  editCellRenderer: (defaultEditCellWidget, cell, controller, focusNode, handleSelected) {
+    // Return a custom widget that wraps the default edit cell widget
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.blue, width: 2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: defaultEditCellWidget, // Uses the controller automatically
+    );
+  },
+)
+```
+
+### Grid-Level Edit Cell Renderer
+
+To apply a custom edit cell renderer to all editable columns:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  editCellRenderer: (defaultEditCellWidget, cell, controller, focusNode, handleSelected) {
+    // This will be used for all columns unless they have their own editCellRenderer
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.green, width: 2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: defaultEditCellWidget,
+    );
+  },
+)
+```
+
+The `editCellRenderer` function provides:
+
+- `defaultEditCellWidget`: The default edit cell widget (usually a TextField)
+- `cell`: The current cell being edited
+- `controller`: The TextEditingController for the edit field
+- `focusNode`: The FocusNode for the edit field, allowing you to control focus
+- `handleSelected`: A callback function to notify the grid when a value is selected (required for select and date fields)
+
+Column-level renderers take precedence over grid-level renderers.
+
+### Handling Different Column Types
+
+For different column types, you may need to implement custom widgets instead of using the default edit widget:
+
+#### Select/Dropdown Columns
+
+For select columns, you need to use the `handleSelected` callback to notify the grid of value changes:
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.select(['Active', 'Inactive', 'Pending']),
+  enableEditingMode: true,
+  editCellRenderer: (defaultEditCellWidget, cell, controller, focusNode, handleSelected) {
+    String? value = cell.value;
+    Color indicatorColor = Colors.grey;
+    
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: indicatorColor, width: 2),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: StatefulBuilder(builder: (context, mSetState) {
+        return DropdownButtonHideUnderline(
+          child: DropdownButton<String>(
+            value: value,
+            isExpanded: true,
+            focusNode: focusNode, // Use the provided focus node
+            onChanged: (String? newValue) {
+              // Important: Call handleSelected to notify the grid of the value change
+              handleSelected?.call(newValue);
+              
+              // Update local state if needed
+              mSetState(() {
+                value = newValue;
+              });
+            },
+            items: (cell.column.type as TrinaColumnTypeSelect)
+                .items
+                .map<DropdownMenuItem<String>>((dynamic value) {
+              return DropdownMenuItem<String>(
+                value: value as String,
+                child: Text(value),
+              );
+            }).toList(),
+          ),
+        );
+      }),
+    );
+  },
+)
+```
+
+#### Date Columns
+
+For date columns, you also need to use the `handleSelected` callback:
+
+```dart
+TrinaColumn(
+  title: 'Date',
+  field: 'date',
+  type: TrinaColumnType.date(),
+  enableEditingMode: true,
+  editCellRenderer: (defaultEditCellWidget, cell, controller, focusNode, handleSelected) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.orange, width: 2),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextFormField(
+              controller: controller,
+              focusNode: focusNode,
+              style: const TextStyle(fontSize: 14),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.calendar_today),
+            onPressed: () async {
+              // Show date picker
+              final DateTime? picked = await showDatePicker(
+                context: context,
+                initialDate: DateTime.tryParse(cell.value.toString()) ?? DateTime.now(),
+                firstDate: DateTime(2000),
+                lastDate: DateTime(2100),
+              );
+              
+              // Important: Call handleSelected to notify the grid of the value change
+              if (picked != null) {
+                handleSelected?.call(picked);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  },
+)
+```
+
+#### Number Columns
+
+For number columns, you can either use the controller (which automatically updates the grid) or manually call `stateManager.changeCellValue()`:
+
+```dart
+TrinaColumn(
+  title: 'Quantity',
+  field: 'quantity',
+  type: TrinaColumnType.number(),
+  enableEditingMode: true,
+  editCellRenderer: (defaultEditCellWidget, cell, controller, focusNode, handleSelected) {
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.remove_circle_outline),
+          onPressed: () {
+            // Option 1: Update the controller (automatically updates the grid)
+            final currentValue = int.tryParse(controller.text) ?? 0;
+            controller.text = (currentValue - 1).toString();
+            
+            // Option 2: Manually update the cell value
+            // stateManager.changeCellValue(cell, currentValue - 1);
+            
+            // Maintain focus
+            focusNode.requestFocus();
+          },
+        ),
+        Expanded(
+          child: TextField(
+            controller: controller, // Using the controller automatically updates the grid
+            focusNode: focusNode,
+            textAlign: TextAlign.center,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              border: InputBorder.none,
+            ),
+            // No need for onChanged if using the controller
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.add_circle_outline),
+          onPressed: () {
+            final currentValue = int.tryParse(controller.text) ?? 0;
+            controller.text = (currentValue + 1).toString();
+            focusNode.requestFocus();
+          },
+        ),
+      ],
+    );
+  },
+)
+```
+
+### Important Notes
+
+1. **Maintaining Focus**: Always use the provided `focusNode` to maintain grid focus control.
+2. **Updating Values**:
+   - For text-based fields, use the provided `controller` to automatically update the grid.
+   - If not using the controller, call `stateManager.changeCellValue(cell, newValue)` to update cell values.
+   - For select and date fields, use the `handleSelected` callback to notify the grid of value changes.
+3. **Controller Synchronization**: For custom inputs, make sure to update the `controller.text` to reflect the new value.
+4. **Type Casting**: Be careful with type casting when working with different column types.
+
+### Understanding Value Change Handling by Column Type
+
+Different column types handle value changes differently:
+
+| Column Type | How to Handle Value Changes |
+|-------------|----------------------------|
+| Text        | Use the provided `controller` which automatically updates the grid. If not using the controller, call `stateManager.changeCellValue(cell, newValue)`. |
+| Number      | Use the provided `controller` or call `stateManager.changeCellValue(cell, numValue)`. |
+| Select      | Call `handleSelected?.call(newValue)` to notify the grid of the selection. |
+| Date        | Call `handleSelected?.call(pickedDate)` to notify the grid of the date selection. |
+| Time        | Call `handleSelected?.call(pickedTime)` to notify the grid of the time selection. |
+
+The key differences:
+
+1. **Text and Number columns**:
+   - When using the provided `controller`, the grid automatically detects changes.
+   - If implementing a custom input that doesn't use the controller, you must manually call `stateManager.changeCellValue()`.
+
+2. **Select, Date, and Time columns**:
+   - These columns implement `PopupCell` which requires using the `handleSelected` callback.
+   - The `handleSelected` callback properly updates the cell and handles any necessary state changes.
+   - Do not use `stateManager.changeCellValue()` directly for these column types as it may not properly update the grid's internal state.
+
+## Keyboard Navigation
+
+TrinaGrid supports keyboard navigation during editing:
+
+- **Enter**: Completes editing and moves to the cell below (configurable)
+- **Tab**: Completes editing and moves to the next cell
+- **Escape**: Cancels editing and reverts to the original value
+- **Arrow keys**: Navigate between cells when not in edit mode
+
+You can configure the Enter key behavior through the grid configuration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    enterKeyAction: TrinaGridEnterKeyAction.editingAndMoveDown, // Default
+    // Other options: editingAndMoveRight, toggleEditing, none
+  ),
+)
+```
+
+## Data Validation
+
+TrinaGrid provides built-in validation for cell values based on column types. You can also implement custom validation:
+
+```dart
+TrinaColumn(
+  title: 'Age',
+  field: 'age',
+  type: TrinaColumnType.number(),
+  enableEditingMode: true,
+  validator: (dynamic value, TrinaValidationContext context) {
+    if (value != null && (value < 0 || value > 120)) {
+      return 'Age must be between 0 and 120';
+    }
+    return null; // Return null if validation passes
+  },
+)
+```
+
+When validation fails, the `onValidationFailed` callback is triggered:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onValidationFailed: (TrinaGridValidationEvent event) {
+    // Handle validation failure
+    print('Validation failed: ${event.errorMessage}');
+  },
+)
+```
+
+## Event Handling
+
+TrinaGrid provides several callbacks for handling cell editing events:
+
+### Cell Value Changed
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (TrinaGridOnChangedEvent event) {
+    // Handle cell value change
+    print('Cell value changed: ${event.value}');
+  },
+)
+```
+
+You can also set an `onChanged` callback for individual cells:
+
+```dart
+TrinaCell(
+  value: 'Initial value',
+  onChanged: (TrinaGridOnChangedEvent event) {
+    // Handle cell value change
+    print('Cell value changed: ${event.value}');
+  },
+)
+```
+
+## Programmatic Control
+
+You can programmatically control cell editing through the state manager:
+
+```dart
+// Check if a cell is currently in edit mode
+bool isEditing = stateManager.isEditing;
+
+// Set a cell to edit mode
+stateManager.setEditing(true);
+
+// Toggle edit mode
+stateManager.toggleEditing();
+
+// Change a cell value programmatically
+stateManager.changeCellValue(cell, newValue);
+```
+
+## Copy and Paste
+
+TrinaGrid supports copy and paste functionality for cell values:
+
+```dart
+// Paste values from clipboard
+stateManager.pasteCellValue(textList);
+```
+
+The paste operation respects the current selection:
+
+- If a single cell is selected, pasting starts from that cell
+- If a range is selected, pasting is constrained to that range
+- If rows are selected, pasting applies to the selected rows
+
+## Custom Cell Editors
+
+You can customize the cell editing experience by implementing custom cell renderers:
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.select([
+    'Active',
+    'Inactive',
+    'Pending',
+  ]),
+  enableEditingMode: true,
+)
+```
+
+## Complete Example
+
+Here's a complete example demonstrating cell editing functionality:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class CellEditingExample extends StatefulWidget {
+  @override
+  _CellEditingExampleState createState() => _CellEditingExampleState();
+}
+
+class _CellEditingExampleState extends State<CellEditingExample> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        readOnly: true, // This column cannot be edited
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        enableEditingMode: true, // Enable editing for this column
+      ),
+      TrinaColumn(
+        title: 'Age',
+        field: 'age',
+        type: TrinaColumnType.number(),
+        enableEditingMode: true,
+        validator: (dynamic value, TrinaValidationContext context) {
+          if (value != null && (value < 0 || value > 120)) {
+            return 'Age must be between 0 and 120';
+          }
+          return null; // Return null if validation passes
+        },
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select([
+          'Active',
+          'Inactive',
+          'Pending',
+        ]),
+        enableEditingMode: true,
+      ),
+    ];
+    
+    rows = [
+      TrinaRow(cells: {
+        'id': TrinaCell(value: '1'),
+        'name': TrinaCell(value: 'John Doe'),
+        'age': TrinaCell(value: 30),
+        'status': TrinaCell(value: 'Active'),
+      }),
+      TrinaRow(cells: {
+        'id': TrinaCell(value: '2'),
+        'name': TrinaCell(value: 'Jane Smith'),
+        'age': TrinaCell(value: 25),
+        'status': TrinaCell(value: 'Inactive'),
+      }),
+      TrinaRow(cells: {
+        'id': TrinaCell(value: '3'),
+        'name': TrinaCell(value: 'Bob Johnson'),
+        'age': TrinaCell(value: 45),
+        'status': TrinaCell(value: 'Pending'),
+      }),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Cell Editing Example'),
+      ),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          stateManager = event.stateManager;
+        },
+        onChanged: (TrinaGridOnChangedEvent event) {
+          print('Cell value changed: ${event.value}');
+        },
+        onValidationFailed: (TrinaGridValidationEvent event) {
+          print('Validation failed: ${event.errorMessage}');
+        },
+        configuration: TrinaGridConfiguration(
+          enterKeyAction: TrinaGridEnterKeyAction.editingAndMoveDown,
+          enableMoveHorizontalInEditing: true,
+        ),
+        mode: TrinaGridMode.normal,
+      ),
+    );
+  }
+}
+
+## Best Practices
+
+- **Enable editing only for columns that need it**: Keep read-only columns for data that shouldn't be modified
+- **Implement validation**: Always validate user input to maintain data integrity
+- **Handle validation failures**: Provide clear feedback when validation fails
+- **Use appropriate column types**: Choose column types that match your data (text, number, select, etc.)
+- **Consider keyboard navigation**: Configure keyboard shortcuts for efficient editing
+- **Test with different input methods**: Ensure your editing experience works well with keyboard, mouse, and touch input
+
+
+---
+
+## Cell Navigation Validation
+
+TrinaGrid provides a powerful callback mechanism to validate and control cell navigation. This feature allows you to prevent users from navigating away from a cell or row until certain conditions are met, such as data validation.
+
+## Overview
+
+The `onBeforeActiveCellChange` callback fires **before** the active cell changes, allowing you to:
+
+- Validate data in the current cell/row
+- Prevent navigation if validation fails
+- Implement custom navigation rules
+- Show validation errors without visual flicker
+
+This is particularly useful for building data entry forms where strict validation rules are required before proceeding.
+
+## Basic Usage
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Return true to allow the change
+    // Return false to cancel the change
+    return true;
+  },
+)
+```
+
+## Event Object
+
+The `TrinaGridOnBeforeActiveCellChangeEvent` provides complete context about the navigation:
+
+```dart
+class TrinaGridOnBeforeActiveCellChangeEvent {
+  /// The current (old) cell that is active
+  final TrinaCell? oldCell;
+
+  /// The current (old) row index
+  final int? oldRowIdx;
+
+  /// The new cell that will become active
+  final TrinaCell newCell;
+
+  /// The new row index
+  final int newRowIdx;
+
+  /// The direction of movement that triggered this cell change.
+  /// This is `null` when the cell change was triggered by a mouse click
+  /// or programmatic call without direction context.
+  /// When navigating via keyboard (arrow keys, tab, etc.), this will be
+  /// TrinaMoveDirection.left, TrinaMoveDirection.right,
+  /// TrinaMoveDirection.up, or TrinaMoveDirection.down.
+  final TrinaMoveDirection? moveDirection;
+}
+```
+
+## Common Use Cases
+
+### 1. Row-Level Validation
+
+Prevent navigation to a different row until the current row is valid:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Check if user is trying to change rows
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      // Validate the current row
+      final currentRow = rows[event.oldRowIdx!];
+      final isValid = validateRow(currentRow);
+
+      if (!isValid) {
+        // Show error message
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Please fix errors in the current row before proceeding'),
+            backgroundColor: Colors.red,
+          ),
+        );
+
+        // Cancel navigation
+        return false;
+      }
+    }
+
+    // Allow navigation
+    return true;
+  },
+)
+```
+
+### 2. Required Field Validation
+
+Ensure required fields are filled before navigating away:
+
+```dart
+bool validateRow(TrinaRow row) {
+  // Check if name field is not empty
+  final name = row.cells['name']?.value;
+  if (name == null || name.toString().trim().isEmpty) {
+    return false;
+  }
+
+  // Check if email field is not empty
+  final email = row.cells['email']?.value;
+  if (email == null || email.toString().trim().isEmpty) {
+    return false;
+  }
+
+  return true;
+}
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+      if (!validateRow(currentRow)) {
+        return false; // Cancel navigation
+      }
+    }
+    return true;
+  },
+)
+```
+
+### 3. Async Validation
+
+Perform asynchronous validation before allowing navigation:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+
+      // Show loading indicator
+      final loadingDialog = showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => Center(child: CircularProgressIndicator()),
+      );
+
+      // Perform async validation
+      validateRowAsync(currentRow).then((isValid) {
+        // Hide loading indicator
+        Navigator.of(context).pop();
+
+        if (!isValid) {
+          showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: Text('Validation Error'),
+              content: Text('Please fix errors before proceeding'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: Text('OK'),
+                ),
+              ],
+            ),
+          );
+        }
+      });
+
+      // Note: For async validation, you might need to store state
+      // and prevent navigation in the sync callback
+      return false; // Cancel for now
+    }
+    return true;
+  },
+)
+```
+
+**Note**: The callback is synchronous. For async validation, you may need to implement a two-step approach:
+1. Cancel navigation in the callback
+2. Perform async validation
+3. If valid, programmatically trigger navigation using `stateManager.setCurrentCell()`
+
+### 4. Conditional Navigation Rules
+
+Allow or prevent navigation based on specific conditions:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Allow same-row navigation
+    if (event.oldRowIdx == event.newRowIdx) {
+      return true;
+    }
+
+    // Allow navigation from the last row
+    if (event.oldRowIdx == rows.length - 1) {
+      return true;
+    }
+
+    // For other cases, validate the current row
+    if (event.oldRowIdx != null) {
+      final currentRow = rows[event.oldRowIdx!];
+      return validateRow(currentRow);
+    }
+
+    return true;
+  },
+)
+```
+
+### 5. Field-Specific Validation
+
+Prevent navigation based on specific field validation:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+
+      // Validate specific fields
+      final email = currentRow.cells['email']?.value?.toString() ?? '';
+      final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+
+      if (email.isNotEmpty && !emailRegex.hasMatch(email)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Please enter a valid email address'),
+            backgroundColor: Colors.red,
+          ),
+        );
+        return false;
+      }
+    }
+
+    return true;
+  },
+)
+```
+
+## Integration with Other Callbacks
+
+The `onBeforeActiveCellChange` callback works seamlessly with other cell-related callbacks:
+
+### Combining with onActiveCellChanged
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Validate before navigation
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final isValid = validateRow(rows[event.oldRowIdx!]);
+      if (!isValid) {
+        return false; // Cancel navigation
+      }
+    }
+    return true;
+  },
+  onActiveCellChanged: (event) {
+    // This only fires if navigation was allowed
+    print('Active cell changed to row ${event.idx}');
+
+    // You can perform actions after successful navigation
+    loadAdditionalDataForRow(event.idx);
+  },
+)
+```
+
+### Combining with onValidationFailed
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Prevent row navigation until validation passes
+    if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+      final currentRow = rows[event.oldRowIdx!];
+      return validateAllFieldsInRow(currentRow);
+    }
+    return true;
+  },
+  onValidationFailed: (event) {
+    // This fires when individual cell validation fails
+    print('Field ${event.column.title} validation failed: ${event.errorMessage}');
+  },
+)
+```
+
+## Keyboard and Mouse Navigation
+
+The `onBeforeActiveCellChange` callback works for **all** navigation methods:
+
+- **Keyboard navigation**: Arrow keys, Tab, Enter
+- **Mouse clicks**: Clicking on cells
+- **Programmatic navigation**: `stateManager.setCurrentCell()`
+
+This ensures consistent validation regardless of how the user navigates.
+
+### Distinguishing Navigation Source
+
+You can use the `moveDirection` property to distinguish between keyboard navigation and mouse clicks:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onBeforeActiveCellChange: (event) {
+    // Check if this is keyboard navigation or mouse click
+    if (event.moveDirection != null) {
+      // Keyboard navigation (arrow keys, tab, etc.)
+      print('Navigating via keyboard: ${event.moveDirection}');
+
+      // Example: Apply stricter validation for keyboard navigation
+      if (event.oldRowIdx != event.newRowIdx) {
+        return validateRowBeforeLeaving(rows[event.oldRowIdx!]);
+      }
+    } else {
+      // Mouse click or programmatic navigation
+      print('Navigation via mouse click or programmatic call');
+
+      // Example: Allow free navigation via mouse
+      return true;
+    }
+
+    return true;
+  },
+)
+```
+
+This is particularly useful for desktop applications where you might want different behavior for keyboard versus mouse navigation.
+
+## Best Practices
+
+1. **Provide Clear Feedback**: Always show clear error messages when preventing navigation
+   ```dart
+   if (!isValid) {
+     ScaffoldMessenger.of(context).showSnackBar(
+       SnackBar(content: Text('Please complete all required fields')),
+     );
+     return false;
+   }
+   ```
+
+2. **Allow Same-Row Navigation**: Let users move between cells in the same row
+   ```dart
+   if (event.oldRowIdx == event.newRowIdx) {
+     return true; // Allow cell navigation within same row
+   }
+   ```
+
+3. **Handle First Selection**: Check if `oldRowIdx` is null (first cell selection)
+   ```dart
+   if (event.oldRowIdx == null) {
+     return true; // Always allow first cell selection
+   }
+   ```
+
+4. **Keep Validation Logic Fast**: The callback is synchronous and blocks navigation
+   ```dart
+   // Good: Fast validation
+   return row.cells['name']?.value != null;
+
+   // Avoid: Slow operations that block UI
+   // return await fetchValidationFromServer(row);
+   ```
+
+5. **Use with Cell Validation**: Combine with column-level validators for comprehensive validation
+   ```dart
+   TrinaColumn(
+     field: 'email',
+     validator: (value, context) {
+       // Cell-level validation
+       if (!isValidEmail(value)) {
+         return 'Invalid email';
+       }
+       return null;
+     },
+   ),
+   ```
+
+6. **Visual Indicators**: Highlight invalid cells to guide users
+   ```dart
+   cellColorCallback: (cellContext) {
+     if (!isValidCell(cellContext.cell)) {
+       return Colors.red.shade50;
+     }
+     return Colors.white;
+   },
+   ```
+
+## Differences from onActiveCellChanged
+
+| Feature | onBeforeActiveCellChange | onActiveCellChanged |
+|---------|-------------------------|---------------------|
+| **Timing** | Before state changes | After state changes |
+| **Can cancel** | Yes (return false) | No |
+| **Return type** | bool | void |
+| **Use case** | Validation, prevention | Tracking, logging |
+| **Old cell info** | Yes (provided in event) | No |
+
+## Example: Complete Validation Form
+
+```dart
+class ValidatedGrid extends StatelessWidget {
+  final List<TrinaColumn> columns = [
+    TrinaColumn(
+      title: 'Name',
+      field: 'name',
+      type: TrinaColumnType.text(),
+      validator: (value, context) {
+        if (value == null || value.toString().trim().isEmpty) {
+          return 'Name is required';
+        }
+        return null;
+      },
+    ),
+    TrinaColumn(
+      title: 'Email',
+      field: 'email',
+      type: TrinaColumnType.text(),
+      validator: (value, context) {
+        if (value == null || value.toString().trim().isEmpty) {
+          return 'Email is required';
+        }
+        final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+        if (!emailRegex.hasMatch(value.toString())) {
+          return 'Invalid email format';
+        }
+        return null;
+      },
+    ),
+  ];
+
+  bool validateRow(TrinaRow row) {
+    // Check all cells in the row
+    for (final column in columns) {
+      final cell = row.cells[column.field];
+      if (column.validator != null) {
+        final error = column.validator!(
+          cell?.value,
+          TrinaValidationContext(
+            column: column,
+            row: row,
+            rowIdx: 0,
+            oldValue: cell?.value,
+          ),
+        );
+        if (error != null) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      columns: columns,
+      rows: rows,
+      onBeforeActiveCellChange: (event) {
+        // Prevent row navigation if current row is invalid
+        if (event.oldRowIdx != null && event.oldRowIdx != event.newRowIdx) {
+          final currentRow = rows[event.oldRowIdx!];
+          final isValid = validateRow(currentRow);
+
+          if (!isValid) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Please fix validation errors before proceeding'),
+                backgroundColor: Colors.red,
+              ),
+            );
+            return false;
+          }
+        }
+
+        return true;
+      },
+      onValidationFailed: (event) {
+        // Show specific field validation errors
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${event.column.title}: ${event.errorMessage}'),
+            backgroundColor: Colors.orange,
+          ),
+        );
+      },
+      cellColorCallback: (cellContext) {
+        // Highlight invalid cells
+        if (cellContext.column.validator != null) {
+          final error = cellContext.column.validator!(
+            cellContext.cell.value,
+            TrinaValidationContext(
+              column: cellContext.column,
+              row: cellContext.row,
+              rowIdx: cellContext.rowIdx,
+              oldValue: cellContext.cell.value,
+            ),
+          );
+          if (error != null) {
+            return Colors.red.shade50;
+          }
+        }
+        return Colors.white;
+      },
+    );
+  }
+}
+```
+
+## Related Features
+
+- [Cell Validation](cell-validation.md) - For column-level and cell-level validation
+- [Cell Editing](cell-editing.md) - For controlling cell editing behavior
+- [Cell Selection](cell-selection.md) - For understanding cell selection and navigation
+- [Cell Value Change Handling](cell_value_change_handling.md) - For handling value changes
+
+
+---
+
+## Cell Renderer
+
+The cell renderer feature allows you to customize the appearance of individual cells in TrinaGrid. This is particularly useful when you want to:
+
+- Display cell values with custom formatting
+- Add icons or other visual indicators based on cell values
+- Create interactive elements within cells
+- Apply conditional styling based on cell content
+
+## Overview
+
+TrinaGrid provides two levels of rendering customization:
+
+1. **Column-level rendering**: Apply a custom renderer to all cells in a column
+2. **Cell-level rendering**: Apply a custom renderer to specific individual cells
+
+When both are defined, the cell-level renderer takes precedence over the column-level renderer.
+
+## Cell-Level Renderer
+
+### Basic Usage
+
+To apply a custom renderer to a specific cell, provide a `renderer` function when creating the `TrinaCell`:
+
+```dart
+TrinaCell(
+  value: 'Completed',
+  renderer: (rendererContext) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.green,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        rendererContext.cell.value.toString(),
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  },
+)
+```
+
+### The TrinaCellRendererContext
+
+The renderer function receives a `TrinaCellRendererContext` object that provides access to:
+
+- `column`: The column definition
+- `rowIdx`: The row index
+- `row`: The row data
+- `cell`: The cell being rendered
+- `stateManager`: The grid's state manager
+
+This context allows you to create dynamic renderers that respond to the cell's data and position within the grid.
+
+## Examples
+
+### Status Indicator
+
+Create a status indicator with different colors based on the cell value:
+
+```dart
+TrinaCell(
+  value: 'In Progress',
+  renderer: (rendererContext) {
+    Color backgroundColor;
+    Color textColor = Colors.white;
+
+    switch (rendererContext.cell.value) {
+      case 'Completed':
+        backgroundColor = Colors.green;
+        break;
+      case 'In Progress':
+        backgroundColor = Colors.orange;
+        break;
+      case 'Pending':
+        backgroundColor = Colors.blue;
+        break;
+      case 'Cancelled':
+        backgroundColor = Colors.red;
+        break;
+      default:
+        backgroundColor = Colors.grey;
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        rendererContext.cell.value.toString(),
+        style: TextStyle(
+          color: textColor,
+          fontWeight: FontWeight.bold,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  },
+)
+```
+
+### Icon with Text
+
+Display an icon alongside text based on the cell value:
+
+```dart
+TrinaCell(
+  value: 'High',
+  renderer: (rendererContext) {
+    IconData iconData;
+    Color iconColor;
+
+    switch (rendererContext.cell.value) {
+      case 'Low':
+        iconData = Icons.arrow_downward;
+        iconColor = Colors.green;
+        break;
+      case 'Medium':
+        iconData = Icons.arrow_forward;
+        iconColor = Colors.blue;
+        break;
+      case 'High':
+        iconData = Icons.arrow_upward;
+        iconColor = Colors.orange;
+        break;
+      case 'Critical':
+        iconData = Icons.priority_high;
+        iconColor = Colors.red;
+        break;
+      default:
+        iconData = Icons.help_outline;
+        iconColor = Colors.grey;
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Icon(
+          iconData,
+          color: iconColor,
+          size: 16,
+        ),
+        const SizedBox(width: 4),
+        Text(
+          rendererContext.cell.value.toString(),
+          style: TextStyle(
+            color: iconColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  },
+)
+```
+
+### Interactive Elements
+
+Create cells with interactive elements:
+
+```dart
+TrinaCell(
+  value: 5,
+  renderer: (rendererContext) {
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.remove_circle_outline),
+          onPressed: () {
+            // Decrement the value
+            int currentValue = rendererContext.cell.value;
+            if (currentValue > 0) {
+              rendererContext.stateManager.changeCellValue(
+                rendererContext.cell,
+                currentValue - 1,
+              );
+            }
+          },
+          iconSize: 16,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+        Text(rendererContext.cell.value.toString()),
+        IconButton(
+          icon: const Icon(Icons.add_circle_outline),
+          onPressed: () {
+            // Increment the value
+            int currentValue = rendererContext.cell.value;
+            rendererContext.stateManager.changeCellValue(
+              rendererContext.cell,
+              currentValue + 1,
+            );
+          },
+          iconSize: 16,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+      ],
+    );
+  },
+)
+```
+
+### Conditional Formatting
+
+Apply different styles based on cell value:
+
+```dart
+TrinaCell(
+  value: 85,
+  renderer: (rendererContext) {
+    int value = rendererContext.cell.value;
+    Color textColor;
+    
+    if (value >= 90) {
+      textColor = Colors.green;
+    } else if (value >= 70) {
+      textColor = Colors.blue;
+    } else if (value >= 50) {
+      textColor = Colors.orange;
+    } else {
+      textColor = Colors.red;
+    }
+    
+    return Text(
+      '$value%',
+      style: TextStyle(
+        color: textColor,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  },
+)
+```
+
+## Best Practices
+
+1. **Performance**: Keep your renderer functions efficient to maintain smooth scrolling
+2. **Reusability**: Create reusable renderer functions for common patterns
+3. **Responsiveness**: Make your custom widgets adapt to different cell sizes
+4. **Consistency**: Maintain a consistent look and feel across your grid
+5. **Accessibility**: Ensure your custom renderers maintain accessibility features
+
+## Comparison with Column Renderer
+
+While column renderers apply to all cells in a column, cell renderers allow for more granular control:
+
+```dart
+// Column-level renderer (applies to all cells in the column)
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.text(),
+  renderer: (rendererContext) {
+    // Default rendering for all cells in this column
+    return Text(
+      rendererContext.cell.value.toString(),
+      style: const TextStyle(fontWeight: FontWeight.bold),
+    );
+  },
+)
+
+// Cell-level renderer (applies only to this specific cell)
+TrinaCell(
+  value: 'Completed',
+  renderer: (rendererContext) {
+    // Custom rendering for this specific cell
+    return Container(
+      color: Colors.green,
+      child: Text(rendererContext.cell.value.toString()),
+    );
+  },
+)
+```
+
+## Related Features
+
+- [Column Renderer](column-renderer.md): Apply custom renderers to all cells in a column
+- [Cell Editing](cell-editing.md): Customize the cell editing experience
+- [Custom Styling](custom-styling.md): Apply global styling to your grid
+
+
+---
+
+## Cell Validation
+
+TrinaGrid provides multiple approaches to validation:
+
+1. **Built-in Column Type Validation**: Each column type has built-in validation rules
+2. **Custom Column Validation**: Define custom validation rules at the column level
+3. **Cell Change Handlers**: Implement validation in cell change event handlers
+
+## Column Type Validation
+
+Each column type in TrinaGrid comes with built-in validation rules that are automatically applied:
+
+### Text Column
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+)
+```
+
+The text column type validates that values are either strings or numbers. Null values are considered invalid.
+
+### Number Column
+
+```dart
+TrinaColumn(
+  title: 'Age',
+  field: 'age',
+  type: TrinaColumnType.number(
+    negative: false, // Disallow negative numbers
+    format: '#,##0', // Format pattern
+  ),
+)
+```
+
+The number column type validates:
+
+- Values are numeric
+- Negative numbers (can be disabled)
+- Format pattern compliance
+
+### Select Column
+
+```dart
+TrinaColumn(
+  title: 'Status',
+  field: 'status',
+  type: TrinaColumnType.select(
+    items: [
+      'Pending',
+      'In Progress',
+      'Completed',
+      'Cancelled',
+    ],
+    onItemSelected: (event) {
+      // Handle selection
+    },
+    enableColumnFilter: true,
+  ),
+)
+```
+
+The select column type validates that values are present in the predefined items list.
+
+### Date Column
+
+```dart
+TrinaColumn(
+  title: 'Birth Date',
+  field: 'birthDate',
+  type: TrinaColumnType.date(
+    format: 'yyyy-MM-dd',
+    startDate: DateTime(1900),
+    endDate: DateTime.now(),
+  ),
+)
+```
+
+The date column type validates:
+
+- Date format compliance
+- Date range (if startDate/endDate specified)
+- Valid date values
+
+### Time Column
+
+```dart
+TrinaColumn(
+  title: 'Start Time',
+  field: 'startTime',
+  type: TrinaColumnType.time(),
+)
+```
+
+The time column type validates that values match the format `HH:mm` (24-hour format).
+
+## Custom Column Validation
+
+You can define custom validation rules at the column level using the `validator` property:
+
+```dart
+TrinaColumn(
+  title: 'Email',
+  field: 'email',
+  type: TrinaColumnType.text(),
+  validator: (value, context) {
+    if (value == null || value.toString().isEmpty) {
+      return 'Email is required';
+    }
+
+    final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+    if (!emailRegex.hasMatch(value.toString())) {
+      return 'Please enter a valid email address';
+    }
+
+    return null; // Return null if validation passes
+  },
+)
+```
+
+### The Validation Context
+
+The validator function receives a `TrinaValidationContext` object that provides access to:
+
+- `column`: The column definition
+- `row`: The row containing the cell being validated
+- `rowIdx`: The row index
+- `oldValue`: The previous value before the change
+- `stateManager`: The grid's state manager
+
+This context allows you to create dynamic validators that can access other cells or grid state.
+
+### Cross-Field Validation
+
+Validate a value based on other fields in the same row:
+
+```dart
+TrinaColumn(
+  title: 'Confirm Password',
+  field: 'confirmPassword',
+  type: TrinaColumnType.text(),
+  validator: (value, context) {
+    final password = context.row.cells['password']?.value;
+    
+    if (value != password) {
+      return 'Passwords do not match';
+    }
+    
+    return null;
+  },
+)
+```
+
+### Complex Validation Rules
+
+Combine multiple validation rules:
+
+```dart
+TrinaColumn(
+  title: 'Password',
+  field: 'password',
+  type: TrinaColumnType.text(),
+  validator: (value, context) {
+    if (value == null || value.toString().isEmpty) {
+      return 'Password is required';
+    }
+
+    final password = value.toString();
+    
+    if (password.length < 8) {
+      return 'Password must be at least 8 characters';
+    }
+    
+    if (!password.contains(RegExp(r'[A-Z]'))) {
+      return 'Password must contain at least one uppercase letter';
+    }
+    
+    if (!password.contains(RegExp(r'[0-9]'))) {
+      return 'Password must contain at least one number';
+    }
+    
+    return null;
+  },
+)
+```
+
+## Handling Validation Failures
+
+You can handle validation failures at the grid level by providing an `onValidationFailed` callback:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onValidationFailed: (event) {
+    // Show error message
+    showErrorDialog(
+      context,
+      'Validation Error',
+      event.errorMessage,
+    );
+    
+    // Log validation failure
+    logger.warning(
+      'Validation failed for ${event.column.title}: ${event.errorMessage}',
+    );
+    
+    // You can also access:
+    // event.value - The invalid value
+    // event.oldValue - The previous value
+    // event.row - The row containing the invalid value
+    // event.rowIdx - The row index
+  },
+)
+```
+
+## Cell Change Handlers
+
+For more complex validation scenarios, you can still use cell change handlers:
+
+```dart
+TrinaCell(
+  value: 'username',
+  onChanged: (event) async {
+    // Show loading indicator
+    event.stateManager.showLoading();
+    
+    try {
+      // Perform async validation
+      final isAvailable = await checkUsernameAvailability(event.value);
+      
+      if (!isAvailable) {
+        event.stateManager.showSnackBar(
+          'Username already taken',
+          backgroundColor: Colors.red,
+        );
+        
+        // Revert to previous value
+        event.stateManager.changeCellValue(
+          event.cell,
+          event.oldValue,
+        );
+      }
+    } finally {
+      // Hide loading indicator
+      event.stateManager.hideLoading();
+    }
+  },
+)
+```
+
+## Validation UI
+
+### Error Feedback
+
+When validation fails, you can provide feedback to users through:
+
+#### Method 1: Using the onValidationFailed callback
+
+```dart
+onValidationFailed: (event) {
+  showSnackBar(
+    context,
+    event.errorMessage,
+    backgroundColor: Colors.red,
+  );
+}
+```
+
+#### Method 2: Using custom cell rendering
+
+```dart
+TrinaColumn(
+  title: 'Email',
+  field: 'email',
+  renderer: (context) {
+    final isValid = isValidEmail(context.cell.value);
+    
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: isValid ? Colors.transparent : Colors.red,
+        ),
+      ),
+      child: Text(
+        context.cell.value.toString(),
+        style: TextStyle(
+          color: isValid ? Colors.black : Colors.red,
+        ),
+      ),
+    );
+  },
+)
+```
+
+## Best Practices
+
+1. **Use Built-in Validation**: Leverage the built-in validation provided by column types whenever possible
+2. **Column-Level Validation**: Use the `validator` property for validation rules that apply to all cells in a column
+3. **Cell-Level Validation**: Use `onChanged` handlers for complex validation scenarios or async validation
+4. **Clear Feedback**: Provide clear error messages when validation fails
+5. **Prevent Invalid States**: Invalid values are automatically prevented from being committed
+6. **Performance**: Keep validation logic efficient, especially for large datasets
+7. **User Experience**: Show loading indicators during asynchronous validation
+8. **Error Recovery**: Provide clear paths for users to correct invalid data
+9. **Consistent Validation**: Apply consistent validation rules across similar data types
+
+## Related Features
+
+- [Cell Navigation Validation](cell-navigation-validation.md) - For preventing navigation away from invalid cells/rows
+- [Column Types](column-types.md) - For details on built-in column types and their validation
+- [Cell Editing](cell-editing.md) - For more details on cell editing behavior
+- [Cell Value Change Handling](cell_value_change_handling.md) - For handling cell value changes
+- [Column Renderers](column-renderer.md) - For customizing cell appearance based on validation state
+
+
+---
+
+## Cell Value Change and Keyboard Event Handling in TrinaGrid
+
+TrinaGrid provides a flexible system for handling cell value changes and keyboard events through callbacks at both the cell level and the grid level. This dual approach gives you fine-grained control over how changes and keyboard interactions are processed in your application.
+
+## Overview
+
+When a cell value changes in TrinaGrid, the following sequence occurs:
+
+1. The cell value is updated in the data model
+2. If present, the cell-level `onChanged` callback is triggered
+3. If present, the grid-level `onChanged` callback is triggered
+4. The UI is updated to reflect the change
+
+This sequence allows you to implement different strategies for handling changes based on your application's architecture.
+
+## Cell-Level onChanged Callback
+
+The cell-level `onChanged` callback is defined directly on the `TrinaCell` object and is specific to that individual cell.
+
+### Syntax
+
+```dart
+TrinaCell(
+  value: initialValue,
+  onChanged: (TrinaGridOnChangedEvent event) {
+    // Handle the cell value change
+  },
+)
+```
+
+### When to Use Cell-Level Callbacks
+
+Cell-level callbacks are ideal for:
+
+- Cell-specific validation or formatting
+- Triggering different actions based on which specific cell changed
+- Implementing cell-specific business logic
+- Creating interdependent cells (where one cell's value affects another)
+- Tracking changes to specific high-importance cells
+
+### Example: Cell-Level Validation
+
+```dart
+TrinaCell(
+  value: 'Initial Value',
+  onChanged: (event) {
+    // Validate this specific cell's value
+    if (event.value.toString().isEmpty) {
+      showToast('This field cannot be empty');
+      // You could also revert the change or apply a default value
+    }
+    
+    // You can also update other UI elements based on this cell's value
+    if (event.value == 'Special Value') {
+      showDialog(context, 'Special value detected!');
+    }
+  },
+)
+```
+
+## Grid-Level onChanged Callback (State Manager)
+
+The grid-level `onChanged` callback is defined on the `TrinaGrid` widget and is triggered for any cell change in the entire grid.
+
+### onChanged callback syntax
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (TrinaGridOnChangedEvent event) {
+    // Handle any cell value change in the grid
+  },
+)
+```
+
+### When to Use Grid-Level Callbacks
+
+Grid-level callbacks are ideal for:
+
+- Centralized handling of all changes
+- Saving changes to a database
+- Logging all modifications
+- Implementing undo/redo functionality
+- Syncing data with external systems
+- Applying global validation rules
+
+### Example: Grid-Level Change Handling
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (event) {
+    // Log all changes
+    logger.info('Cell changed: ${event.column.field} = ${event.value}');
+    
+    // Save changes to database
+    databaseService.updateField(
+      rowId: event.row.cells['id']?.value,
+      field: event.column.field,
+      value: event.value,
+    );
+    
+    // Update application state
+    appStateManager.notifyDataChanged();
+  },
+)
+```
+
+## Combined Approach
+
+You can use both cell-level and grid-level callbacks together to create a comprehensive change handling system.
+
+### Example: Combined Approach
+
+```dart
+// Cell-level handling for specific validation
+TrinaCell(
+  value: 'John',
+  onChanged: (event) {
+    // Cell-specific validation
+    if (event.value.toString().length < 3) {
+      showToast('Name must be at least 3 characters');
+    }
+  },
+)
+
+// Grid-level handling for global operations
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onChanged: (event) {
+    // Global handling for all cells
+    saveChangesToDatabase(event.row, event.column.field, event.value);
+    updateUIState();
+  },
+)
+```
+
+## The TrinaGridOnChangedEvent Object
+
+Both callback types receive a `TrinaGridOnChangedEvent` object that contains information about the change:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `columnIdx` | `int` | The index of the column in the current view |
+| `column` | `TrinaColumn` | The column object |
+| `rowIdx` | `int` | The index of the row in the current view |
+| `row` | `TrinaRow` | The row object |
+| `cell` | `TrinaCell` | The cell that was changed |
+| `value` | `dynamic` | The new value |
+| `oldValue` | `dynamic` | The previous value |
+
+### Example: Using the Event Object
+
+```dart
+onChanged: (event) {
+  print('Column: ${event.column.title}');
+  print('Field: ${event.column.field}');
+  print('Row index: ${event.rowIdx}');
+  print('Changed from: ${event.oldValue} to ${event.value}');
+  
+  // Direct access to the changed cell
+  print('Cell key: ${event.cell.key}');
+  print('Original value: ${event.cell.originalValue}');
+  print('Is dirty: ${event.cell.isDirty}');
+  
+  // Access formatted value
+  String formattedValue = event.column.formattedValueForDisplay(event.value);
+  print('Formatted value: $formattedValue');
+  
+  // Access other cells in the same row
+  final otherCellValue = event.row.cells['otherField']?.value;
+}
+```
+
+## Keyboard Event Handling
+
+In addition to value changes, TrinaGrid also provides keyboard event handling through the `onKeyPressed` callback at the cell level. This allows you to capture and respond to keyboard interactions like Enter, Tab, Escape, and modifier key combinations.
+
+### Cell-Level onKeyPressed Callback
+
+The `onKeyPressed` callback is defined on the `TrinaCell` object and is triggered when any key is pressed while the cell is being edited.
+
+### Syntax
+
+```dart
+TrinaCell(
+  value: initialValue,
+  onKeyPressed: (TrinaGridOnKeyEvent event) {
+    // Handle keyboard events
+  },
+)
+```
+
+### When to Use Keyboard Event Callbacks
+
+Keyboard event callbacks are ideal for:
+
+- Implementing custom navigation patterns (e.g., Shift+Enter to move up)
+- Creating keyboard shortcuts for specific cells
+- Validating input as users type
+- Triggering actions based on special keys (Enter, Escape, Tab)
+- Implementing auto-completion or suggestion features
+- Handling modifier key combinations (Ctrl+Enter, Shift+Tab, etc.)
+
+### The TrinaGridOnKeyEvent Object
+
+The `onKeyPressed` callback receives a `TrinaGridOnKeyEvent` object with the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `column` | `TrinaColumn` | The column where the key was pressed |
+| `row` | `TrinaRow` | The row where the key was pressed |
+| `rowIdx` | `int` | The index of the row |
+| `cell` | `TrinaCell` | The cell where the key was pressed |
+| `event` | `KeyEvent` | The raw Flutter KeyEvent |
+| `isEnter` | `bool` | Whether the Enter key was pressed |
+| `isEscape` | `bool` | Whether the Escape key was pressed |
+| `isTab` | `bool` | Whether the Tab key was pressed |
+| `isShiftPressed` | `bool` | Whether Shift is pressed |
+| `isCtrlPressed` | `bool` | Whether Ctrl/Cmd is pressed |
+| `isAltPressed` | `bool` | Whether Alt is pressed |
+| `logicalKey` | `LogicalKeyboardKey` | The logical key that was pressed |
+| `currentValue` | `String?` | The current text value in the cell (if editing) |
+
+### Example: Keyboard Event Handling
+
+```dart
+TrinaCell(
+  value: 'Press Enter to submit',
+  onKeyPressed: (event) {
+    // Handle Enter key
+    if (event.isEnter && !event.isShiftPressed) {
+      print('Enter pressed - submitting value: ${event.currentValue}');
+      // Perform submission logic
+    } 
+    // Handle Shift+Enter for new line (in multi-line cells)
+    else if (event.isEnter && event.isShiftPressed) {
+      print('Shift+Enter pressed - new line');
+      // Allow new line in multi-line cells
+    }
+    // Handle Tab navigation
+    else if (event.isTab) {
+      if (event.isShiftPressed) {
+        print('Shift+Tab - moving to previous cell');
+      } else {
+        print('Tab - moving to next cell');
+      }
+    }
+    // Handle Escape to cancel
+    else if (event.isEscape) {
+      print('Escape pressed - canceling edit');
+      // The grid will handle reverting the value
+    }
+    // Handle Ctrl+S for save
+    else if (event.isCtrlPressed && event.logicalKey.keyLabel == 'S') {
+      print('Ctrl+S pressed - saving data');
+      // Trigger save operation
+    }
+  },
+)
+```
+
+### Combined Value Change and Keyboard Event Handling
+
+You can use both `onChanged` and `onKeyPressed` callbacks together for comprehensive cell interaction handling:
+
+```dart
+TrinaCell(
+  value: 'Initial Value',
+  onChanged: (event) {
+    // Handle value changes
+    print('Value changed from ${event.oldValue} to ${event.value}');
+    saveToDatabase(event.value);
+  },
+  onKeyPressed: (event) {
+    // Handle keyboard events
+    if (event.isEnter && event.isCtrlPressed) {
+      // Ctrl+Enter to submit and move to next row
+      submitAndMoveToNextRow();
+    } else if (event.isEscape) {
+      // Escape to cancel (handled by grid)
+      showToast('Edit canceled');
+    }
+  },
+)
+```
+
+## Batch Cell Updates with updateRowCells
+
+When you need to update multiple cells in a single row (e.g., syncing with backend data), use `updateRowCells` instead of calling `changeCellValue` multiple times. It applies all changes and only triggers a single UI notification at the end.
+
+### Syntax
+
+```dart
+stateManager.updateRowCells(
+  row,
+  {
+    'name': 'Updated Name',
+    'age': 25,
+    'status': 'active',
+  },
+);
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `row` | `TrinaRow` | required | The row whose cells should be updated |
+| `values` | `Map<String, dynamic>` | required | Map of column field names to new values |
+| `callOnChangedEvent` | `bool` | `true` | Whether to trigger onChanged callbacks |
+| `force` | `bool` | `false` | Bypass read-only and editability checks |
+| `notify` | `bool` | `true` | Whether to notify listeners (trigger UI rebuild) |
+| `validate` | `bool` | `true` | Whether to validate values before setting |
+
+### Example: Syncing a Row with Backend Data
+
+```dart
+// Fetch updated data from API
+final updatedData = await api.getRecord(recordId);
+
+// Find the row to update
+final row = stateManager.rows.firstWhere(
+  (r) => r.cells['id']?.value == recordId,
+);
+
+// Update all cells in one call
+stateManager.updateRowCells(row, {
+  'name': updatedData['name'],
+  'email': updatedData['email'],
+  'status': updatedData['status'],
+});
+```
+
+Fields that don't exist in the row's cells are silently skipped. Cells that fail validation or are read-only are also skipped without affecting the other updates.
+
+## Best Practices
+
+1. **Use cell-level callbacks for cell-specific logic** and grid-level callbacks for application-wide concerns.
+
+2. **Keep callbacks lightweight** to ensure smooth performance, especially in large grids.
+
+3. **Consider the callback order**: cell-level callbacks are called before grid-level callbacks, so you can use this to your advantage in your application architecture.
+
+4. **Handle errors gracefully** in both callback types to prevent UI freezes.
+
+5. **Use the appropriate callback type** based on your needs:
+   - For isolated cell behavior: use cell-level callbacks
+   - For centralized data management: use grid-level callbacks
+   - For comprehensive solutions: use both
+
+## Complete Example
+
+Here's a complete example demonstrating value change and keyboard event handling:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class CellChangeHandlingExample extends StatefulWidget {
+  @override
+  _CellChangeHandlingExampleState createState() => _CellChangeHandlingExampleState();
+}
+
+class _CellChangeHandlingExampleState extends State<CellChangeHandlingExample> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+  
+  // Track changes and keyboard events for display
+  final List<String> changeLog = [];
+  
+  @override
+  void initState() {
+    super.initState();
+    
+    // Define columns
+    columns = [
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Age',
+        field: 'age',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Notes',
+        field: 'notes',
+        type: TrinaColumnType.text(),
+      ),
+    ];
+    
+    // Create rows with cell-level callbacks
+    rows = [
+      TrinaRow(
+        cells: {
+          'name': TrinaCell(
+            value: 'John',
+            onChanged: (event) {
+              // Cell-level handling
+              _logChange('CELL-LEVEL: Name changed to ${event.value}');
+              
+              // Cell-specific validation
+              if (event.value.toString().length < 2) {
+                _logChange('VALIDATION: Name too short!');
+              }
+            },
+            onKeyPressed: (event) {
+              // Handle keyboard events for name field
+              if (event.isEnter && event.isCtrlPressed) {
+                _logChange('KEYBOARD: Ctrl+Enter pressed in Name field');
+                // Could trigger form submission here
+              } else if (event.isTab) {
+                _logChange('KEYBOARD: Tab pressed, moving to next field');
+              }
+            },
+          ),
+          'age': TrinaCell(
+            value: 30,
+            onChanged: (event) {
+              // Cell-level handling
+              _logChange('CELL-LEVEL: Age changed to ${event.value}');
+              
+              // Cell-specific validation
+              if (event.value < 18) {
+                _logChange('VALIDATION: Must be 18 or older!');
+              }
+            },
+            onKeyPressed: (event) {
+              // Handle keyboard events for age field
+              if (event.isEnter) {
+                _logChange('KEYBOARD: Enter pressed in Age field');
+              }
+            },
+          ),
+          'notes': TrinaCell(
+            value: 'Press Shift+Enter for special action',
+            onKeyPressed: (event) {
+              // Demonstrate various keyboard interactions
+              if (event.isEnter && event.isShiftPressed) {
+                _logChange('KEYBOARD: Shift+Enter - Special action triggered!');
+                // Could insert line break or perform special action
+              } else if (event.isEscape) {
+                _logChange('KEYBOARD: Escape pressed - Edit canceled');
+              } else if (event.isCtrlPressed && event.logicalKey.keyLabel == 'S') {
+                _logChange('KEYBOARD: Ctrl+S - Save triggered');
+                // Could trigger save operation
+              }
+            },
+          ),
+        },
+      ),
+      // Add more rows as needed
+    ];
+  }
+  
+  void _logChange(String message) {
+    setState(() {
+      changeLog.add(message);
+      // Keep log size manageable
+      if (changeLog.length > 10) changeLog.removeAt(0);
+    });
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Cell Change & Keyboard Event Handling')),
+      body: Column(
+        children: [
+          Expanded(
+            flex: 2,
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (event) {
+                stateManager = event.stateManager;
+              },
+              onChanged: (event) {
+                // Grid-level handling for all cells
+                _logChange('GRID-LEVEL: ${event.column.field} changed to ${event.value}');
+              },
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Container(
+              padding: EdgeInsets.all(16),
+              color: Colors.grey[200],
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Change Log:', style: TextStyle(fontWeight: FontWeight.bold)),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: changeLog.length,
+                      itemBuilder: (context, index) {
+                        return Text(changeLog[changeLog.length - 1 - index]);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+This example demonstrates how to use cell-level callbacks for both value changes and keyboard events, along with grid-level callbacks to handle changes in a TrinaGrid, with a visual log showing the sequence of events and keyboard interactions.
+
+
+---
+
+## Pagination in Trina Grid
+
+Trina Grid offers multiple pagination options to efficiently handle datasets of various sizes. This document provides an overview of the available pagination features and helps you choose the right approach for your application.
+
+## Pagination Types
+
+Trina Grid supports three main types of pagination:
+
+1. **[Client-Side Pagination](pagination-client.md)** - For smaller datasets that can be loaded entirely into memory
+2. **[Lazy Pagination (Server-Side)](lazy-pagination.md)** - For large datasets where data is fetched from the server page by page
+3. **[Infinity Scroll](infinity-scroll.md)** - For continuous scrolling with on-demand data loading
+
+## Choosing the Right Pagination Type
+
+| Pagination Type | Best For | Key Benefits | Limitations |
+|----------------|----------|-------------|------------|
+| **Client-Side** | Small to medium datasets (<1000 rows) | Simple implementation, instant page changes, full client-side sorting and filtering | Requires loading all data upfront, higher memory usage |
+| **Lazy (Server-Side)** | Large datasets, server APIs with pagination support | Minimal memory usage, handles millions of records, server-side sorting and filtering | Requires server-side implementation, page changes require network requests |
+| **Infinity Scroll** | Continuous data streams, social media-like feeds | Seamless user experience, progressive loading | More complex to implement with sorting and filtering |
+
+## Pagination Features
+
+All pagination types in Trina Grid include these built-in features:
+
+### Total Rows Display
+
+Shows the total number of pages and records in the footer. Enabled by default.
+
+**Format:** `/ TotalPages [TotalRecords]`
+
+Example: `/ 50 [5000]` means 50 pages with 5000 total records.
+
+### Go to Page
+
+Allows users to jump directly to a specific page via a search icon button. Enabled by default.
+
+**How to use:**
+1. Click the search icon in the pagination footer
+2. Enter the desired page number
+3. Press Enter or click "Go"
+
+### Configuration
+
+Control these features globally via `TrinaGridConfiguration`:
+
+```dart
+TrinaGrid(
+  configuration: TrinaGridConfiguration(
+    paginationShowTotalRows: true,    // Show total rows (default: true)
+    paginationEnableGotoPage: true,   // Enable goto page (default: true)
+  ),
+  // ...
+)
+```
+
+Or override per pagination widget:
+
+```dart
+TrinaPagination(
+  stateManager,
+  showTotalRows: false,      // Override config setting
+  enableGotoPage: false,     // Override config setting
+)
+```
+
+## Implementation Overview
+
+### Client-Side Pagination
+
+```dart
+TrinaGrid(
+  // Grid configuration
+  createFooter: (stateManager) {
+    return TrinaPagination(stateManager);
+  },
+)
+```
+
+[Learn more about Client-Side Pagination](pagination-client.md)
+
+### Lazy Pagination (Server-Side)
+
+```dart
+TrinaGrid(
+  // Grid configuration
+  createFooter: (stateManager) {
+    return TrinaLazyPagination(
+      fetch: fetch,  // Your data fetching function
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+[Learn more about Lazy Pagination](lazy-pagination.md)
+
+### Infinity Scroll
+
+```dart
+TrinaGrid(
+  // Grid configuration
+  createFooter: (stateManager) {
+    return TrinaInfinityScrollRows(
+      fetch: fetch,  // Your data fetching function
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+[Learn more about Infinity Scroll](infinity-scroll.md)
+
+## Best Practices
+
+1. **Choose the right pagination type** based on your dataset size and requirements
+2. **Set appropriate page sizes** - typically 10-50 rows per page depending on row complexity
+3. **Consider user experience** - show loading indicators, total record counts, and clear navigation
+4. **Test with realistic data volumes** to ensure performance meets expectations
+5. **Combine with other features** like sorting and filtering for a complete data management solution
+
+## Related Features
+
+- [Column Sorting](column-sorting.md)
+- [Column Filtering](column-filtering.md)
+- [Export](export.md)
+
+
+---
+
+## Client-Side Pagination in Trina Grid
+
+Client-side pagination is suitable for smaller datasets that can be loaded entirely into memory. It handles pagination logic on the client side without requiring server requests for each page change.
+
+## Overview
+
+Client-side pagination in TrinaGrid:
+
+- Handles all pagination logic locally
+- Suitable for datasets that fit in memory
+- Provides smooth user experience with instant page changes
+- Maintains sorting and filtering capabilities on the full dataset
+
+## Basic Implementation
+
+To add client-side pagination to your grid, simply add the `TrinaPagination` widget to your grid's footer:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  createFooter: (stateManager) {
+    return TrinaPagination(
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+## Configuration Options
+
+The `TrinaPagination` widget supports several configuration options:
+
+```dart
+TrinaPagination(
+  stateManager: stateManager,
+  // Number of pages to move with prev/next buttons
+  // Default: null (moves by visible page count)
+  pageSizeToMove: 1,
+)
+```
+
+## Page Size Configuration
+
+You can configure the default page size and change it programmatically:
+
+```dart
+// Set default page size in state manager
+stateManager.setPageSize(20);
+
+// Get current page size
+int currentPageSize = stateManager.pageSize;
+
+// Get total number of pages
+int totalPages = stateManager.totalPage;
+```
+
+## Navigation Methods
+
+The state manager provides several methods for programmatic page navigation:
+
+```dart
+// Move to a specific page
+stateManager.setPage(pageNumber);
+
+// Reset to first page
+stateManager.resetPage();
+
+// Get current page number
+int currentPage = stateManager.page;
+
+// Get page range
+int rangeFrom = stateManager.pageRangeFrom;
+int rangeTo = stateManager.pageRangeTo;
+```
+
+## Working with Row Groups
+
+Client-side pagination works seamlessly with row grouping:
+
+```dart
+// Check if pagination is active
+bool isPaginated = stateManager.isPaginated;
+
+// Get paginated rows with groups
+if (stateManager.enabledRowGroups) {
+  // Pagination will respect group structure
+  // and keep parent-child relationships intact
+}
+```
+
+## Complete Example
+
+Here's a complete example demonstrating client-side pagination:
+
+```dart
+class MyDataGrid extends StatefulWidget {
+  @override
+  _MyDataGridState createState() => _MyDataGridState();
+}
+
+class _MyDataGridState extends State<MyDataGrid> {
+  late TrinaGridStateManager stateManager;
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize your columns and rows here
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+    ]);
+
+    // Add sample data
+    rows.addAll([
+      TrinaRow(cells: {
+        'id': TrinaCell(value: '1'),
+        'name': TrinaCell(value: 'John Doe'),
+      }),
+      // ... more rows
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      columns: columns,
+      rows: rows,
+      onLoaded: (event) {
+        stateManager = event.stateManager;
+        // Configure initial page size
+        stateManager.setPageSize(10);
+      },
+      createFooter: (stateManager) => TrinaPagination(
+        stateManager: stateManager,
+        pageSizeToMove: 1,
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+1. **Dataset Size**
+   - Use client-side pagination for smaller datasets (typically < 1000 rows)
+   - Consider lazy pagination for larger datasets
+
+2. **Page Size**
+   - Choose a reasonable page size based on your UI and data
+   - Consider screen size and data complexity
+   - Typical values range from 10-50 rows per page
+
+3. **Performance**
+   - Monitor memory usage with large datasets
+   - Consider implementing virtualization for better performance
+   - Test pagination with sorting and filtering enabled
+
+4. **User Experience**
+   - Provide clear pagination controls
+   - Show total record count when available
+   - Maintain consistent page sizes across sessions
+
+## Related Features
+
+- For server-side pagination, see [Lazy Pagination](lazy-pagination.md)
+- For infinite scrolling, see [Infinity Scroll](infinity-scroll.md)
+
+
+---
+
+## Lazy Pagination in Trina Grid
+
+Lazy pagination (or server-side pagination) is designed for handling large datasets where loading all data at once would be inefficient. Instead of loading the entire dataset, it fetches only the data needed for the current page from the server.
+
+## Key Benefits
+
+- Reduces memory usage by loading only necessary data
+- Improves initial load time and performance
+- Efficiently handles very large datasets
+- Allows server-side processing of sorting and filtering
+
+## Implementation
+
+To implement lazy pagination, you need to:
+
+1. Create a fetch function that handles data retrieval from the server
+2. Add the `TrinaLazyPagination` widget to your grid's footer
+
+```dart
+createFooter: (stateManager) {
+  return TrinaLazyPagination(
+    fetch: fetch,
+    stateManager: stateManager,
+  );
+},
+```
+
+The fetch function should implement the `TrinaLazyPaginationFetch` type:
+
+```dart
+Future<TrinaLazyPaginationResponse> fetch(
+  TrinaLazyPaginationRequest request,
+) async {
+  // Fetch data from server based on request parameters
+  // ...
+
+  return TrinaLazyPaginationResponse(
+    totalPage: totalPages,
+    rows: fetchedRows,
+    totalRecords: totalRecordCount,
+  );
+}
+```
+
+## Configuration Options
+
+`TrinaLazyPagination` provides several configuration options:
+
+```dart
+TrinaLazyPagination(
+  // Set the initial page (default: 1)
+  initialPage: 1,
+  
+  // Set the initial page size (default: 10)
+  initialPageSize: 10,
+  
+  // Whether to fetch data on initialization (default: true)
+  initialFetch: true,
+  
+  // Whether sorting should trigger server-side fetching (default: true)
+  fetchWithSorting: true,
+  
+  // Whether filtering should trigger server-side fetching (default: true)
+  fetchWithFiltering: true,
+  
+  // Number of pages to move with prev/next buttons (default: null - moves by visible page count)
+  pageSizeToMove: null,
+  
+  // Required fetch function
+  fetch: fetch,
+  
+  // Required state manager
+  stateManager: stateManager,
+);
+```
+
+## Handling Sorting and Filtering
+
+The `TrinaLazyPaginationRequest` provides information about the current sorting and filtering state:
+
+```dart
+// Sorting
+if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+  // Apply server-side sorting based on sortColumn
+}
+
+// Filtering
+if (request.filterRows.isNotEmpty) {
+  // Apply server-side filtering based on filterRows
+  // You can convert filterRows to a more usable format:
+  final filterMap = FilterHelper.convertRowsToMap(request.filterRows);
+  // or
+  final filter = FilterHelper.convertRowsToFilter(
+    request.filterRows,
+    stateManager.refColumns,
+  );
+}
+```
+
+When sorting or filtering changes, the pagination automatically resets to page 1 to ensure data consistency.
+
+## Page Size Selection
+
+Lazy pagination supports a page size selector dropdown:
+
+```dart
+TrinaLazyPagination(
+  // Enable page size selector dropdown
+  showPageSizeSelector: true,
+  
+  // Available page size options
+  pageSizes: [10, 20, 30, 50, 100],
+  
+  // Callback when page size changes
+  onPageSizeChanged: (pageSize) {
+    print('Page size changed to: $pageSize');
+  },
+  
+  // Optional styling for dropdown
+  dropdownDecoration: BoxDecoration(...),
+  dropdownItemDecoration: BoxDecoration(...),
+  pageSizeDropdownIcon: Icon(...),
+  
+  // Other required parameters
+  fetch: fetch,
+  stateManager: stateManager,
+);
+```
+
+## Custom Pagination UI
+
+You can provide a custom UI for the pagination footer by using the `builder` property. This allows you to create a completely custom layout and set of controls for pagination.
+
+The `builder` function provides the `TrinaLazyPaginationState`, which gives you access to the current pagination status and methods to control it.
+
+### `TrinaLazyPaginationState` Properties and Methods
+
+- `page`: The current page number.
+- `pageSize`: The number of items per page.
+- `totalPage`: The total number of pages.
+- `totalRecords`: The total number of records in the dataset.
+- `isFirstPage`: Whether the current page is the first page.
+- `isLastPage`: Whether the current page is the last page.
+- `setPage(int page)`: Navigates to a specific page.
+- `nextPage()`: Navigates to the next page.
+- `previousPage()`: Navigates to the previous page.
+- `firstPage()`: Navigates to the first page.
+- `lastPage()`: Navigates to the last page.
+- `setPageSize(int size)`: Changes the page size and re-fetches data.
+- `refresh()`: Re-fetches the data for the current page.
+
+### Example
+
+```dart
+createFooter: (stateManager) {
+  return TrinaLazyPagination(
+    fetch: fetch,
+    stateManager: stateManager,
+    builder: (context, state) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.first_page),
+              onPressed: state.isFirstPage ? null : state.firstPage,
+            ),
+            IconButton(
+              icon: const Icon(Icons.navigate_before),
+              onPressed: state.isFirstPage ? null : state.previousPage,
+            ),
+            Text('Page ${state.page} of ${state.totalPage}'),
+            IconButton(
+              icon: const Icon(Icons.navigate_next),
+              onPressed: state.isLastPage ? null : state.nextPage,
+            ),
+            IconButton(
+              icon: const Icon(Icons.last_page),
+              onPressed: state.isLastPage ? null : state.lastPage,
+            ),
+            const Spacer(),
+            if (state.totalRecords != null)
+              Text('Total records: ${state.totalRecords}'),
+          ],
+        ),
+      );
+    },
+  );
+},
+```
+
+## Complete Example
+
+Here's a complete example demonstrating lazy pagination:
+
+```dart
+class MyDataGrid extends StatefulWidget {
+  @override
+  _MyDataGridState createState() => _MyDataGridState();
+}
+
+class _MyDataGridState extends State<MyDataGrid> {
+  late TrinaGridStateManager stateManager;
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+
+  Future<TrinaLazyPaginationResponse> fetch(TrinaLazyPaginationRequest request) async {
+    // Simulate API call
+    final response = await myApi.fetchData(
+      page: request.page,
+      pageSize: request.pageSize,
+      sortColumn: request.sortColumn,
+      filterRows: request.filterRows,
+    );
+
+    return TrinaLazyPaginationResponse(
+      totalPage: response.totalPages,
+      rows: response.rows,
+      totalRecords: response.totalCount,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaGrid(
+      columns: columns,
+      rows: rows,
+      onLoaded: (event) => stateManager = event.stateManager,
+      createFooter: (stateManager) => TrinaLazyPagination(
+        initialPage: 1,
+        initialPageSize: 20,
+        showPageSizeSelector: true,
+        pageSizes: [10, 20, 50, 100],
+        fetch: fetch,
+        stateManager: stateManager,
+      ),
+    );
+  }
+}
+```
+
+## Related Features
+
+- For tracking lazy pagination events, see [Lazy Pagination Events](lazy-pagination-events.md)
+- For programmatically changing pages with events, see [Lazy Pagination Events - Programmatically Changing Pages](lazy-pagination-events.md#programmatically-changing-pages-with-events)
+- For client-side pagination, see [Client-Side Pagination](pagination-client.md)
+- For infinite scrolling, see [Infinity Scroll](infinity-scroll.md)
+
+---
+
+## Infinite Scrolling
+
+Infinite scrolling is a feature in TrinaGrid that allows you to load data dynamically as the user scrolls through the grid. This approach is particularly useful for handling large datasets efficiently, as it loads only the data that is currently needed, reducing initial load time and memory usage.
+
+## Overview
+
+The infinite scrolling feature in TrinaGrid is implemented through the `TrinaInfinityScrollRows` widget, which can be added to the grid's footer. This widget monitors the scroll position and triggers data loading when the user reaches the end of the currently loaded data.
+
+Key benefits of infinite scrolling:
+
+- **Improved Performance**: Only loads the data that's needed, reducing memory usage and initial load time
+- **Better User Experience**: Provides a seamless scrolling experience without pagination controls
+- **Server-Side Processing**: Supports server-side sorting and filtering
+- **Keyboard Navigation**: Loads more data when navigating with arrow keys or Page Down
+
+## Implementation
+
+### Basic Setup
+
+To implement infinite scrolling in your TrinaGrid, you need to:
+
+1. Create a fetch callback function that returns a `TrinaInfinityScrollRowsResponse`
+2. Add the `TrinaInfinityScrollRows` widget to the grid's footer
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,  // Can be initially empty
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    stateManager = event.stateManager;
+  },
+  createFooter: (s) => TrinaInfinityScrollRows(
+    initialFetch: true,
+    fetchWithSorting: true,
+    fetchWithFiltering: true,
+    fetch: fetch,
+    stateManager: s,
+  ),
+)
+```
+
+### Fetch Callback
+
+The fetch callback is responsible for loading data when needed. It receives a `TrinaInfinityScrollRowsRequest` and should return a `TrinaInfinityScrollRowsResponse`.
+
+```dart
+Future<TrinaInfinityScrollRowsResponse> fetch(
+  TrinaInfinityScrollRowsRequest request,
+) async {
+  // Fetch data from your data source
+  List<TrinaRow> fetchedRows = await yourDataFetchingLogic(request);
+  
+  // Determine if this is the last batch of data
+  bool isLast = noMoreDataAvailable;
+  
+  return TrinaInfinityScrollRowsResponse(
+    isLast: isLast,
+    rows: fetchedRows,
+  );
+}
+```
+
+### Request Parameters
+
+The `TrinaInfinityScrollRowsRequest` provides information about what data to fetch:
+
+- `lastRow`: The last row currently displayed in the grid (null for initial fetch)
+- `sortColumn`: The column being sorted (if any)
+- `filterRows`: The current filter conditions (if any)
+
+### Response Parameters
+
+The `TrinaInfinityScrollRowsResponse` requires:
+
+- `isLast`: Set to true when there is no more data to load
+- `rows`: The list of rows to be added to the grid
+
+## Configuration Options
+
+The `TrinaInfinityScrollRows` widget accepts several configuration options:
+
+- `initialFetch` (default: true): Whether to fetch data when the grid is first loaded
+- `fetchWithSorting` (default: true): Whether sorting should be handled by the fetch callback
+- `fetchWithFiltering` (default: true): Whether filtering should be handled by the fetch callback
+- `fetch`: The callback function to fetch data
+- `stateManager`: The TrinaGrid state manager
+
+## Handling Sorting and Filtering
+
+When `fetchWithSorting` or `fetchWithFiltering` is set to true, the grid will call the fetch function with the appropriate parameters when the user changes the sort or filter settings.
+
+### Sorting
+
+When sorting is enabled, the `sortColumn` parameter in the request will contain information about which column is being sorted and in what direction.
+
+```dart
+if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+  // Apply sorting logic based on request.sortColumn
+}
+```
+
+### Filtering
+
+When filtering is enabled, the `filterRows` parameter in the request will contain the filter conditions.
+
+```dart
+if (request.filterRows.isNotEmpty) {
+  // Apply filtering logic based on request.filterRows
+  // You can use FilterHelper to convert the filter rows to a more usable format
+  final filter = FilterHelper.convertRowsToFilter(
+    request.filterRows,
+    stateManager.refColumns,
+  );
+}
+```
+
+## Events That Trigger Data Loading
+
+Data loading is triggered in the following scenarios:
+
+1. When the grid is first loaded (if `initialFetch` is true)
+2. When the user scrolls to the bottom of the grid
+3. When the user tries to navigate beyond the last row using arrow keys
+4. When the user changes the sort settings (if `fetchWithSorting` is true)
+5. When the user changes the filter settings (if `fetchWithFiltering` is true)
+
+## Example Implementation
+
+Here's a complete example of implementing infinite scrolling with TrinaGrid:
+
+```dart
+class MyGridScreen extends StatefulWidget {
+  @override
+  _MyGridScreenState createState() => _MyGridScreenState();
+}
+
+class _MyGridScreenState extends State<MyGridScreen> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+  
+  @override
+  void initState() {
+    super.initState();
+    
+    // Define your columns
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      // Add more columns as needed
+    ];
+    
+    // Start with an empty list of rows
+    rows = [];
+  }
+  
+  Future<TrinaInfinityScrollRowsResponse> fetch(
+    TrinaInfinityScrollRowsRequest request,
+  ) async {
+    // Get the last ID to determine what data to fetch next
+    final lastId = request.lastRow?.cells['id']?.value as int? ?? 0;
+    
+    // Apply sorting if needed
+    String? sortField;
+    bool? sortAscending;
+    
+    if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+      sortField = request.sortColumn!.field;
+      sortAscending = request.sortColumn!.sort.isAscending;
+    }
+    
+    // Apply filtering if needed
+    Map<String, dynamic>? filters;
+    
+    if (request.filterRows.isNotEmpty) {
+      filters = FilterHelper.convertRowsToMap(request.filterRows);
+    }
+    
+    // Fetch data from your API
+    final response = await yourApiService.fetchData(
+      lastId: lastId,
+      pageSize: 30,
+      sortField: sortField,
+      sortAscending: sortAscending,
+      filters: filters,
+    );
+    
+    // Convert API response to TrinaRows
+    final fetchedRows = response.items.map((item) => TrinaRow(
+      cells: {
+        'id': TrinaCell(value: item.id),
+        'name': TrinaCell(value: item.name),
+        // Add more cells as needed
+      },
+    )).toList();
+    
+    return TrinaInfinityScrollRowsResponse(
+      isLast: response.isLastPage,
+      rows: fetchedRows,
+    );
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Infinite Scrolling Grid')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          stateManager = event.stateManager;
+          stateManager.setShowColumnFilter(true);
+        },
+        createFooter: (s) => TrinaInfinityScrollRows(
+          initialFetch: true,
+          fetchWithSorting: true,
+          fetchWithFiltering: true,
+          fetch: fetch,
+          stateManager: s,
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Demo
+
+You can find a complete working example of infinite scrolling in the TrinaGrid demo project under `demo/lib/screen/feature/row_infinity_scroll_screen.dart`. The demo shows how to implement infinite scrolling with sorting and filtering support.
+
+## Related Features
+
+- [Lazy Pagination](lazy-pagination.md) - For page-based loading with lazy loading
+- [Client Pagination](pagination-client.md) - For client-side pagination
+
+
+---
+
+## Lazy Loading
+
+Lazy loading is a performance optimization technique in TrinaGrid that allows you to load data on demand rather than all at once. This approach is particularly useful when dealing with large datasets, as it significantly reduces initial load time and memory usage by only loading the data that is currently needed.
+
+## Overview
+
+TrinaGrid provides a robust lazy loading implementation through the `TrinaLazyPagination` component. This component enables you to fetch and display data in paginated chunks, with built-in support for:
+
+- Server-side pagination
+- Server-side sorting
+- Server-side filtering
+- Customizable page sizes
+- Pagination controls
+
+## Benefits of Lazy Loading
+
+- **Improved Performance**: Reduces initial load time and memory usage by loading only the data that is needed
+- **Better User Experience**: Provides responsive UI even with large datasets
+- **Reduced Network Traffic**: Only transfers the data that is actually being viewed
+- **Server-Side Processing**: Offloads data processing to the server, reducing client-side computation
+
+## Implementation
+
+### Basic Setup
+
+To implement lazy loading with pagination in your TrinaGrid, you need to:
+
+1. Create a fetch callback function that returns a `TrinaLazyPaginationResponse`
+2. Add the `TrinaLazyPagination` widget to the grid's footer
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: [], // Start with empty rows
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    stateManager = event.stateManager;
+  },
+  createFooter: (s) => TrinaLazyPagination(
+    initialPage: 1,
+    initialFetch: true,
+    fetchWithSorting: true,
+    fetchWithFiltering: true,
+    fetch: fetch,
+    stateManager: s,
+  ),
+)
+```
+
+### Fetch Callback
+
+The fetch callback is responsible for loading data when needed. It receives a `TrinaLazyPaginationRequest` and should return a `TrinaLazyPaginationResponse`.
+
+```dart
+Future<TrinaLazyPaginationResponse> fetch(
+  TrinaLazyPaginationRequest request,
+) async {
+  // Calculate pagination parameters
+  final page = request.page;
+  final pageSize = request.pageSize;
+  
+  // Apply sorting if needed
+  if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+    // Apply sorting logic based on request.sortColumn
+  }
+  
+  // Apply filtering if needed
+  if (request.filterRows.isNotEmpty) {
+    // Apply filtering logic based on request.filterRows
+  }
+  
+  // Fetch data from your data source for the current page
+  final fetchedRows = await yourDataService.fetchPage(
+    page: page,
+    pageSize: pageSize,
+    sortColumn: request.sortColumn,
+    filterRows: request.filterRows,
+  );
+  
+  return TrinaLazyPaginationResponse(
+    totalPage: totalPageCount,
+    rows: fetchedRows,
+    totalRecords: totalRecordCount, // Optional
+  );
+}
+```
+
+### Request Parameters
+
+The `TrinaLazyPaginationRequest` provides information about what data to fetch:
+
+- `page`: The page number to fetch (starting from 1)
+- `pageSize`: The number of items per page
+- `sortColumn`: The column being sorted (if any)
+- `filterRows`: The current filter conditions (if any)
+
+### Response Parameters
+
+The `TrinaLazyPaginationResponse` requires:
+
+- `totalPage`: The total number of pages available
+- `rows`: The list of rows for the current page
+- `totalRecords`: (Optional) The total number of records across all pages
+
+## Configuration Options
+
+The `TrinaLazyPagination` widget accepts several configuration options:
+
+- `initialPage` (default: 1): The page to load initially
+- `initialPageSize` (default: 10): The number of items per page
+- `initialFetch` (default: true): Whether to fetch data when the grid is first loaded
+- `fetchWithSorting` (default: true): Whether sorting should be handled by the fetch callback
+- `fetchWithFiltering` (default: true): Whether filtering should be handled by the fetch callback
+- `pageSizeToMove`: How many pages to move when clicking the previous/next buttons
+- `showPageSizeSelector` (default: false): Whether to show a dropdown to change page size
+- `pageSizes` (default: [10, 20, 30, 50, 100]): Available page size options in the dropdown
+- `fetch`: The callback function to fetch data
+- `stateManager`: The TrinaGrid state manager
+
+## Handling Sorting and Filtering
+
+When `fetchWithSorting` or `fetchWithFiltering` is set to true, the grid will call the fetch function with the appropriate parameters when the user changes the sort or filter settings.
+
+### Sorting
+
+When sorting is enabled, the `sortColumn` parameter in the request will contain information about which column is being sorted and in what direction.
+
+```dart
+if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+  // Get sort direction
+  final isAscending = request.sortColumn!.sort.isAscending;
+  
+  // Get sort field
+  final sortField = request.sortColumn!.field;
+  
+  // Apply sorting logic
+  // ...
+}
+```
+
+### Filtering
+
+When filtering is enabled, the `filterRows` parameter in the request will contain the filter conditions.
+
+```dart
+if (request.filterRows.isNotEmpty) {
+  // Convert filter rows to a more usable format
+  final filterMap = FilterHelper.convertRowsToMap(request.filterRows);
+  
+  // Or create a filter function
+  final filter = FilterHelper.convertRowsToFilter(
+    request.filterRows,
+    stateManager.refColumns,
+  );
+  
+  // Apply filtering logic
+  // ...
+}
+```
+
+## Page Size Selection
+
+You can enable a page size selector dropdown by setting `showPageSizeSelector` to true:
+
+```dart
+TrinaLazyPagination(
+  // ... other parameters
+  showPageSizeSelector: true,
+  pageSizes: [10, 25, 50, 100],
+  onPageSizeChanged: (newPageSize) {
+    // Optional callback when page size changes
+    print('Page size changed to $newPageSize');
+  },
+  // ... other parameters
+)
+```
+
+## Complete Example
+
+Here's a complete example of implementing lazy loading with pagination in TrinaGrid:
+
+```dart
+class MyGridScreen extends StatefulWidget {
+  @override
+  _MyGridScreenState createState() => _MyGridScreenState();
+}
+
+class _MyGridScreenState extends State<MyGridScreen> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+  
+  @override
+  void initState() {
+    super.initState();
+    
+    // Define your columns
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      // Add more columns as needed
+    ];
+    
+    // Start with an empty list of rows
+    rows = [];
+  }
+  
+  Future<TrinaLazyPaginationResponse> fetch(
+    TrinaLazyPaginationRequest request,
+  ) async {
+    // In a real application, you would fetch data from an API
+    // This is a simplified example
+    
+    // Apply sorting if needed
+    String? sortField;
+    bool? sortAscending;
+    
+    if (request.sortColumn != null && !request.sortColumn!.sort.isNone) {
+      sortField = request.sortColumn!.field;
+      sortAscending = request.sortColumn!.sort.isAscending;
+    }
+    
+    // Apply filtering if needed
+    Map<String, dynamic>? filters;
+    
+    if (request.filterRows.isNotEmpty) {
+      filters = FilterHelper.convertRowsToMap(request.filterRows);
+    }
+    
+    // Fetch data from your API
+    final response = await yourApiService.fetchPaginatedData(
+      page: request.page,
+      pageSize: request.pageSize,
+      sortField: sortField,
+      sortAscending: sortAscending,
+      filters: filters,
+    );
+    
+    // Convert API response to TrinaRows
+    final fetchedRows = response.items.map((item) => TrinaRow(
+      cells: {
+        'id': TrinaCell(value: item.id),
+        'name': TrinaCell(value: item.name),
+        // Add more cells as needed
+      },
+    )).toList();
+    
+    return TrinaLazyPaginationResponse(
+      totalPage: response.totalPages,
+      rows: fetchedRows,
+      totalRecords: response.totalRecords,
+    );
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Lazy Loading Grid')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          stateManager = event.stateManager;
+          stateManager.setShowColumnFilter(true);
+        },
+        createFooter: (s) => TrinaLazyPagination(
+          initialPage: 1,
+          initialPageSize: 25,
+          initialFetch: true,
+          fetchWithSorting: true,
+          fetchWithFiltering: true,
+          showPageSizeSelector: true,
+          pageSizes: [10, 25, 50, 100],
+          fetch: fetch,
+          stateManager: s,
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Demo
+
+You can find a complete working example of lazy loading with pagination in the TrinaGrid demo project under `demo/lib/screen/feature/row_lazy_pagination_screen.dart`. The demo shows how to implement lazy loading with sorting and filtering support.
+
+## Related Features
+
+- [Infinite Scrolling](infinite-scrolling.md) - For continuous scrolling with on-demand data loading
+- [Client-Side Pagination](pagination-client.md) - For client-side pagination
+- [Pagination Overview](pagination.md) - For a general overview of pagination options
+
+
+---
+
+## Copy & Paste
+
+TrinaGrid provides a robust copy and paste functionality that allows users to easily transfer data between cells within the grid or between the grid and external applications.
+
+## Overview
+
+The copy and paste feature in TrinaGrid enables users to:
+
+- Copy a single cell value
+- Copy a range of selected cells
+- Copy entire rows
+- Paste data into a single cell
+- Paste data into a range of cells
+- Paste data into selected rows
+
+This functionality is implemented through keyboard shortcuts and integrates with the system clipboard, allowing for seamless data transfer between TrinaGrid and other applications.
+
+## Benefits
+
+- **Improved Productivity**: Quickly duplicate or move data within the grid
+- **Data Transfer**: Easily move data between TrinaGrid and external applications like spreadsheets
+- **Bulk Editing**: Make changes to multiple cells at once by copying and pasting
+- **Data Formatting**: Maintain tabular structure when copying and pasting multiple cells
+
+## Implementation
+
+### Keyboard Shortcuts
+
+TrinaGrid uses standard keyboard shortcuts for copy and paste operations:
+
+- **Ctrl+C** (Cmd+C on macOS): Copy selected cells or rows
+- **Ctrl+V** (Cmd+V on macOS): Paste clipboard content into the grid
+
+### Copy Functionality
+
+The copy operation depends on what is currently selected in the grid:
+
+1. **Single Cell**: When a single cell is selected, its value is copied to the clipboard.
+2. **Cell Range**: When multiple cells are selected, their values are copied as a tab-separated, newline-delimited text.
+3. **Rows**: When rows are selected, all visible columns for those rows are copied as tab-separated, newline-delimited text.
+
+```dart
+// Example of how copy works internally
+Clipboard.setData(ClipboardData(text: stateManager.currentSelectingText));
+```
+
+### Paste Functionality
+
+The paste operation depends on the current selection and the clipboard content:
+
+1. **Single Cell**: When pasting into a single cell, if the clipboard contains a table of data, it will be pasted starting from the selected cell.
+2. **Cell Range**: When a range of cells is selected, the clipboard content will be pasted within that range, repeating if necessary.
+3. **Selected Rows**: When rows are selected, the clipboard content will be pasted into those rows across all columns.
+
+```dart
+// Example of how paste works internally
+Clipboard.getData('text/plain').then((value) {
+  if (value == null) {
+    return;
+  }
+  List<List<String>> textList = TrinaClipboardTransformation.stringToList(
+    value.text!,
+    cellSeparator: stateManager.configuration.copyPasteCellSeparator ?? '\t',
+    lineSeparator: stateManager.configuration.copyPasteLineSeparator ?? '\n',
+  );
+  stateManager.pasteCellValue(textList);
+});
+```
+
+## Clipboard Data Format
+
+When copying data from TrinaGrid, the data is formatted as follows:
+
+- **Cell Separator**: Cells in the same row are separated by tab characters (`\t`) by default
+- **Line Separator**: Rows are separated by platform-specific line endings by default:
+  - Windows: CRLF (`\r\n`)
+  - macOS/Linux: LF (`\n`)
+
+For example, a 2x2 selection on Windows would be formatted as:
+```
+value1\tvalue2\r\n
+value3\tvalue4
+```
+
+When pasting data into TrinaGrid, the same format is expected. TrinaGrid will parse the clipboard text and convert it into a two-dimensional array of values before applying it to the grid. The paste operation accepts both LF and CRLF line endings regardless of platform for maximum compatibility.
+
+## Paste Behavior
+
+When pasting data, TrinaGrid follows these rules:
+
+1. **Data Type Conversion**: Values are automatically converted to match the column's data type
+2. **Validation**: Cell-level validation is applied to pasted values
+3. **Events**: Cell change events are triggered for each modified cell
+4. **Row State**: Rows with modified cells are marked as updated
+5. **Repeating Pattern**: If the pasted data is smaller than the target range, it will be repeated to fill the range
+
+## Example Usage
+
+### Basic Copy and Paste
+
+1. Select a cell or range of cells using the mouse or keyboard
+2. Press Ctrl+C (Cmd+C on macOS) to copy the values
+3. Select the target cell or range where you want to paste
+4. Press Ctrl+V (Cmd+V on macOS) to paste the values
+
+### Copying from External Applications
+
+1. Copy data from an external application (e.g., Excel, Google Sheets)
+2. Select the target cell in TrinaGrid where you want to begin pasting
+3. Press Ctrl+V (Cmd+V on macOS) to paste the values
+
+### Copying to External Applications
+
+1. Select cells or rows in TrinaGrid
+2. Press Ctrl+C (Cmd+C on macOS) to copy the values
+3. Switch to the external application
+4. Paste the values using the application's paste command
+
+## Configuration
+
+The copy and paste functionality is enabled by default and does not require additional configuration. However, you can customize the behavior in several ways:
+
+### Custom Separators
+
+You can configure custom separators for copy and paste operations using `TrinaGridConfiguration`:
+
+```dart
+TrinaGrid(
+  configuration: TrinaGridConfiguration(
+    // Customize cell separator (default: tab character '\t')
+    copyPasteCellSeparator: ',',  // Use comma for CSV-compatible format
+
+    // Customize line separator (default: platform-specific)
+    // null = platform-specific (\r\n on Windows, \n on macOS/Linux)
+    copyPasteLineSeparator: '\n',  // Force LF on all platforms
+  ),
+  // Other properties...
+)
+```
+
+**Separator Options:**
+
+- `copyPasteCellSeparator`: Separator between cells in the same row
+  - Default: `null` (uses tab `\t`)
+  - Common alternatives: `,` for CSV, `;` for some locales
+
+- `copyPasteLineSeparator`: Separator between rows
+  - Default: `null` (uses platform-specific line endings)
+  - Common alternatives: `\n` for cross-platform consistency
+
+**Use Cases:**
+
+```dart
+// CSV format - comma-separated with LF line endings
+TrinaGridConfiguration(
+  copyPasteCellSeparator: ',',
+  copyPasteLineSeparator: '\n',
+)
+
+// Excel-compatible format with platform-specific line endings
+TrinaGridConfiguration(
+  copyPasteCellSeparator: '\t',
+  copyPasteLineSeparator: null,  // Platform-specific
+)
+
+// Custom format - pipe-separated
+TrinaGridConfiguration(
+  copyPasteCellSeparator: '|',
+  copyPasteLineSeparator: '\n',
+)
+```
+
+### Other Customization Options
+
+1. **Custom Cell Handling**: Implement custom `onChanged` handlers for cells to control how pasted values are processed
+2. **Keyboard Shortcuts**: Customize the keyboard shortcuts by overriding the default shortcut handlers
+
+```dart
+TrinaGrid(
+  // Other properties...
+  onLoaded: (TrinaGridOnLoadedEvent event) {
+    // Access the state manager
+    final stateManager = event.stateManager;
+
+    // Customize keyboard shortcuts if needed
+    stateManager.setShortcuts([
+      // Your custom shortcuts
+    ]);
+  },
+)
+```
+
+## Limitations
+
+- Editing mode: Copy and paste operations are disabled when a cell is in editing mode
+- Read-only cells: Values cannot be pasted into read-only cells
+- Complex widgets: When copying cells containing complex widgets, only their string representation will be copied
+
+## Related Features
+
+- [Cell Selection](cell-selection.md) - Learn how to select cells and rows
+- [Keyboard Navigation](keyboard-navigation.md) - Navigate the grid using keyboard shortcuts
+- [Cell Editing](cell-editing.md) - Edit cell values directly in the grid
+
+
+---
+
+## Trina Grid Export Services
+
+Trina Grid provides multiple export options to convert grid data into different formats for download, sharing, or further processing.
+
+![Export Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/export.gif)
+
+## Available Export Formats
+
+Currently, Trina Grid supports the following export formats:
+
+- **CSV** - For tabular data export to spreadsheet applications
+- **JSON** - For structured data export and API consumption
+- **PDF** - For printable documents with formatting
+
+## Using Export Services
+
+All export services implement the `TrinaGridExport` interface, providing a consistent API:
+
+```dart
+Future<dynamic> export({
+  required TrinaGridStateManager stateManager,
+  List<String>? columns,
+  bool includeHeaders = true,
+  bool ignoreFixedRows = false,
+  // Additional format-specific options may be available
+});
+```
+
+### Common Parameters
+
+- **stateManager**: Required. The grid's state manager containing data to be exported
+- **columns**: Optional. List of specific column titles to include (if null, exports all visible columns)
+- **includeHeaders**: Optional. Whether to include column headers in the export (default: true)
+- **ignoreFixedRows**: Optional. Whether to exclude frozen/fixed rows from the export (default: false)
+
+## CSV Export
+
+`TrinaGridExportCsv` exports grid data to comma-separated values format.
+
+```dart
+final csvExport = TrinaGridExportCsv();
+final String csvData = await csvExport.export(
+  stateManager: gridStateManager,
+  columns: ['Column A', 'Column B'], // Optional
+  includeHeaders: true, // Optional
+  ignoreFixedRows: false, // Optional
+  separator: ',', // Optional - Can be changed to ';', '\t', etc.
+);
+```
+
+The CSV export:
+
+- Properly escapes fields containing commas, quotes, or newlines
+- Returns a String containing the CSV data
+- Can optionally exclude frozen rows from export
+- Supports custom separators (default is comma, but can be semicolon, tab, etc.)
+
+## JSON Export
+
+`TrinaGridExportJson` exports grid data to JSON format.
+
+```dart
+final jsonExport = TrinaGridExportJson();
+final String jsonData = await jsonExport.export(
+  stateManager: gridStateManager,
+  columns: ['Column A', 'Column B'], // Optional
+  includeHeaders: true, // Optional
+  ignoreFixedRows: false, // Optional
+);
+```
+
+The JSON export:
+
+- Returns data as a string containing a JSON array
+- Each row is represented as a JSON object with field names as keys
+- If `includeHeaders` is true, the first object contains header information
+- Can optionally exclude frozen rows from export
+
+## PDF Export
+
+`TrinaGridExportPdf` exports grid data to PDF format for printing or sharing.
+
+```dart
+final pdfExport = TrinaGridExportPdf();
+final Uint8List pdfData = await pdfExport.export(
+  stateManager: gridStateManager,
+  columns: ['Column A', 'Column B'], // Optional
+  includeHeaders: true, // Optional
+  ignoreFixedRows: false, // Optional
+  title: 'Grid Export', // Optional
+  creator: 'Application Name', // Optional
+  pdfSettings: TrinaGridExportPdfSettings( // Optional - for styling
+    pageTheme: pw.PageTheme(
+      pageFormat: PdfPageFormat.a4.landscape, // Page orientation
+      theme: pw.ThemeData(...), // Theme for the PDF
+    ),
+    headerStyle: pw.TextStyle(...), // Header text style
+    headerDecoration: pw.BoxDecoration(...), // Header cell decoration
+    cellStyle: pw.TextStyle(...), // Cell text style
+    cellDecoration: (index, data, rowNum) => pw.BoxDecoration(...), // Cell decoration
+  ),
+);
+```
+
+The PDF export:
+
+- Returns a `Uint8List` containing the binary PDF data
+- Supports additional PDF-specific parameters:
+  - **title**: Optional. Title displayed in the PDF header
+  - **creator**: Optional. Creator metadata in the PDF
+  - **pdfSettings**: Optional. Advanced styling and layout options:
+    - **pageTheme**: Set page format (A4, Letter, etc.) and orientation (portrait/landscape)
+    - **headerStyle**: Customize the text style for header cells
+    - **headerDecoration**: Customize the background and borders for header cells
+    - **cellStyle**: Customize the text style for data cells
+    - **cellDecoration**: Customize the background and borders for data cells (function based on row/column)
+
+### PDF Styling Example
+
+Here's an example of customizing PDF export with custom colors and styling:
+
+```dart
+// Function to convert Flutter Color to PdfColor
+PdfColor flutterToPdfColor(Color color) {
+  return PdfColor.fromInt(color.toARGB32());
+}
+
+// Create a custom theme
+final themeData = pw.ThemeData(
+  tableHeader: pw.TextStyle(
+    color: flutterToPdfColor(Colors.white),
+  ),
+  defaultTextStyle: pw.TextStyle(
+    color: flutterToPdfColor(Colors.black),
+    fontSize: 12,
+  ),
+);
+
+// Export with custom styling
+final headerColor = Colors.blue;
+final textColor = Colors.black;
+final pdfLandscape = true;
+
+final pdfExport = TrinaGridExportPdf();
+final pdfData = await pdfExport.export(
+  stateManager: stateManager,
+  title: 'My Grid Export',
+  creator: 'Trina Grid Demo',
+  pdfSettings: TrinaGridExportPdfSettings(
+    pageTheme: pw.PageTheme(
+      pageFormat: pdfLandscape ? PdfPageFormat.a4.landscape : PdfPageFormat.a4,
+      theme: themeData,
+    ),
+    cellStyle: pw.TextStyle(
+      color: flutterToPdfColor(textColor),
+      fontSize: 12,
+    ),
+    cellDecoration: (index, data, rowNum) {
+      return pw.BoxDecoration(
+        border: pw.Border.all(
+          color: PdfColor.fromInt(0x000000),
+          width: 0.5,
+        ),
+      );
+    },
+    headerStyle: pw.TextStyle(
+      color: flutterToPdfColor(Colors.white),
+    ),
+    headerDecoration: pw.BoxDecoration(
+      color: flutterToPdfColor(headerColor),
+      border: pw.Border.all(
+        color: PdfColor.fromInt(0x000000),
+        width: 0.5,
+      ),
+    ),
+  ),
+);
+```
+
+## Example Usage
+
+```dart
+// Get the state manager from your grid
+final stateManager = myGrid.stateManager;
+
+// Export to CSV
+final csvExport = TrinaGridExportCsv();
+final String csvData = await csvExport.export(
+  stateManager: stateManager,
+  ignoreFixedRows: true, // Exclude frozen rows
+);
+
+// Export to JSON
+final jsonExport = TrinaGridExportJson();
+final String jsonData = await jsonExport.export(
+  stateManager: stateManager,
+  ignoreFixedRows: true, // Exclude frozen rows
+);
+
+// Export to PDF
+final pdfExport = TrinaGridExportPdf();
+final Uint8List pdfData = await pdfExport.export(
+  stateManager: stateManager,
+  title: 'My Grid Export',
+  ignoreFixedRows: true, // Exclude frozen rows
+);
+```
+
+## Saving Exported Files
+
+For mobile and desktop applications, use the `file_saver` package to save exported files:
+
+```dart
+import 'package:file_saver/file_saver.dart';
+
+// Save PDF file
+String? saveFilePath = await FileSaver.instance.saveFile(
+  name: 'grid-export',
+  bytes: pdfData, // Uint8List from PDF export
+  ext: 'pdf',
+  mimeType: MimeType.pdf,
+);
+
+// Save CSV file or JSON file
+await FileSaver.instance.saveFile(
+  name: 'grid-export',
+  bytes: Uint8List.fromList(csvData.codeUnits), // Convert String to Uint8List
+  ext: 'csv',
+  mimeType: MimeType.csv,
+);
+```
+
+## Column Selection for Export
+
+Trina Grid allows users to select specific columns for export. This is useful when you want to export only certain columns from your grid:
+
+```dart
+// Get selected columns from a UI selection mechanism
+final Map<String, bool> selectedColumns = {
+  'Column A': true,
+  'Column B': false,
+  'Column C': true,
+};
+
+// Extract selected column titles
+final List<String> columnsToExport = selectedColumns.entries
+    .where((entry) => entry.value)
+    .map((entry) => entry.key)
+    .toList();
+
+// Use selected columns in export
+final exportData = await csvExport.export(
+  stateManager: stateManager,
+  columns: columnsToExport,
+);
+```
+
+This approach allows for flexible export options that can be easily integrated with UI components like checkboxes or selection dialogs.
+
+
+---
+
+## Loading Options
+
+TrinaGrid provides flexible options for displaying loading indicators while data is being processed or loaded. This feature allows you to control both the coverage area of the loading indicator and customize its appearance with your own widgets.
+
+![Loading Options Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/loading-options.gif)
+
+## Loading Levels
+
+You can control how much of the grid is covered by the loading indicator using the `TrinaGridLoadingLevel` enum:
+
+| Level | Description |
+|-------|-------------|
+| `TrinaGridLoadingLevel.grid` | Covers the entire grid area (default) |
+| `TrinaGridLoadingLevel.body` | Covers only the body area of the grid |
+| `TrinaGridLoadingLevel.row` | Covers only the row area of the grid |
+
+## Basic Usage
+
+To show or hide a loading indicator, use the `setShowLoading` method on the `TrinaGridStateManager`:
+
+```dart
+// Show loading with default settings (grid level)
+stateManager.setShowLoading(true);
+
+// Show loading with a specific level
+stateManager.setShowLoading(true, level: TrinaGridLoadingLevel.body);
+
+// Hide loading
+stateManager.setShowLoading(false);
+```
+
+The loading indicator can be used to provide visual feedback during asynchronous operations:
+
+```dart
+// Show loading indicator
+stateManager.setShowLoading(true);
+
+// Perform an asynchronous operation
+yourAsyncOperation().then((_) {
+  // Hide loading indicator when operation completes
+  stateManager.setShowLoading(false);
+});
+```
+
+## Custom Loading Widgets
+
+For complete control over the loading indicator's appearance, you can provide your own custom widget. This allows you to match your application's branding and style.
+
+```dart
+// Show loading with a custom widget
+stateManager.setShowLoading(
+  true,
+  customLoadingWidget: YourCustomLoadingWidget(),
+);
+```
+
+**Important Note:** When using a custom loading widget, the loading level is always treated as `TrinaGridLoadingLevel.grid`, regardless of the level parameter provided.
+
+### Example Custom Loading Widgets
+
+#### Branded Loading
+
+```dart
+Container(
+  color: Colors.black.withOpacity(0.7),
+  child: Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      CircleAvatar(
+        radius: 40,
+        backgroundColor: Colors.blue,
+        child: Icon(
+          Icons.grid_on,
+          color: Colors.white,
+          size: 40,
+        ),
+      ),
+      SizedBox(height: 20),
+      Text(
+        'Loading data...',
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: 18,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      SizedBox(height: 30),
+      SizedBox(
+        width: 200,
+        child: LinearProgressIndicator(
+          backgroundColor: Colors.white.withOpacity(0.2),
+          valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
+        ),
+      ),
+    ],
+  ),
+)
+```
+
+#### Shimmer Loading Effect
+
+A shimmer loading effect can create the illusion of content being loaded:
+
+```dart
+Container(
+  color: Colors.white.withOpacity(0.9),
+  child: Center(
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        // Shimmer loading widgets here
+        // See example code for implementation details
+      ],
+    ),
+  ),
+)
+```
+
+#### Simple Spinner
+
+```dart
+Container(
+  color: Colors.black.withOpacity(0.5),
+  child: Center(
+    child: SizedBox(
+      width: 100,
+      height: 100,
+      child: CircularProgressIndicator(
+        strokeWidth: 8,
+        valueColor: AlwaysStoppedAnimation<Color>(
+          Colors.purple.shade400,
+        ),
+      ),
+    ),
+  ),
+)
+```
+
+## Best Practices
+
+- **Provide Feedback**: Always show loading indicators for operations that take more than a few hundred milliseconds.
+- **Choose Appropriate Coverage**: Use grid-level loading for operations that affect the entire grid and body-level for operations that only affect the data.
+- **Match Your App's Style**: When using custom loading widgets, make sure they match your application's overall design language.
+- **Informative Messages**: Include informative text when appropriate to help users understand what's happening.
+- **Consider Overlays**: For longer operations, consider using a shimmer effect or placeholder content to indicate that data is loading.
+
+## Complete Example
+
+```dart
+class LoadingOptionsExample extends StatefulWidget {
+  @override
+  _LoadingOptionsExampleState createState() => _LoadingOptionsExampleState();
+}
+
+class _LoadingOptionsExampleState extends State<LoadingOptionsExample> {
+  late TrinaGridStateManager stateManager;
+  
+  void _loadData() {
+    // Show loading with the default loading widget
+    stateManager.setShowLoading(true);
+    
+    // Simulate a network request
+    Future.delayed(const Duration(seconds: 2), () {
+      // Hide loading when data is loaded
+      if (mounted) {
+        stateManager.setShowLoading(false);
+      }
+    });
+  }
+  
+  void _loadDataWithCustomWidget() {
+    // Show loading with a custom widget
+    stateManager.setShowLoading(
+      true,
+      customLoadingWidget: Container(
+        color: Colors.black.withOpacity(0.7),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircleAvatar(
+              radius: 40,
+              backgroundColor: Colors.blue,
+              child: Icon(
+                Icons.grid_on,
+                color: Colors.white,
+                size: 40,
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Fetching your data...',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    
+    // Simulate a network request
+    Future.delayed(const Duration(seconds: 3), () {
+      // Hide loading when data is loaded
+      if (mounted) {
+        stateManager.setShowLoading(false);
+      }
+    });
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Loading Options Example')),
+      body: Column(
+        children: [
+          Row(
+            children: [
+              ElevatedButton(
+                onPressed: _loadData,
+                child: Text('Show Default Loading'),
+              ),
+              SizedBox(width: 16),
+              ElevatedButton(
+                onPressed: _loadDataWithCustomWidget,
+                child: Text('Show Custom Loading'),
+              ),
+            ],
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: yourColumns,
+              rows: yourRows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+For more examples, refer to the loading options demo in the example application. 
+
+---
+
+## Scrollbars
+
+TrinaGrid provides extensive customization options for scrollbars, allowing you to create a better user experience, especially for desktop applications.
+
+## Overview
+
+Scrollbars in TrinaGrid can be customized through the `scrollbar` property in `TrinaGridConfiguration`, which provides a comprehensive set of options to control scrollbar appearance and behavior.
+
+![scrollbars](https://raw.githubusercontent.com/doonfrs/trina_grid/refs/heads/main/doc/assets/scrollbars.gif)
+
+## Basic Usage
+
+By default, TrinaGrid shows scrollbars when needed, but they can be configured to always be visible:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      isAlwaysShown: true, // Prevents scrollbars from fading out
+    ),
+  ),
+)
+```
+
+## Advanced Scrollbar Customization
+
+For more detailed control over the grid's scrollbars, you can use additional properties of `TrinaGridScrollbarConfig`:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      // Visibility settings
+      isAlwaysShown: true,    // Prevents scrollbars from fading out after scrolling stops
+      thumbVisible: true,     // Whether the scrollbar thumb is visible at all
+      showTrack: true,        // Whether to show the track background
+      showHorizontal: true,   // Whether to show the horizontal scrollbar
+      showVertical: true,     // Whether to show the vertical scrollbar
+      
+      // Appearance settings
+      thickness: 8.0,                          // Thickness of the scrollbar
+      minThumbLength: 40.0,                    // Minimum length of the scrollbar thumb
+      thumbColor: Colors.blue.withOpacity(0.6), // Color of the scrollbar thumb
+      trackColor: Colors.grey.withOpacity(0.2), // Color of the scrollbar track
+      thumbHoverColor: Colors.blue.withOpacity(0.8), // Color when hovering over the thumb
+      trackHoverColor: Colors.grey.withOpacity(0.3), // Color when hovering over the track
+      isDraggable: true,                       // Enable scrollbar thumb dragging
+    ),
+  ),
+)
+```
+
+## Configuration Options
+
+### TrinaGridScrollbarConfig
+
+The `TrinaGridScrollbarConfig` class provides the following key options for scrollbar customization:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `isAlwaysShown` | `bool` | `false` | If true, scrollbars remain visible all the time. If false, they appear during scrolling and fade out after about 3 seconds of inactivity. |
+| `thumbVisible` | `bool` | `true` | Whether the scrollbar thumb is visible at all. If false, scrollbars won't show even during scrolling. |
+| `showTrack` | `bool` | `true` | Whether to show the scrollbar track background. |
+| `showHorizontal` | `bool` | `true` | Whether to show the horizontal scrollbar. |
+| `showVertical` | `bool` | `true` | Whether to show the vertical scrollbar. |
+| `thickness` | `double` | `8.0` | Thickness of the scrollbar. |
+| `minThumbLength` | `double` | `40.0` | Minimum length of the scrollbar thumb. |
+| `thumbColor` | `Color?` | `null` | Color of the scrollbar thumb (defaults to semi-transparent gray if null). |
+| `trackColor` | `Color?` | `null` | Color of the scrollbar track (defaults to light gray if null). |
+| `thumbHoverColor` | `Color?` | `null` | Color of the scrollbar thumb when hovered (defaults to a more opaque version of thumbColor if null). |
+| `trackHoverColor` | `Color?` | `null` | Color of the scrollbar track when hovered (defaults to a more opaque version of trackColor if null). |
+| `isDraggable` | `bool` | `true` | Whether scrollbar thumbs can be dragged with mouse or touch to scroll content. |
+| `smoothScrolling` | `bool` | `true` | Whether to use smooth scrolling animation for mouse wheel input. When enabled, scrolling animates smoothly instead of jumping instantly. |
+
+## Examples
+
+### Always Visible Scrollbars
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      isAlwaysShown: true,
+    ),
+  ),
+)
+```
+
+### Custom Scrollbar Colors
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      thumbColor: Colors.blue.withOpacity(0.6),
+      trackColor: Colors.grey.withOpacity(0.2),
+    ),
+  ),
+)
+```
+
+### Hiding Horizontal Scrollbar
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      showHorizontal: false,
+      showVertical: true,
+    ),
+  ),
+)
+```
+
+### Completely Hiding Scrollbars
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      thumbVisible: false,
+    ),
+  ),
+)
+```
+
+### Thicker Scrollbars for Touch Devices
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      thickness: 12.0,
+      minThumbLength: 60.0,
+    ),
+  ),
+)
+```
+
+### Disabling Scrollbar Dragging
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      isDraggable: false, // Disable scrollbar thumb dragging
+    ),
+  ),
+)
+```
+
+### Custom Hover Colors
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      thumbColor: Colors.blue.withOpacity(0.6),
+      thumbHoverColor: Colors.blue.withOpacity(0.9),
+      trackColor: Colors.grey.withOpacity(0.2),
+      trackHoverColor: Colors.grey.withOpacity(0.4),
+    ),
+  ),
+)
+```
+
+### Smooth Scrolling
+
+**Enabled by Default** - TrinaGrid uses smooth scrolling for mouse wheel input by default, providing a polished user experience similar to macOS/iOS:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      smoothScrolling: true, // Default, can be omitted
+    ),
+  ),
+)
+```
+
+To disable smooth scrolling and use instant jumping (legacy behavior):
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      smoothScrolling: false, // Instant scroll jumps
+    ),
+  ),
+)
+```
+
+**How it works:**
+- Mouse wheel scrolling animates smoothly to the target position
+- Uses easing animation for natural deceleration
+- Cancels automatically when you start dragging the scrollbar
+- Responsive to direction changes while scrolling
+
+## Scroll Physics
+
+The `scrollPhysics` parameter allows you to customize the scrolling behavior of the grid beyond what the scrollbar configuration provides. This controls how the grid responds to user scrolling gestures and scroll commands.
+
+### Basic Usage
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const NeverScrollableScrollPhysics(),
+)
+```
+
+### Available Scroll Physics
+
+Flutter provides several built-in `ScrollPhysics` that you can use:
+
+#### NeverScrollableScrollPhysics
+
+Disables all scrolling in the grid. Useful when you want to display a fixed grid without scrolling capability.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const NeverScrollableScrollPhysics(),
+)
+```
+
+#### ClampingScrollPhysics
+
+Provides a clamping scroll effect (Android-style). The scroll position cannot go beyond the content bounds without resistance.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const ClampingScrollPhysics(),
+)
+```
+
+#### BouncingScrollPhysics
+
+Provides a bouncing scroll effect (iOS-style). The scroll can go slightly beyond the content bounds and bounces back.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const BouncingScrollPhysics(),
+)
+```
+
+#### AlwaysScrollableScrollPhysics
+
+Forces the grid to be scrollable even if the content fits within the viewport.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const AlwaysScrollableScrollPhysics(),
+)
+```
+
+### Default Behavior
+
+When `scrollPhysics` is not specified (or set to `null`), TrinaGrid uses the platform-specific default scroll physics from `MaterialScrollBehavior`:
+- Android: Clamping scroll physics
+- iOS/macOS: Bouncing scroll physics
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  // Uses platform-specific default
+)
+```
+
+### Combining Scroll Physics
+
+You can combine multiple scroll physics using the `applyTo` method for more complex behaviors:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const BouncingScrollPhysics().applyTo(
+    const AlwaysScrollableScrollPhysics(),
+  ),
+)
+```
+
+### Use Cases
+
+**Disable scrolling for embedded grids:**
+```dart
+// Useful when the grid is inside a scrollable parent
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const NeverScrollableScrollPhysics(),
+)
+```
+
+**Force consistent platform behavior:**
+```dart
+// Always use iOS-style bouncing on all platforms
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const BouncingScrollPhysics(),
+)
+```
+
+**Customize overscroll behavior:**
+```dart
+// Prevent overscroll glow effect on Android
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const ClampingScrollPhysics(),
+)
+```
+
+## Best Practices
+
+1. **Desktop Applications**: For desktop applications, consider setting `isAlwaysShown: true` to make scrollbars always visible, improving usability.
+
+2. **Touch Devices**: For touch devices, consider using thicker scrollbars by increasing the `thickness` value.
+
+3. **Consistent Styling**: Match scrollbar colors with your application's theme for a consistent look and feel.
+
+4. **Accessibility**: Ensure scrollbars are visible enough for all users, especially those with visual impairments.
+
+5. **Behavior Clarification**: Remember that:
+   - `isAlwaysShown: true` makes scrollbars permanently visible (never fades out)
+   - `isAlwaysShown: false` makes scrollbars appear during scrolling and fade out after about 3 seconds
+   - `thumbVisible: false` completely hides scrollbars regardless of the `isAlwaysShown` setting
+
+6. **Smooth Scrolling**: The smooth scrolling feature is enabled by default and provides a better user experience for mouse wheel users. Consider disabling it only if you have specific performance concerns or prefer instant scrolling behavior.
+
+7. **Scroll Physics**: Choose appropriate scroll physics based on your use case:
+   - Use `NeverScrollableScrollPhysics()` when the grid is inside a scrollable parent to prevent scroll conflicts
+   - Use platform-specific physics (default) for the most native feel on each platform
+   - Consider `AlwaysScrollableScrollPhysics()` if you need scrolling gestures to work even when content fits the viewport
+
+## Limitations
+
+- The scrollbar settings only apply to the grid's main scrollbars, not to any scrollable widgets inside cells.
+- Some scrollbar properties might not be available on all platforms due to platform-specific implementations.
+
+## Related Features
+
+- [Column Freezing](column-freezing.md) - Learn how to freeze columns in place while scrolling horizontally
+- [Frozen Rows](frozen-rows.md) - Learn how to freeze rows in place while scrolling vertically
+
+
+---
+
+## Context Menus
+
+Context menus in TrinaGrid provide an intuitive way for users to access column-specific actions and settings. These menus enhance the user experience by offering quick access to common operations like column freezing, resizing, filtering, and visibility controls.
+
+![Context Menus Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/context-menus.gif)
+
+## Overview
+
+TrinaGrid's context menu system allows users to interact with columns through a popup menu that appears when clicking on a context icon in the column header. The menu provides access to various column operations, and developers can customize both the appearance and functionality of these menus.
+
+## Enabling Context Menus
+
+Context menus can be enabled or disabled for each column individually:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableContextMenu: true, // Enable context menu for this column (default is true)
+)
+```
+
+## Context Menu Features
+
+When enabled, the context menu provides access to several column operations:
+
+### Column Freezing
+
+- **Freeze to Start**: Freezes the column to the left side of the grid
+- **Freeze to End**: Freezes the column to the right side of the grid
+- **Unfreeze**: Unfreezes a previously frozen column
+
+### Column Sizing
+
+- **Auto Fit**: Automatically adjusts the column width to fit its content
+
+### Column Visibility
+
+- **Hide Column**: Hides the column from view (requires `enableHideColumnMenuItem: true`)
+- **Set Columns**: Opens a popup to manage the visibility of all columns (requires `enableSetColumnsMenuItem: true`)
+
+### Column Filtering
+
+- **Set Filter**: Opens the filter popup for the column (requires `enableFilterMenuItem: true`)
+- **Reset Filter**: Clears all active filters (requires `enableFilterMenuItem: true`)
+
+## Customizing Context Menu Items
+
+You can control which menu items appear in the context menu by configuring the column properties:
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableContextMenu: true,
+  enableFilterMenuItem: true,      // Show filter-related menu items
+  enableHideColumnMenuItem: true,  // Show hide column menu item
+  enableSetColumnsMenuItem: true,  // Show set columns menu item
+)
+```
+
+## Context Menu Icon and Resizing
+
+The context menu icon appears on the right side of the column header when `enableContextMenu` is set to `true`. This icon serves two purposes:
+
+1. **Menu Access**: Clicking the icon opens the context menu
+2. **Column Resizing**: If `enableDropToResize` is also enabled, dragging the icon allows users to resize the column
+
+```dart
+TrinaColumn(
+  title: 'Name',
+  field: 'name',
+  type: TrinaColumnType.text(),
+  enableContextMenu: true,
+  enableDropToResize: true, // Allow resizing by dragging the context menu icon
+)
+```
+
+## Customizing the Context Menu
+
+TrinaGrid allows you to fully customize the context menu by implementing your own `TrinaColumnMenuDelegate`:
+
+```dart
+class CustomColumnMenu implements TrinaColumnMenuDelegate<dynamic> {
+  @override
+  List<PopupMenuEntry<dynamic>> buildMenuItems({
+    required TrinaGridStateManager stateManager,
+    required TrinaColumn column,
+  }) {
+    // Return custom menu items
+    return [
+      PopupMenuItem<String>(
+        value: 'custom_action',
+        child: Text('Custom Action'),
+      ),
+      // Add more menu items as needed
+    ];
+  }
+
+  @override
+  void onSelected({
+    required BuildContext context,
+    required TrinaGridStateManager stateManager,
+    required TrinaColumn column,
+    required bool mounted,
+    required String? selected,
+  }) {
+    // Handle menu item selection
+    if (selected == 'custom_action') {
+      // Perform custom action
+    }
+  }
+}
+
+// Use the custom menu delegate
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  columnMenuDelegate: CustomColumnMenu(),
+)
+```
+
+### Extending the Default Menu
+
+If you want to keep the default menu items and add your own custom items, you can extend the default menu using the following pattern:
+
+```dart
+class ExtendedColumnMenuDelegate implements TrinaColumnMenuDelegate<dynamic> {
+  // Custom menu item keys
+  static const String customAction1 = 'custom_action_1';
+  static const String customAction2 = 'custom_action_2';
+
+  // Default delegate to handle standard menu items
+  final TrinaColumnMenuDelegateDefault _defaultDelegate = 
+      const TrinaColumnMenuDelegateDefault();
+
+  @override
+  List<PopupMenuEntry<dynamic>> buildMenuItems({
+    required TrinaGridStateManager stateManager,
+    required TrinaColumn column,
+  }) {
+    // Get default menu items
+    final defaultItems = _defaultDelegate.buildMenuItems(
+      stateManager: stateManager,
+      column: column,
+    );
+    
+    // Add custom menu items with a divider
+    return [
+      ...defaultItems,
+      const PopupMenuDivider(),
+      // Custom menu items
+      PopupMenuItem<String>(
+        value: customAction1,
+        height: 36,
+        enabled: true,
+        child: Text('Custom Action 1'),
+      ),
+      PopupMenuItem<String>(
+        value: customAction2,
+        height: 36,
+        enabled: true,
+        child: Text('Custom Action 2'),
+      ),
+    ];
+  }
+
+  @override
+  void onSelected({
+    required BuildContext context,
+    required TrinaGridStateManager stateManager,
+    required TrinaColumn column,
+    required bool mounted,
+    required dynamic selected,
+  }) {
+    // Handle custom menu items first
+    switch (selected) {
+      case customAction1:
+        // Handle custom action 1
+        break;
+      case customAction2:
+        // Handle custom action 2
+        break;
+      default:
+        // Pass anything else to the default delegate
+        if (selected is TrinaGridColumnMenuItem) {
+          _defaultDelegate.onSelected(
+            context: context,
+            stateManager: stateManager,
+            column: column,
+            mounted: mounted,
+            selected: selected,
+          );
+        }
+        break;
+    }
+  }
+}
+```
+
+You can also selectively remove or modify default menu items before adding your custom ones:
+
+```dart
+@override
+List<PopupMenuEntry<dynamic>> buildMenuItems({
+  required TrinaGridStateManager stateManager,
+  required TrinaColumn column,
+}) {
+  // Get default menu items
+  final defaultItems = _defaultDelegate.buildMenuItems(
+    stateManager: stateManager,
+    column: column,
+  );
+  
+  // Remove specific default items if needed
+  defaultItems.removeWhere((element) {
+    if (element is PopupMenuItem && element.value is TrinaGridColumnMenuItem) {
+      return element.value == TrinaGridColumnMenuItem.freezeToStart;
+    }
+    return false;
+  });
+  
+  // Add custom menu items
+  return [
+    ...defaultItems,
+    const PopupMenuDivider(),
+    // Your custom menu items...
+  ];
+}
+```
+
+### Column-Specific Menu Items
+
+You can display different menu items for specific columns by checking the column properties in your `buildMenuItems` method:
+
+```dart
+@override
+List<PopupMenuEntry<dynamic>> buildMenuItems({
+  required TrinaGridStateManager stateManager,
+  required TrinaColumn column,
+}) {
+  // Get default menu items
+  final defaultItems = _defaultDelegate.buildMenuItems(
+    stateManager: stateManager,
+    column: column,
+  );
+  
+  // Create a list to hold all menu items
+  final allItems = [...defaultItems];
+  
+  // Add a divider if we have default items
+  if (defaultItems.isNotEmpty) {
+    allItems.add(const PopupMenuDivider());
+  }
+  
+  // Add column-specific menu items
+  if (column.field == '0') {
+    // Special menu items only for the first column
+    allItems.add(
+      PopupMenuItem<String>(
+        value: 'first_column_action',
+        height: 36,
+        enabled: true,
+        child: Container(
+          color: Colors.amber,
+          child: Text('Only show in first column', 
+            style: TextStyle(fontSize: 13)),
+        ),
+      ),
+    );
+  }
+  
+  // Add menu items specific to numeric columns
+  if (column.type.isNumber) {
+    allItems.add(
+      const PopupMenuItem<String>(
+        value: 'sum_column',
+        height: 36,
+        enabled: true,
+        child: Text('Calculate sum', style: TextStyle(fontSize: 13)),
+      ),
+    );
+  }
+  
+  // Add standard custom menu items for all columns
+  if (column.key != stateManager.columns.last.key) {
+    allItems.add(
+      const PopupMenuItem<String>(
+        value: 'move_next',
+        height: 36,
+        enabled: true,
+        child: Text('Move next', style: TextStyle(fontSize: 13)),
+      ),
+    );
+  }
+  
+  return allItems;
+}
+```
+
+Remember to handle these column-specific actions in your `onSelected` method:
+
+```dart
+@override
+void onSelected({
+  required BuildContext context,
+  required TrinaGridStateManager stateManager,
+  required TrinaColumn column,
+  required bool mounted,
+  required dynamic selected,
+}) {
+  switch (selected) {
+    case 'first_column_action':
+      // Handle first column specific action
+      break;
+    case 'sum_column':
+      // Calculate and display sum for numeric column
+      break;
+    case 'move_next':
+      // Move column to next position
+      break;
+    default:
+      // Pass anything else to the default delegate
+      if (selected is TrinaGridColumnMenuItem) {
+        _defaultDelegate.onSelected(
+          context: context,
+          stateManager: stateManager,
+          column: column,
+          mounted: mounted,
+          selected: selected,
+        );
+      }
+      break;
+  }
+}
+```
+
+## Styling the Context Menu
+
+You can customize the appearance of the context menu icon and the menu itself through the `TrinaGridStyleConfig`:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      // Customize the context menu icon
+      columnContextIcon: Icons.more_vert,
+      
+      // Customize menu colors
+      menuBackgroundColor: Colors.white,
+      iconColor: Colors.blue,
+    ),
+  ),
+)
+```
+
+## Example
+
+Here's a complete example demonstrating context menus:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class ContextMenuExample extends StatefulWidget {
+  @override
+  _ContextMenuExampleState createState() => _ContextMenuExampleState();
+}
+
+class _ContextMenuExampleState extends State<ContextMenuExample> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        enableContextMenu: true,
+        enableFilterMenuItem: true,
+        enableHideColumnMenuItem: true,
+        enableSetColumnsMenuItem: true,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        enableContextMenu: true,
+        enableDropToResize: true,
+      ),
+      TrinaColumn(
+        title: 'Role',
+        field: 'role',
+        type: TrinaColumnType.text(),
+        enableContextMenu: false, // Disable context menu for this column
+      ),
+    ]);
+
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'name': TrinaCell(value: 'John Doe'),
+          'role': TrinaCell(value: 'Developer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'name': TrinaCell(value: 'Jane Smith'),
+          'role': TrinaCell(value: 'Designer'),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'name': TrinaCell(value: 'Bob Johnson'),
+          'role': TrinaCell(value: 'Manager'),
+        },
+      ),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Context Menu Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+      ),
+    );
+  }
+}
+```
+
+## Interaction with Other Features
+
+Context menus work seamlessly with other TrinaGrid features:
+
+- **Column Freezing**: The context menu provides options to freeze and unfreeze columns
+- **Column Resizing**: When both `enableContextMenu` and `enableDropToResize` are enabled, the context menu icon can be dragged to resize the column
+- **Column Filtering**: The context menu provides access to filtering options when `enableFilterMenuItem` is true
+- **Column Visibility**: The context menu provides options to hide columns and manage column visibility
+
+## Best Practices
+
+- Enable context menus for columns that users might need to configure frequently
+- Consider enabling all menu item types (`enableFilterMenuItem`, `enableHideColumnMenuItem`, and `enableSetColumnsMenuItem`) for a consistent user experience
+- If you need custom menu items, implement a custom `TrinaColumnMenuDelegate`
+- If you want to allow column resizing, enable both `enableContextMenu` and `enableDropToResize`
+
+
+---
+
+## Dual Grid Mode
+
+TrinaGrid offers a powerful dual grid mode that allows you to display two grids side by side with synchronized keyboard navigation between them. This feature is particularly useful for master-detail relationships or any scenario where two related datasets need to be displayed simultaneously.
+
+## Overview
+
+The dual grid mode provides:
+
+- Two grids arranged horizontally with a customizable divider
+- Seamless keyboard navigation between the grids
+- Synchronized selection events
+- Flexible layout options for controlling grid widths
+- Support for both standard and popup display modes
+
+## Basic Usage
+
+```dart
+TrinaDualGrid(
+  gridPropsA: TrinaDualGridProps(
+    columns: leftGridColumns,
+    rows: leftGridRows,
+    onLoaded: (event) {
+      leftGridStateManager = event.stateManager;
+    },
+    // Other grid properties...
+  ),
+  gridPropsB: TrinaDualGridProps(
+    columns: rightGridColumns,
+    rows: rightGridRows,
+    onLoaded: (event) {
+      rightGridStateManager = event.stateManager;
+    },
+    // Other grid properties...
+  ),
+)
+```
+
+## Master-Detail Pattern
+
+A common use case for dual grid mode is implementing a master-detail pattern, where selecting a row in the left grid updates the content in the right grid:
+
+```dart
+void leftGridHandler() {
+  if (leftGridStateManager.currentRow == null) {
+    return;
+  }
+
+  if (leftGridStateManager.currentRow!.key != currentRowKey) {
+    currentRowKey = leftGridStateManager.currentRow!.key;
+    
+    // Show loading indicator
+    rightGridStateManager.setShowLoading(true);
+    
+    // Fetch related data for the selected row
+    fetchRelatedData();
+  }
+}
+
+// In your initState or onLoaded callback:
+leftGridStateManager.addListener(leftGridHandler);
+```
+
+## Layout Options
+
+TrinaGrid provides several display options for controlling the width distribution between the two grids:
+
+### Equal Ratio (Default)
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  display: TrinaDualGridDisplayRatio(), // 50:50 ratio by default
+)
+```
+
+### Custom Ratio
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  display: TrinaDualGridDisplayRatio(ratio: 0.7), // 70:30 ratio
+)
+```
+
+### Fixed Left Grid Width
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  display: TrinaDualGridDisplayFixedAndExpanded(width: 300), // Left grid fixed at 300px
+)
+```
+
+### Fixed Right Grid Width
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  display: TrinaDualGridDisplayExpandedAndFixed(width: 300), // Right grid fixed at 300px
+)
+```
+
+## Divider Customization
+
+You can customize the divider between the grids:
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  divider: TrinaDualGridDivider(
+    show: true, // Show the divider
+    backgroundColor: Colors.grey[200]!, // Divider background color
+    indicatorColor: Colors.blue, // Center indicator color
+    draggingColor: Colors.lightBlue[100]!, // Color when dragging
+  ),
+)
+```
+
+For dark themes, you can use the built-in dark theme divider:
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  divider: const TrinaDualGridDivider.dark(),
+)
+```
+
+## Popup Mode
+
+In addition to the standard dual grid mode, TrinaGrid also offers a popup version that can be triggered from user actions:
+
+```dart
+TrinaDualGridPopup(
+  context: context,
+  gridPropsA: TrinaDualGridProps(
+    columns: leftGridColumns,
+    rows: leftGridRows,
+    // Other properties...
+  ),
+  gridPropsB: TrinaDualGridProps(
+    columns: rightGridColumns,
+    rows: rightGridRows,
+    // Other properties...
+  ),
+  width: 800, // Optional custom width
+  height: 600, // Optional custom height
+  onSelected: (event) {
+    // Handle selection
+  },
+);
+```
+
+## Keyboard Navigation
+
+The dual grid mode seamlessly handles keyboard navigation between the two grids:
+
+- When focus is on the right edge of the left grid and you press the right arrow key, focus automatically moves to the right grid
+- When focus is on the left edge of the right grid and you press the left arrow key, focus automatically moves to the left grid
+
+## Events
+
+You can listen for selection events across both grids:
+
+```dart
+TrinaDualGrid(
+  // Grid properties...
+  onSelected: (TrinaDualOnSelectedEvent event) {
+    // Access selected rows/cells from both grids
+    final leftSelectedRow = event.gridA?.row;
+    final rightSelectedRow = event.gridB?.row;
+    
+    // Take action based on selections
+  },
+)
+```
+
+## Example
+
+See the [dual mode example](https://github.com/doonfrs/trina_grid/blob/master/demo/lib/screen/feature/dual_mode_screen.dart) for a complete implementation showing how to use the dual grid mode with dynamic data loading.
+
+
+---
+
+## Change Tracking
+
+Change tracking is a powerful feature in TrinaGrid that allows you to monitor and manage modifications to cell values. This feature helps users identify which cells have been modified but not yet committed, and provides functionality to commit or revert these changes.
+
+![Change Tracking Demo](https://raw.githubusercontent.com/doonfrs/trina_grid/master/doc/assets/change-tracking.gif)
+
+## Overview
+
+The change tracking feature enables you to:
+
+- Track modifications to cell values
+- Visually highlight cells with uncommitted changes
+- Commit changes globally or for specific cells
+- Revert changes globally or for specific cells
+- Monitor the number of dirty (modified) cells
+- Integrate with your application's data management workflow
+
+## Enabling Change Tracking
+
+To enable change tracking, use the `setChangeTracking` method on the grid's state manager:
+
+```dart
+stateManager.setChangeTracking(true);
+```
+
+You can also configure the visual appearance of dirty cells using the grid's configuration:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      cellDirtyColor: Colors.amber[100]!, // Customize the color for dirty cells
+    ),
+  ),
+)
+```
+
+## Managing Changes
+
+### Checking if a Cell is Dirty
+
+You can check if a cell has uncommitted changes using the `isDirty` property:
+
+```dart
+bool hasPendingChanges = cell.isDirty;
+```
+
+### Committing Changes
+
+To commit changes, you can use the `commitChanges` method. You can either commit all changes or specify a particular cell:
+
+```dart
+// Commit all changes
+stateManager.commitChanges();
+
+// Commit changes for a specific cell
+stateManager.commitChanges(cell: specificCell);
+```
+
+### Reverting Changes
+
+To revert changes back to their original values:
+
+```dart
+// Revert all changes
+stateManager.revertChanges();
+
+// Revert changes for a specific cell
+stateManager.revertChanges(cell: specificCell);
+```
+
+## Example Implementation
+
+Here's a complete example showing how to implement change tracking with UI controls:
+
+```dart
+class ChangeTrackingScreen extends StatefulWidget {
+  @override
+  _ChangeTrackingScreenState createState() => _ChangeTrackingScreenState();
+}
+
+class _ChangeTrackingScreenState extends State<ChangeTrackingScreen> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+  
+  // Use ValueNotifier for efficient updates without rebuilding the entire widget
+  final ValueNotifier<bool> changeTrackingNotifier = ValueNotifier<bool>(false);
+  final ValueNotifier<TrinaCell?> selectedCellNotifier = ValueNotifier<TrinaCell?>(null);
+  final ValueNotifier<int> dirtyCountNotifier = ValueNotifier<int>(0);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Controls for change tracking
+        Row(
+          children: [
+            ValueListenableBuilder<bool>(
+              valueListenable: changeTrackingNotifier,
+              builder: (context, isEnabled, _) {
+                return Switch(
+                  value: isEnabled,
+                  onChanged: (flag) {
+                    changeTrackingNotifier.value = flag;
+                    stateManager.setChangeTracking(flag);
+                    updateDirtyCount();
+                  },
+                );
+              },
+            ),
+            const Text('Enable Change Tracking'),
+            ValueListenableBuilder<int>(
+              valueListenable: dirtyCountNotifier,
+              builder: (context, count, _) {
+                return Text(
+                  'Dirty Cells: $count',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: count > 0 ? Colors.orange : Colors.black,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        
+        // Commit/Revert buttons
+        ValueListenableBuilder<TrinaCell?>(
+          valueListenable: selectedCellNotifier,
+          builder: (context, selectedCell, _) {
+            return Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    stateManager.commitChanges();
+                    updateDirtyCount();
+                  },
+                  child: const Text('Commit All Changes'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    stateManager.revertChanges();
+                    updateDirtyCount();
+                  },
+                  child: const Text('Revert All Changes'),
+                ),
+                ElevatedButton(
+                  onPressed: selectedCell != null
+                      ? () {
+                          stateManager.commitChanges(cell: selectedCell);
+                          updateDirtyCount();
+                        }
+                      : null,
+                  child: const Text('Commit Selected Cell'),
+                ),
+                ElevatedButton(
+                  onPressed: selectedCell != null
+                      ? () {
+                          stateManager.revertChanges(cell: selectedCell);
+                          updateDirtyCount();
+                        }
+                      : null,
+                  child: const Text('Revert Selected Cell'),
+                ),
+              ],
+            );
+          },
+        ),
+        
+        // The grid
+        Expanded(
+          child: TrinaGrid(
+            columns: columns,
+            rows: rows,
+            onChanged: (event) {
+              if (changeTrackingNotifier.value) {
+                updateDirtyCount();
+              }
+            },
+            onLoaded: (event) {
+              stateManager = event.stateManager;
+              stateManager.setSelectingMode(TrinaGridSelectingMode.cell);
+            },
+            onActiveCellChanged: (event) {
+              selectedCellNotifier.value = event.cell;
+            },
+            configuration: TrinaGridConfiguration(
+              style: TrinaGridStyleConfig(
+                cellDirtyColor: Colors.amber[100]!,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // Update the count of dirty cells
+  void updateDirtyCount() {
+    int count = 0;
+    for (var row in rows) {
+      for (var cell in row.cells.values) {
+        if (cell.isDirty) {
+          count++;
+        }
+      }
+    }
+    dirtyCountNotifier.value = count;
+  }
+}
+```
+
+## Best Practices
+
+1. **Efficient State Management**: Use `ValueNotifier` or similar state management solutions to avoid unnecessary rebuilds when tracking changes.
+
+2. **Visual Feedback**: Provide clear visual indicators for:
+   - Cells with uncommitted changes
+   - The total number of modified cells
+   - Whether change tracking is enabled/disabled
+
+3. **Granular Control**: Offer both global and cell-level options for committing and reverting changes.
+
+4. **Error Handling**: Implement proper error handling when committing or reverting changes, especially if these operations involve backend services.
+
+5. **Performance**: For large datasets, consider optimizing the dirty cell count calculation or using a more efficient tracking mechanism.
+
+## Integration with Other Features
+
+Change tracking works seamlessly with other TrinaGrid features:
+
+- **Cell Editing**: Track changes made during cell editing
+- **Copy/Paste**: Monitor changes made through paste operations
+- **Keyboard Navigation**: Maintain tracking state while navigating with keyboard
+- **Data Validation**: Validate changes before marking cells as dirty
+
+## Events and Callbacks
+
+The following events are relevant for change tracking:
+
+- `onChanged`: Triggered when a cell value changes
+- `onActiveCellChanged`: Useful for tracking the currently selected cell
+- `onLoaded`: Used to initialize the state manager and configure change tracking
+
+## Limitations and Considerations
+
+1. Change tracking increases memory usage as it needs to maintain the original values.
+2. For very large datasets, frequent updates to the dirty cell count might impact performance.
+3. The feature works best with primitive data types; complex objects might require custom comparison logic.
+
+## See Also
+
+- [Cell Editing](cell-editing.md)
+- [Data Validation](cell-validation.md)
+- [Cell Selection](cell-selection.md)
+
+
+---
+
+## Custom Renderers Examples
+
+This page provides complete examples of using custom renderers in TrinaGrid.
+
+## Task Management Grid Example
+
+This example demonstrates a task management grid with various custom renderers:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class TaskManagementGrid extends StatefulWidget {
+  const TaskManagementGrid({Key? key}) : super(key: key);
+
+  @override
+  State<TaskManagementGrid> createState() => _TaskManagementGridState();
+}
+
+class _TaskManagementGridState extends State<TaskManagementGrid> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  late TrinaGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        width: 80,
+        enableRowDrag: true,
+        enableRowChecked: true,
+        // Column-level renderer for all ID cells
+        renderer: (rendererContext) {
+          return Text(
+            rendererContext.cell.value.toString(),
+            style: const TextStyle(
+              color: Colors.blue,
+              fontWeight: FontWeight.bold,
+            ),
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Task',
+        field: 'task',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select(['Pending', 'In Progress', 'Completed', 'Cancelled']),
+        width: 150,
+      ),
+      TrinaColumn(
+        title: 'Priority',
+        field: 'priority',
+        type: TrinaColumnType.select(['Low', 'Medium', 'High', 'Critical']),
+        width: 120,
+      ),
+      TrinaColumn(
+        title: 'Due Date',
+        field: 'due_date',
+        type: TrinaColumnType.date(),
+        width: 130,
+      ),
+      TrinaColumn(
+        title: 'Progress',
+        field: 'progress',
+        type: TrinaColumnType.number(),
+        width: 150,
+        // Column-level renderer for progress cells
+        renderer: (rendererContext) {
+          final value = rendererContext.cell.value as int? ?? 0;
+          
+          return Stack(
+            children: [
+              Container(
+                width: double.infinity,
+                height: 20,
+                decoration: BoxDecoration(
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              Container(
+                width: (value / 100) * (rendererContext.column.width - 20),
+                height: 20,
+                decoration: BoxDecoration(
+                  color: value < 30 
+                      ? Colors.red 
+                      : (value < 70 ? Colors.orange : Colors.green),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              Center(
+                child: Text(
+                  '$value%',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      TrinaColumn(
+        title: 'Assigned To',
+        field: 'assigned_to',
+        type: TrinaColumnType.text(),
+        width: 150,
+      ),
+    ]);
+
+    // Create rows with custom cell renderers
+    for (var i = 1; i <= 10; i++) {
+      final statusValue = i % 4 == 0 
+          ? 'Completed' 
+          : (i % 4 == 1 ? 'In Progress' : (i % 4 == 2 ? 'Pending' : 'Cancelled'));
+      
+      final priorityValue = i % 4 == 0 
+          ? 'Low' 
+          : (i % 4 == 1 ? 'Medium' : (i % 4 == 2 ? 'High' : 'Critical'));
+
+      final dueDate = DateTime.now().add(Duration(days: i * 2));
+      final progress = (i * 10) % 100;
+
+      final cells = {
+        'id': TrinaCell(value: 'TASK-$i'),
+        'task': TrinaCell(value: 'Complete feature #$i'),
+        'status': TrinaCell(
+          value: statusValue,
+          // Cell-level renderer for status cells
+          renderer: (rendererContext) {
+            Color backgroundColor;
+            Color textColor = Colors.white;
+
+            switch (rendererContext.cell.value) {
+              case 'Completed':
+                backgroundColor = Colors.green;
+                break;
+              case 'In Progress':
+                backgroundColor = Colors.orange;
+                break;
+              case 'Pending':
+                backgroundColor = Colors.blue;
+                break;
+              case 'Cancelled':
+                backgroundColor = Colors.red;
+                break;
+              default:
+                backgroundColor = Colors.grey;
+            }
+
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                rendererContext.cell.value.toString(),
+                style: TextStyle(
+                  color: textColor,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            );
+          },
+        ),
+        'priority': TrinaCell(
+          value: priorityValue,
+          // Cell-level renderer for priority cells
+          renderer: (rendererContext) {
+            IconData iconData;
+            Color iconColor;
+
+            switch (rendererContext.cell.value) {
+              case 'Low':
+                iconData = Icons.arrow_downward;
+                iconColor = Colors.green;
+                break;
+              case 'Medium':
+                iconData = Icons.arrow_forward;
+                iconColor = Colors.blue;
+                break;
+              case 'High':
+                iconData = Icons.arrow_upward;
+                iconColor = Colors.orange;
+                break;
+              case 'Critical':
+                iconData = Icons.priority_high;
+                iconColor = Colors.red;
+                break;
+              default:
+                iconData = Icons.help_outline;
+                iconColor = Colors.grey;
+            }
+
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Icon(
+                  iconData,
+                  color: iconColor,
+                  size: 16,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  rendererContext.cell.value.toString(),
+                  style: TextStyle(
+                    color: iconColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        'due_date': TrinaCell(
+          value: dueDate.toString().substring(0, 10),
+          // Cell-level renderer for due date cells
+          renderer: (rendererContext) {
+            final dueDate = DateTime.parse(rendererContext.cell.value);
+            final today = DateTime.now();
+            final difference = dueDate.difference(today).inDays;
+            
+            Color textColor = Colors.black;
+            if (difference < 0) {
+              textColor = Colors.red;
+            } else if (difference <= 2) {
+              textColor = Colors.orange;
+            }
+            
+            return Row(
+              children: [
+                if (difference < 0)
+                  const Icon(Icons.warning, color: Colors.red, size: 16),
+                if (difference >= 0 && difference <= 2)
+                  const Icon(Icons.access_time, color: Colors.orange, size: 16),
+                const SizedBox(width: 4),
+                Text(
+                  rendererContext.cell.value.toString(),
+                  style: TextStyle(
+                    color: textColor,
+                    fontWeight: difference <= 2 ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        'progress': TrinaCell(value: progress),
+        'assigned_to': TrinaCell(
+          value: 'User ${i % 3 + 1}',
+          // Cell-level renderer for assigned to cells
+          renderer: (rendererContext) {
+            final userName = rendererContext.cell.value.toString();
+            final avatarColor = userName == 'User 1' 
+                ? Colors.blue 
+                : (userName == 'User 2' ? Colors.green : Colors.purple);
+            
+            return Row(
+              children: [
+                CircleAvatar(
+                  backgroundColor: avatarColor,
+                  radius: 12,
+                  child: Text(
+                    userName.substring(userName.length - 1),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(userName),
+              ],
+            );
+          },
+        ),
+      };
+
+      rows.add(TrinaRow(cells: cells));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Task Management Grid'),
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(16),
+        child: TrinaGrid(
+          columns: columns,
+          rows: rows,
+          onLoaded: (TrinaGridOnLoadedEvent event) {
+            stateManager = event.stateManager;
+          },
+          configuration: const TrinaGridConfiguration(),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Reusable Cell Renderers
+
+You can create reusable renderer functions to maintain consistency:
+
+```dart
+// Define reusable renderer functions
+Widget statusRenderer(TrinaCellRendererContext context) {
+  Color backgroundColor;
+  Color textColor = Colors.white;
+
+  switch (context.cell.value) {
+    case 'Completed':
+      backgroundColor = Colors.green;
+      break;
+    case 'In Progress':
+      backgroundColor = Colors.orange;
+      break;
+    case 'Pending':
+      backgroundColor = Colors.blue;
+      break;
+    case 'Cancelled':
+      backgroundColor = Colors.red;
+      break;
+    default:
+      backgroundColor = Colors.grey;
+  }
+
+  return Container(
+    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    decoration: BoxDecoration(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Text(
+      context.cell.value.toString(),
+      style: TextStyle(
+        color: textColor,
+        fontWeight: FontWeight.bold,
+      ),
+      textAlign: TextAlign.center,
+    ),
+  );
+}
+
+// Use the reusable renderer
+TrinaCell(
+  value: 'Completed',
+  renderer: statusRenderer,
+)
+```
+
+## Interactive Cell Example
+
+This example shows how to create cells with interactive elements:
+
+```dart
+TrinaColumn(
+  title: 'Rating',
+  field: 'rating',
+  type: TrinaColumnType.number(),
+  width: 200,
+  renderer: (rendererContext) {
+    final rating = rendererContext.cell.value as int? ?? 0;
+    
+    return Row(
+      children: List.generate(5, (index) {
+        return IconButton(
+          icon: Icon(
+            index < rating ? Icons.star : Icons.star_border,
+            color: index < rating ? Colors.amber : Colors.grey,
+          ),
+          onPressed: () {
+            // Update the rating when a star is clicked
+            rendererContext.stateManager.changeCellValue(
+              rendererContext.cell,
+              index + 1,
+            );
+          },
+          iconSize: 20,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        );
+      }),
+    );
+  },
+)
+```
+
+## Conditional Cell Renderer Example
+
+This example demonstrates how to apply different renderers based on conditions:
+
+```dart
+// Create a function that returns different renderers based on conditions
+TrinaCellRenderer getConditionalRenderer(String value) {
+  if (value == 'Completed') {
+    return (context) => Container(
+          color: Colors.green[100],
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.green),
+              const SizedBox(width: 4),
+              Text(
+                context.cell.value.toString(),
+                style: const TextStyle(color: Colors.green),
+              ),
+            ],
+          ),
+        );
+  } else if (value == 'Cancelled') {
+    return (context) => Container(
+          color: Colors.red[100],
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              const Icon(Icons.cancel, color: Colors.red),
+              const SizedBox(width: 4),
+              Text(
+                context.cell.value.toString(),
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+          ),
+        );
+  }
+  
+  // Default renderer
+  return (context) => Text(context.cell.value.toString());
+}
+
+// Use the conditional renderer
+TrinaCell(
+  value: 'Completed',
+  renderer: getConditionalRenderer('Completed'),
+)
+```
+
+## Best Practices
+
+1. **Extract Reusable Renderers**: Create functions for common rendering patterns
+2. **Keep Renderers Simple**: Avoid complex logic in renderer functions
+3. **Consider Performance**: Use lightweight widgets for better scrolling performance
+4. **Handle Null Values**: Always handle potential null values in your renderers
+5. **Maintain Consistency**: Use similar styling patterns across your grid
+
+## Related Documentation
+
+- [Cell Renderer Feature](https://github.com/doonfrs/trina_grid/blob/main/doc/features/cell-renderer.md)
+- [Column Renderer Feature](https://github.com/doonfrs/trina_grid/blob/main/doc/features/column-renderer.md)
+- [Custom Styling](https://github.com/doonfrs/trina_grid/blob/main/doc/features/custom-styling.md)
+
+
+---
+
+## Dynamic Row Heights Example
+
+This example demonstrates how to use TrinaGrid's dynamic row heights feature to create rows with different heights.
+
+## Basic Example
+
+Here's a simple example showing how to create rows with custom heights:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class DynamicRowHeightExample extends StatefulWidget {
+  @override
+  _DynamicRowHeightExampleState createState() => _DynamicRowHeightExampleState();
+}
+
+class _DynamicRowHeightExampleState extends State<DynamicRowHeightExample> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeData();
+  }
+
+  void _initializeData() {
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+      TrinaColumn(
+        title: 'Description',
+        field: 'description',
+        type: TrinaColumnType.text(),
+        width: 300,
+      ),
+    ];
+
+    rows = [
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '1'),
+          'name': TrinaCell(value: 'Normal Row'),
+          'description': TrinaCell(value: 'This row uses the default height'),
+        },
+        // No height specified - uses default
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '2'),
+          'name': TrinaCell(value: 'Tall Row'),
+          'description': TrinaCell(value: 'This row has a custom height of 80px'),
+        },
+        height: 80.0, // Custom height
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '3'),
+          'name': TrinaCell(value: 'Very Tall Row'),
+          'description': TrinaCell(value: 'This row has a custom height of 120px'),
+        },
+        height: 120.0, // Custom height
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Dynamic Row Heights Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        configuration: TrinaGridConfiguration(
+          style: TrinaGridStyleConfig(
+            rowHeight: 45.0, // Default height
+            enableCellBorderHorizontal: true,
+            enableCellBorderVertical: true,
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Interactive Example
+
+Here's a more advanced example that allows users to modify row heights at runtime:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class InteractiveRowHeightExample extends StatefulWidget {
+  @override
+  _InteractiveRowHeightExampleState createState() => _InteractiveRowHeightExampleState();
+}
+
+class _InteractiveRowHeightExampleState extends State<InteractiveRowHeightExample> {
+  TrinaGridStateManager? stateManager;
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeData();
+  }
+
+  void _initializeData() {
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.text(),
+        width: 80,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        width: 200,
+      ),
+      TrinaColumn(
+        title: 'Height',
+        field: 'height',
+        type: TrinaColumnType.text(),
+        width: 100,
+      ),
+    ];
+
+    rows = List.generate(5, (index) {
+      return TrinaRow(
+        cells: {
+          'id': TrinaCell(value: '${index + 1}'),
+          'name': TrinaCell(value: 'Row ${index + 1}'),
+          'height': TrinaCell(value: '45px'),
+        },
+      );
+    });
+  }
+
+  void _setRowHeight(int rowIndex, double height) {
+    if (stateManager != null) {
+      stateManager!.setRowHeight(rowIndex, height);
+      
+      // Update the height display in the grid
+      final row = rows[rowIndex];
+      row.cells['height']!.value = '${height.toInt()}px';
+      
+      setState(() {});
+    }
+  }
+
+  void _resetRowHeight(int rowIndex) {
+    if (stateManager != null) {
+      stateManager!.resetRowHeight(rowIndex);
+      
+      // Update the height display in the grid
+      final row = rows[rowIndex];
+      row.cells['height']!.value = '45px';
+      
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Interactive Row Heights Example')),
+      body: Column(
+        children: [
+          // Control Panel
+          Container(
+            padding: const EdgeInsets.all(16),
+            color: Colors.grey[100],
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Row Height Controls', 
+                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                SizedBox(height: 16),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => _setRowHeight(0, 60.0),
+                      child: Text('Row 0 → 60px'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _setRowHeight(1, 80.0),
+                      child: Text('Row 1 → 80px'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _setRowHeight(2, 100.0),
+                      child: Text('Row 2 → 100px'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _resetRowHeight(0),
+                      child: Text('Reset Row 0'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _resetRowHeight(1),
+                      child: Text('Reset Row 1'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => _resetRowHeight(2),
+                      child: Text('Reset Row 2'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          
+          // Grid
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (TrinaGridOnLoadedEvent event) {
+                stateManager = event.stateManager;
+              },
+              rowColorCallback: (TrinaRowColorContext context) {
+                // Highlight rows with custom heights
+                if (context.row.height != null) {
+                  return Colors.blue.withValues(alpha: 0.1);
+                }
+                // Use default alternating row colors
+                return context.rowIdx % 2 == 0 ? Colors.white : Colors.grey[50]!;
+              },
+              configuration: TrinaGridConfiguration(
+                style: TrinaGridStyleConfig(
+                  rowHeight: 45.0, // Default height
+                  enableCellBorderHorizontal: true,
+                  enableCellBorderVertical: true,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Visual Indicators
+
+You can use the `rowColorCallback` to visually distinguish rows with custom heights:
+
+```dart
+rowColorCallback: (TrinaRowColorContext context) {
+  if (context.row.height != null) {
+    return Colors.blue.withValues(alpha: 0.1); // Custom height rows
+  }
+  return context.rowIdx % 2 == 0 ? Colors.white : Colors.grey[50]!; // Default
+},
+```
+
+## Content-Based Heights
+
+You can set row heights based on content requirements:
+
+```dart
+rows = [
+  TrinaRow(
+    cells: {
+      'id': TrinaCell(value: '1'),
+      'content': TrinaCell(value: 'Short content'),
+    },
+    // Uses default height
+  ),
+  TrinaRow(
+    cells: {
+      'id': TrinaCell(value: '2'),
+      'content': TrinaCell(value: 'Very long content that needs more space to display properly without truncation'),
+    },
+    height: 80.0, // Extra height for long content
+  ),
+];
+```
+
+## Status-Based Heights
+
+Different heights for different row types:
+
+```dart
+rows = List.generate(10, (index) {
+  final isExpanded = index % 3 == 0; // Every 3rd row is expanded
+  
+  return TrinaRow(
+    cells: {
+      'id': TrinaCell(value: '${index + 1}'),
+      'status': TrinaCell(value: isExpanded ? 'expanded' : 'normal'),
+    },
+    height: isExpanded ? 100.0 : null, // Custom height for expanded rows
+  );
+});
+```
+
+## Best Practices
+
+1. **Set heights at creation time** when possible for better performance
+2. **Use visual indicators** to help users understand which rows have custom heights
+3. **Consider the impact** on scrolling performance with many variable-height rows
+4. **Update UI elements** after changing heights to reflect the new state
+5. **Use meaningful height values** that provide better content display
+
+## Common Patterns
+
+### Expanding/Collapsing Rows
+```dart
+void _toggleRowExpansion(int rowIndex) {
+  if (stateManager != null) {
+    final currentHeight = stateManager!.getRowHeight(rowIndex);
+    final isExpanded = currentHeight > 45.0;
+    
+    if (isExpanded) {
+      stateManager!.resetRowHeight(rowIndex);
+    } else {
+      stateManager!.setRowHeight(rowIndex, 100.0);
+    }
+    
+    setState(() {});
+  }
+}
+```
+
+### Batch Height Operations
+```dart
+void _setAllRowsToHeight(double height) {
+  if (stateManager != null) {
+    for (int i = 0; i < rows.length; i++) {
+      stateManager!.setRowHeight(i, height);
+    }
+    setState(() {});
+  }
+}
+```
+
+### Height Validation
+```dart
+void _setRowHeightWithValidation(int rowIndex, double height) {
+  if (height < 30.0) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Height must be at least 30px')),
+    );
+    return;
+  }
+  
+  if (height > 200.0) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Height cannot exceed 200px')),
+    );
+    return;
+  }
+  
+  if (stateManager != null) {
+    stateManager!.setRowHeight(rowIndex, height);
+    setState(() {});
+  }
+}
+```
+
+This example demonstrates the key concepts of dynamic row heights in TrinaGrid. You can now create grids with rows of different heights and modify them dynamically at runtime!
+
+
+---
+
+## Cell Coloring
+
+Cell coloring is a feature in TrinaGrid that allows you to customize the background color of individual cells based on their content or state. This feature enhances data visualization by providing visual cues that help users quickly identify patterns, categories, or important information within specific cells.
+
+## Overview
+
+The cell coloring feature enables you to dynamically assign colors to cells based on custom logic. This is particularly useful for:
+
+- Highlighting cells that meet specific criteria
+- Creating conditional formatting based on cell values
+- Visually categorizing data at a granular level
+- Indicating status or priority levels for individual cells
+- Enhancing the overall user experience with targeted visual feedback
+
+## Implementing Cell Coloring
+
+To implement cell coloring in TrinaGrid, you need to use the `cellColorCallback` parameter when creating your TrinaGrid widget. This callback function receives a `TrinaCellColorContext` object and should return a `Color?` object (or `null` for default cell color).
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellColorCallback: (cellColorContext) {
+    // Your custom logic to determine cell color
+    return yourColorValue;
+  },
+)
+```
+
+## The TrinaCellColorContext
+
+The `cellColorContext` parameter provides context information about the cell being rendered, including:
+
+- `cell`: The TrinaCell object containing the cell's data
+- `column`: The TrinaColumn object containing the column's configuration
+- `row`: The TrinaRow object containing the row's data
+- `rowIdx`: The index of the row in the current view
+- `stateManager`: The TrinaGridStateManager instance
+
+This context allows you to make color decisions based on cell data, column type, row data, position, or grid state.
+
+## Examples
+
+### Basic Cell Coloring
+
+Here's a simple example that colors cells based on their value:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellColorCallback: (cellColorContext) {
+    // Color cells based on their value
+    if (cellColorContext.cell.value == 'High Priority') {
+      return Colors.red[100]!;
+    } else if (cellColorContext.cell.value == 'Medium Priority') {
+      return Colors.orange[100]!;
+    } else if (cellColorContext.cell.value == 'Low Priority') {
+      return Colors.green[100]!;
+    }
+    
+    // Return null for default color
+    return null;
+  },
+)
+```
+
+### Column-Specific Cell Coloring
+
+You can apply different coloring logic based on the column:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellColorCallback: (cellColorContext) {
+    // Color cells in the 'status' column
+    if (cellColorContext.column.field == 'status') {
+      final status = cellColorContext.cell.value;
+      if (status == 'Active') {
+        return Colors.green[100]!;
+      } else if (status == 'Pending') {
+        return Colors.yellow[100]!;
+      } else if (status == 'Inactive') {
+        return Colors.grey[100]!;
+      }
+    }
+    
+    // Color cells in the 'priority' column
+    if (cellColorContext.column.field == 'priority') {
+      final priority = cellColorContext.cell.value;
+      if (priority == 'High') {
+        return Colors.red[100]!;
+      } else if (priority == 'Medium') {
+        return Colors.orange[100]!;
+      } else if (priority == 'Low') {
+        return Colors.blue[100]!;
+      }
+    }
+    
+    // Default color for other cells
+    return null;
+  },
+)
+```
+
+### Conditional Cell Coloring Based on Multiple Factors
+
+You can implement complex logic that considers multiple cell and row properties:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellColorCallback: (cellColorContext) {
+    final cell = cellColorContext.cell;
+    final column = cellColorContext.column;
+    final row = cellColorContext.row;
+    
+    // Highlight overdue tasks in the due date column
+    if (column.field == 'due_date') {
+      final dueDate = cell.value as DateTime?;
+      if (dueDate != null && dueDate.isBefore(DateTime.now())) {
+        return Colors.red[200]!;
+      }
+    }
+    
+    // Highlight completed status cells
+    if (column.field == 'status' && cell.value == 'Completed') {
+      return Colors.green[200]!;
+    }
+    
+    // Highlight high priority tasks in any text column
+    if (column.type.isText) {
+      final priority = row.cells['priority']?.value;
+      if (priority == 'High') {
+        return Colors.orange[50]!;
+      }
+    }
+    
+    // Default color
+    return null;
+  },
+)
+```
+
+### Numeric Value-Based Coloring
+
+Color cells based on numeric thresholds:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellColorCallback: (cellColorContext) {
+    if (cellColorContext.column.field == 'score') {
+      final score = cellColorContext.cell.value as num?;
+      if (score != null) {
+        if (score >= 90) {
+          return Colors.green[100]!; // Excellent
+        } else if (score >= 70) {
+          return Colors.yellow[100]!; // Good
+        } else if (score >= 50) {
+          return Colors.orange[100]!; // Average
+        } else {
+          return Colors.red[100]!; // Poor
+        }
+      }
+    }
+    
+    return null;
+  },
+)
+```
+
+## Dynamic Cell Coloring
+
+One of the powerful aspects of the `cellColorCallback` is that it's called whenever the grid is redrawn, which means cell colors will update dynamically when:
+
+- Cell values change
+- Rows are added or removed
+- The grid is sorted or filtered
+- Any other operation that causes the grid to redraw
+
+This allows for responsive visual feedback as users interact with the grid.
+
+## Combining with Row Coloring
+
+Cell coloring works independently of row coloring and can be used together. When both are used:
+
+1. Row colors are applied first as the base background
+2. Cell colors are applied on top and will override row colors for specific cells
+3. This allows for sophisticated highlighting strategies
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowColorCallback: (rowColorContext) {
+    // Apply subtle row coloring
+    return rowColorContext.rowIdx % 2 == 0 
+        ? Colors.grey[50]! 
+        : Colors.white;
+  },
+  cellColorCallback: (cellColorContext) {
+    // Override with specific cell coloring
+    if (cellColorContext.cell.value == 'Important') {
+      return Colors.yellow[200]!;
+    }
+    return null; // Keep row color
+  },
+)
+```
+
+## Combining with Other Features
+
+Cell coloring works well with other TrinaGrid features:
+
+### With Cell Selection
+
+When combining cell coloring with cell selection, be aware that the selection highlight may temporarily override your custom cell colors. The colors will reappear when the cell is deselected.
+
+### With Cell Editing
+
+During cell editing, the edit mode colors may temporarily override custom cell colors. Your colors will return when editing is completed.
+
+### With Cell Validation
+
+You can combine cell coloring with validation to highlight invalid cells:
+
+```dart
+cellColorCallback: (cellColorContext) {
+  // Highlight validation errors
+  if (cellColorContext.cell.hasError) {
+    return Colors.red[100]!;
+  }
+  
+  // Your other coloring logic...
+  return null;
+}
+```
+
+## Best Practices
+
+1. **Use Subtle Colors**: Choose light background colors that don't interfere with text readability.
+
+2. **Maintain Contrast**: Ensure sufficient contrast between the text and background colors for accessibility.
+
+3. **Be Consistent**: Use colors consistently throughout your application to maintain a coherent user experience.
+
+4. **Consider Accessibility**: Keep in mind users with color vision deficiencies when choosing your color scheme.
+
+5. **Performance**: Keep your `cellColorCallback` logic efficient, especially for large datasets, as it will be called frequently during scrolling and updates.
+
+6. **Return null for Default**: Return `null` instead of a color when you want to use the default cell color to avoid unnecessary overrides.
+
+7. **Documentation**: Document the meaning of different colors in your application to help users understand the visual cues.
+
+## Complete Example
+
+Here's a complete example demonstrating cell coloring in TrinaGrid:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class CellColorExample extends StatefulWidget {
+  @override
+  _CellColorExampleState createState() => _CellColorExampleState();
+}
+
+class _CellColorExampleState extends State<CellColorExample> {
+  List<TrinaColumn> columns = [];
+  List<TrinaRow> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+    
+    columns = [
+      TrinaColumn(
+        title: 'Task',
+        field: 'task',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Priority',
+        field: 'priority',
+        type: TrinaColumnType.select(['High', 'Medium', 'Low']),
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select(['Completed', 'Pending', 'Cancelled']),
+      ),
+      TrinaColumn(
+        title: 'Score',
+        field: 'score',
+        type: TrinaColumnType.number(),
+      ),
+    ];
+
+    rows = [
+      TrinaRow(cells: {
+        'task': TrinaCell(value: 'Complete project'),
+        'priority': TrinaCell(value: 'High'),
+        'status': TrinaCell(value: 'Pending'),
+        'score': TrinaCell(value: 95),
+      }),
+      TrinaRow(cells: {
+        'task': TrinaCell(value: 'Review code'),
+        'priority': TrinaCell(value: 'Medium'),
+        'status': TrinaCell(value: 'Completed'),
+        'score': TrinaCell(value: 78),
+      }),
+      // Add more rows...
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Cell Color Example')),
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        cellColorCallback: (TrinaCellColorContext context) {
+          // Priority column coloring
+          if (context.column.field == 'priority') {
+            switch (context.cell.value) {
+              case 'High':
+                return Colors.red[100]!;
+              case 'Medium':
+                return Colors.orange[100]!;
+              case 'Low':
+                return Colors.green[100]!;
+            }
+          }
+          
+          // Status column coloring
+          if (context.column.field == 'status') {
+            switch (context.cell.value) {
+              case 'Completed':
+                return Colors.green[200]!;
+              case 'Pending':
+                return Colors.yellow[200]!;
+              case 'Cancelled':
+                return Colors.grey[200]!;
+            }
+          }
+          
+          // Score column coloring
+          if (context.column.field == 'score') {
+            final score = context.cell.value as num?;
+            if (score != null) {
+              if (score >= 90) return Colors.green[100]!;
+              if (score >= 70) return Colors.yellow[100]!;
+              if (score >= 50) return Colors.orange[100]!;
+              return Colors.red[100]!;
+            }
+          }
+          
+          return null; // Default color
+        },
+      ),
+    );
+  }
+}
+```
+
+This example demonstrates comprehensive cell coloring based on different column types and values, providing a rich visual experience for users.
+
+
+---
+
+## Lazy Pagination Events in TrinaGrid
+
+Trina Grid provides events to help you monitor and respond to lazy pagination operations. The most significant of these is the `onLazyFetchCompleted` event, which is triggered whenever a lazy pagination fetch operation completes.
+
+## Overview
+
+When using lazy pagination, you often need to know when data has been successfully loaded. The `onLazyFetchCompleted` event gives you this information, allowing you to:
+
+- Update UI elements based on loaded data
+- Track pagination statistics
+- Implement custom loading indicators
+- Perform additional operations after data is loaded
+- Log pagination information for analytics
+
+## Using onLazyFetchCompleted
+
+The `onLazyFetchCompleted` callback is available directly on the `TrinaGrid` widget:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLazyFetchCompleted: (event) {
+    // Handle the lazy fetch completed event
+    print('Fetch completed: page ${event.page} of ${event.totalPage}');
+    print('Total records: ${event.totalRecords}');
+  },
+  createFooter: (stateManager) {
+    return TrinaLazyPagination(
+      fetch: fetch,
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+## The TrinaGridOnLazyFetchCompletedEvent Object
+
+The `onLazyFetchCompleted` callback receives a `TrinaGridOnLazyFetchCompletedEvent` object containing information about the completed fetch operation:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `stateManager` | `TrinaGridStateManager` | Reference to the grid's state manager |
+| `page` | `int` | The current page number after fetch completed |
+| `totalPage` | `int` | The total number of pages available |
+| `totalRecords` | `int?` | The total number of records (if available) |
+
+### Example: Using the Event Object
+
+```dart
+onLazyFetchCompleted: (event) {
+  // Access pagination information
+  print('Current page: ${event.page}');
+  print('Total pages: ${event.totalPage}');
+  print('Total records: ${event.totalRecords ?? "Not available"}');
+  
+  // Calculate progress
+  final progress = (event.page / event.totalPage) * 100;
+  print('Pagination progress: ${progress.toStringAsFixed(1)}%');
+  
+  // Access state manager for additional operations
+  event.stateManager.setShowLoading(false);
+}
+```
+
+## Common Use Cases
+
+### Updating Loading Status
+
+```dart
+bool isLoading = false;
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLazyFetchCompleted: (event) {
+    // Update loading status
+    setState(() {
+      isLoading = false;
+    });
+  },
+  createFooter: (stateManager) {
+    // Show your custom loading indicator while fetching
+    if (isLoading) {
+      return CustomLoadingIndicator();
+    }
+    
+    return TrinaLazyPagination(
+      fetch: (request) {
+        setState(() {
+          isLoading = true;
+        });
+        return fetchData(request);
+      },
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+### Pagination Statistics
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLazyFetchCompleted: (event) {
+    // Update pagination statistics in UI
+    setState(() {
+      currentPage = event.page;
+      totalPages = event.totalPage;
+      totalRecords = event.totalRecords;
+    });
+  },
+  createFooter: (stateManager) {
+    return Column(
+      children: [
+        // Custom statistics display
+        Text('Showing page $currentPage of $totalPages (Total: $totalRecords records)'),
+        
+        // Standard pagination controls
+        TrinaLazyPagination(
+          fetch: fetch,
+          stateManager: stateManager,
+        ),
+      ],
+    );
+  },
+)
+```
+
+### Analytics Tracking
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  onLazyFetchCompleted: (event) {
+    // Log pagination analytics
+    analyticsService.logEvent(
+      'data_page_viewed',
+      parameters: {
+        'page_number': event.page,
+        'total_pages': event.totalPage,
+        'records_count': event.totalRecords,
+        'page_size': stateManager.pageSize,
+      },
+    );
+  },
+  createFooter: (stateManager) {
+    return TrinaLazyPagination(
+      fetch: fetch,
+      stateManager: stateManager,
+    );
+  },
+)
+```
+
+## Pagination Component Events
+
+In addition to the grid-level event, the `TrinaLazyPagination` component itself provides a similar callback:
+
+```dart
+TrinaLazyPagination(
+  fetch: fetch,
+  stateManager: stateManager,
+  onLazyFetchCompleted: (page, totalPage, totalRecords) {
+    // This is called at the pagination component level
+    print('Pagination component: page $page of $totalPage');
+  },
+)
+```
+
+This component-level callback is useful when you need to handle events specific to the pagination component itself, rather than at the grid level.
+
+## Complete Example
+
+Here's a complete example demonstrating the use of `onLazyFetchCompleted`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+class LazyPaginationEventExample extends StatefulWidget {
+  @override
+  _LazyPaginationEventExampleState createState() => _LazyPaginationEventExampleState();
+}
+
+class _LazyPaginationEventExampleState extends State<LazyPaginationEventExample> {
+  late List<TrinaColumn> columns;
+  late List<TrinaRow> rows;
+  late TrinaGridStateManager stateManager;
+  
+  // Pagination stats
+  int currentPage = 0;
+  int totalPages = 0;
+  int? totalRecords;
+  bool isLoading = false;
+  
+  @override
+  void initState() {
+    super.initState();
+    
+    // Define columns
+    columns = [
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+      ),
+      TrinaColumn(
+        title: 'Description',
+        field: 'description',
+        type: TrinaColumnType.text(),
+      ),
+    ];
+    
+    // Initial empty rows
+    rows = [];
+  }
+  
+  Future<TrinaLazyPaginationResponse> fetch(TrinaLazyPaginationRequest request) async {
+    setState(() {
+      isLoading = true;
+    });
+    
+    // Simulate API call with delay
+    await Future.delayed(Duration(milliseconds: 800));
+    
+    // Generate sample data
+    final fetchedRows = List.generate(
+      request.pageSize,
+      (index) => TrinaRow(
+        cells: {
+          'id': TrinaCell(value: (request.page - 1) * request.pageSize + index + 1),
+          'name': TrinaCell(value: 'Item ${(request.page - 1) * request.pageSize + index + 1}'),
+          'description': TrinaCell(value: 'Description for item ${(request.page - 1) * request.pageSize + index + 1}'),
+        },
+      ),
+    );
+    
+    return TrinaLazyPaginationResponse(
+      totalPage: 10,
+      rows: fetchedRows,
+      totalRecords: 100,
+    );
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Lazy Pagination Events'),
+      ),
+      body: Column(
+        children: [
+          // Stats display
+          Container(
+            padding: EdgeInsets.all(8),
+            color: Colors.grey[200],
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Page: $currentPage / $totalPages'),
+                Text('Total Records: ${totalRecords ?? "-"}'),
+                if (isLoading) CircularProgressIndicator(strokeWidth: 2),
+              ],
+            ),
+          ),
+          
+          // Grid with event handling
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (event) => stateManager = event.stateManager,
+              onLazyFetchCompleted: (event) {
+                // Update state with pagination information
+                setState(() {
+                  currentPage = event.page;
+                  totalPages = event.totalPage;
+                  totalRecords = event.totalRecords;
+                  isLoading = false;
+                });
+                
+                // Log pagination event
+                print('Fetch complete: Page $currentPage of $totalPages');
+                print('Total records: $totalRecords');
+              },
+              createFooter: (stateManager) {
+                return TrinaLazyPagination(
+                  initialPage: 1,
+                  initialPageSize: 10,
+                  showPageSizeSelector: true,
+                  pageSizes: [10, 20, 50, 100],
+                  fetch: fetch,
+                  stateManager: stateManager,
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Programmatically Changing Pages with Events
+
+In addition to the UI-based pagination controls, you can also programmatically change the current page using the `TrinaGridChangeLazyPageEvent`. This is useful when you need to:
+
+- Jump to a specific page based on user actions outside the grid
+- Refresh the current page without rebuilding the grid
+- Implement custom pagination controls
+
+### Using TrinaGridChangeLazyPageEvent
+
+```dart
+// Get a reference to the state manager (typically from onLoaded event)
+late TrinaGridStateManager stateManager;
+
+// To change to a specific page
+stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: 3));
+
+// To refresh the current page without changing it
+stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: null));
+```
+
+### Example: Custom Pagination Controls
+
+```dart
+class CustomPaginationControls extends StatelessWidget {
+  final TrinaGridStateManager stateManager;
+  final int totalPages;
+
+  const CustomPaginationControls({
+    required this.stateManager,
+    required this.totalPages,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        ElevatedButton(
+          onPressed: () {
+            // Jump to first page
+            stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: 1));
+          },
+          child: Text('First'),
+        ),
+        SizedBox(width: 8),
+        ElevatedButton(
+          onPressed: () {
+            // Jump to a specific page
+            final currentPage = stateManager.page;
+            if (currentPage > 1) {
+              stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: currentPage - 1));
+            }
+          },
+          child: Text('Previous'),
+        ),
+        SizedBox(width: 8),
+        Text('Page ${stateManager.page} of $totalPages'),
+        SizedBox(width: 8),
+        ElevatedButton(
+          onPressed: () {
+            // Jump to a specific page
+            final currentPage = stateManager.page;
+            if (currentPage < totalPages) {
+              stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: currentPage + 1));
+            }
+          },
+          child: Text('Next'),
+        ),
+        SizedBox(width: 8),
+        ElevatedButton( 
+          onPressed: () {
+            // Jump to last page
+            stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: totalPages));
+          },
+          child: Text('Last'),
+        ),
+        SizedBox(width: 16),
+        ElevatedButton(
+          onPressed: () {
+            // Refresh current page
+            stateManager.eventManager!.addEvent(TrinaGridChangeLazyPageEvent(page: null));
+          },
+          child: Text('Refresh'),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Related Features
+
+- For basic Lazy Pagination implementation, see [Lazy Pagination](lazy-pagination.md)
+- For client-side pagination, see [Client-Side Pagination](pagination-client.md)
+- For infinite scrolling, see [Infinity Scroll](infinite-scrolling.md)
+
+
+---
+
+## Migration Guides
+
+This directory contains guides to help you migrate to TrinaGrid from other data grid packages.
+
+## Available Migration Guides
+
+- [Migrating from PlutoGrid](pluto-to-trina.md): A comprehensive guide to migrating from PlutoGrid to TrinaGrid, including an automatic migration tool.
+- [Migration Tool Reference](migration-tool.md): A quick reference guide for using the TrinaGrid migration tool.
+
+## Migration Tool
+
+TrinaGrid includes a built-in migration tool that can automatically update your codebase. For more information, see the [PlutoGrid migration guide](pluto-to-trina.md) or the [Migration Tool Reference](migration-tool.md).
+
+## Need Help?
+
+If you encounter any issues during migration:
+
+- Check the detailed migration guides in this directory
+- Open an issue on the [TrinaGrid GitHub repository](https://github.com/doonfrs/trina_grid/issues)
+- Reach out to the maintainer [Feras Abdulrahman](https://github.com/doonfrs)
+
+
+---
+


### PR DESCRIPTION
## Summary

- Add `llm.txt` and `llms-full.txt` following the [llmstxt.org](https://llmstxt.org) standard for AI agent discoverability
- Add `--generate-llms` CLI command to auto-regenerate `llms-full.txt` from `doc/` files (auto-discovers new docs, ordered by `doc/index.md`)
- Link in README.md Documentation section, deploy to gh-pages, exclude large file from pub.dev package

## Test plan
- [x] `dart run bin/trina_grid.dart --generate-llms` generates `llms-full.txt` (50 files, ~15k lines)
- [ ] Verify `llm.txt` links resolve on GitHub
- [ ] Verify README link renders on GitHub