### PR TITLE
Fix: use decimal keyboard for numeric column filters

### DIFF
--- a/lib/src/ui/columns/trina_column_filter.dart
+++ b/lib/src/ui/columns/trina_column_filter.dart
@@ -328,7 +328,7 @@ class TrinaColumnFilterState extends TrinaStateWithChange<TrinaColumnFilter> {
             (widget.column.type is TrinaColumnTypeNumber ||
                     widget.column.type is TrinaColumnTypeCurrency ||
                     widget.column.type is TrinaColumnTypePercentage
-                ? TextInputType.number
+                ? const TextInputType.numberWithOptions(decimal: true)
                 : null),
         onTap: _handleOnTap,
         onChanged: _handleOnChanged,


### PR DESCRIPTION
## Summary
- Changed default keyboard type for number, currency, and percentage column filters from `TextInputType.number` to `TextInputType.numberWithOptions(decimal: true)`
- On mobile, `TextInputType.number` shows a keyboard without a decimal point button, making it impossible to filter by decimal values (e.g. prices like 12.50)
- The `filterWidgetDelegate.keyboardType` override still takes precedence, so this is backwards compatible

## Test plan
- Open a grid with a currency/number/percentage column filter on a mobile device
- Tap the filter field — keyboard should now show a decimal point button