### PR TITLE
fix: Use TrinaOptional for filterIconWidget in copyWith to allow null…

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -786,7 +786,7 @@ class TrinaGridStyleConfig {
     bool? enableCellBorderHorizontal,
     bool? enableRowColorAnimation,
     Icon? filterIcon,
-    Widget? filterIconWidget,
+    TrinaOptional<Widget?>? filterIconWidget,
     Color? gridBackgroundColor,
     Color? rowColor,
     TrinaOptional<Color?>? oddRowColor,
@@ -860,7 +860,9 @@ class TrinaGridStyleConfig {
         enableRowColorAnimation:
             enableRowColorAnimation ?? this.enableRowColorAnimation,
         filterIcon: filterIcon ?? this.filterIcon,
-        filterIconWidget: filterIconWidget ?? this.filterIconWidget,
+        filterIconWidget: filterIconWidget == null
+            ? this.filterIconWidget
+            : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
@@ -948,7 +950,9 @@ class TrinaGridStyleConfig {
         enableRowColorAnimation:
             enableRowColorAnimation ?? this.enableRowColorAnimation,
         filterIcon: filterIcon ?? this.filterIcon,
-        filterIconWidget: filterIconWidget ?? this.filterIconWidget,
+        filterIconWidget: filterIconWidget == null
+            ? this.filterIconWidget
+            : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,


### PR DESCRIPTION
… reset

The copyWith method used `??` for filterIconWidget, making it impossible to reset the value back to null once set. Changed to TrinaOptional<Widget?>? to match the pattern used by other nullable widget properties like columnAscendingIcon and columnDescendingIcon.