### PR TITLE
fix: filter popup column dropdown shows localized titles (#356)

### DIFF
--- a/lib/src/helper/filter_helper.dart
+++ b/lib/src/helper/filter_helper.dart
@@ -523,7 +523,10 @@ class FilterPopupState {
       TrinaColumn(
         title: configuration.localeText.filterColumn,
         field: FilterHelper.filterFieldColumn,
-        type: TrinaColumnType.select(columnMap.keys.toList(growable: false)),
+        type: TrinaColumnType.select(
+          columnMap.keys.toList(growable: false),
+          menuItemBuilder: (item) => Text(columnMap[item] ?? ''),
+        ),
         enableFilterMenuItem: false,
         applyFormatterInEditing: true,
         formatter: (dynamic value) {

--- a/test/src/helper/filter_helper_test.dart
+++ b/test/src/helper/filter_helper_test.dart
@@ -891,6 +891,31 @@ void main() {
         }
       });
 
+      // Regression for https://github.com/doonfrs/trina_grid/issues/356:
+      // dropdown items must render localized titles, not raw field names.
+      test('The first column of filterColumns should render dropdown items '
+          'with localized titles via menuItemBuilder.', () {
+        var filterColumn = filterColumns[0];
+        var columnType = filterColumn.type as TrinaColumnTypeSelect<String>;
+
+        expect(columnType.menuItemBuilder, isNotNull);
+
+        var allColumnsWidget = columnType.menuItemBuilder!(
+          FilterHelper.filterFieldAllColumns,
+        );
+        expect(allColumnsWidget, isA<Text>());
+        expect(
+          (allColumnsWidget as Text).data,
+          configuration.localeText.filterAllColumns,
+        );
+
+        for (var i = 0; i < columns.length; i += 1) {
+          var itemWidget = columnType.menuItemBuilder!(columns[i].field);
+          expect(itemWidget, isA<Text>());
+          expect((itemWidget as Text).data, columns[i].title);
+        }
+      });
+
       test('The second column of filterColumns should be select type.', () {
         var filterColumn = filterColumns[1];
 


### PR DESCRIPTION
Closes #356.

## Summary

- The column-selection dropdown in the filter popup (column header → "Set filter") was rendering raw field names (`trinaFilterAllColumns`, `foo`, …) instead of localized column titles.
- Root cause: in `_makeFilterColumns()` the column-selection `TrinaColumnType.select` was created with only a `formatter`. The formatter is consumed by the **closed cell** path (`formattedValueForDisplayInEditing`), but the **open dropdown** at `trina_dropdown_menu.dart` `_ItemListView` only consults `menuItemBuilder` / `itemToString` and falls back to `item.toString()` (the raw key) when both are absent.
- Fix: pass `menuItemBuilder: (item) => Text(columnMap[item] ?? '')` to the select type, mirroring the pattern already used by the sibling filter-type column at `filter_helper.dart:539`.

## Files

- `lib/src/helper/filter_helper.dart` — added `menuItemBuilder` to the column-selection `TrinaColumnType.select`.
- `test/src/helper/filter_helper_test.dart` — regression test under `FilterPopupState › makeColumns` that verifies `menuItemBuilder` is non-null and renders the localized title for `filterAllColumns` and each user column. Confirmed it fails without the fix and passes with it.

## Test plan

- [x] `dart format` clean on edited files.
- [x] `dart analyze` clean on edited files.
- [x] `flutter test` — full suite passes (1554 tests, +1 new regression test).
- [x] Regression test verified to fail when the fix is reverted (catches the bug).
- [ ] Manual: open filter popup → "Column" dropdown shows localized titles instead of raw keys.