### PR TITLE
fix: extend horizontal scroll past vertical scrollbar overlay (#355)

### DIFF
--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -211,68 +211,81 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
             child: Stack(
               fit: StackFit.expand,
               children: [
-                // Main grid content - takes full width
+                // Main grid content - takes full width.
+                // Extra trailing padding equal to the vertical scrollbar's
+                // footprint extends the horizontal scroll extent so the last
+                // column can be scrolled out from under the overlaid vertical
+                // scrollbar instead of being permanently covered by it.
                 (scrollConfig.smoothScrolling
                     ? TrinaSingleChildSmoothScrollView.new
                     : SingleChildScrollView.new)(
                   controller: _horizontalScroll,
                   scrollDirection: Axis.horizontal,
-                  child: CustomSingleChildLayout(
-                    delegate: ListResizeDelegate(stateManager, _columns),
-                    child: Column(
-                      children: [
-                        // Frozen top rows
-                        if (_frozenTopRows.isNotEmpty)
-                          Column(
-                            children: _frozenTopRows
-                                .asMap()
-                                .entries
-                                .map((e) => _buildRow(context, e.value, e.key))
-                                .toList(),
-                          ),
-                        // Scrollable rows
-                        Expanded(
-                          child:
-                              (scrollConfig.smoothScrolling
-                              ? TrinaSmoothListView.builder
-                              : ListView.builder)(
-                                cacheExtent: stateManager.rowsCacheExtent,
-                                controller: _verticalScroll,
-                                scrollDirection: Axis.vertical,
-                                itemCount: _scrollableRows.length,
-                                itemExtent:
-                                    (stateManager.rowWrapper != null &&
-                                        !stateManager
-                                            .configuration
-                                            .rowWrapperIsConstantHeight)
-                                    ? null
-                                    : stateManager.rowTotalHeight,
-                                addRepaintBoundaries: false,
-                                itemBuilder: (ctx, i) => _buildRow(
-                                  context,
-                                  _scrollableRows[i],
-                                  i + _frozenTopRows.length,
-                                ),
-                              ),
-                        ),
-                        // Frozen bottom rows
-                        if (_frozenBottomRows.isNotEmpty)
-                          Column(
-                            children: _frozenBottomRows
-                                .asMap()
-                                .entries
-                                .map(
-                                  (e) => _buildRow(
+                  child: Padding(
+                    padding: scrollConfig.showVertical
+                        ? EdgeInsetsDirectional.only(
+                            end: scrollConfig.thickness + 4,
+                          )
+                        : EdgeInsets.zero,
+                    child: CustomSingleChildLayout(
+                      delegate: ListResizeDelegate(stateManager, _columns),
+                      child: Column(
+                        children: [
+                          // Frozen top rows
+                          if (_frozenTopRows.isNotEmpty)
+                            Column(
+                              children: _frozenTopRows
+                                  .asMap()
+                                  .entries
+                                  .map(
+                                    (e) => _buildRow(context, e.value, e.key),
+                                  )
+                                  .toList(),
+                            ),
+                          // Scrollable rows
+                          Expanded(
+                            child:
+                                (scrollConfig.smoothScrolling
+                                ? TrinaSmoothListView.builder
+                                : ListView.builder)(
+                                  cacheExtent: stateManager.rowsCacheExtent,
+                                  controller: _verticalScroll,
+                                  scrollDirection: Axis.vertical,
+                                  itemCount: _scrollableRows.length,
+                                  itemExtent:
+                                      (stateManager.rowWrapper != null &&
+                                          !stateManager
+                                              .configuration
+                                              .rowWrapperIsConstantHeight)
+                                      ? null
+                                      : stateManager.rowTotalHeight,
+                                  addRepaintBoundaries: false,
+                                  itemBuilder: (ctx, i) => _buildRow(
                                     context,
-                                    e.value,
-                                    e.key +
-                                        _frozenTopRows.length +
-                                        _scrollableRows.length,
+                                    _scrollableRows[i],
+                                    i + _frozenTopRows.length,
                                   ),
-                                )
-                                .toList(),
+                                ),
                           ),
-                      ],
+                          // Frozen bottom rows
+                          if (_frozenBottomRows.isNotEmpty)
+                            Column(
+                              children: _frozenBottomRows
+                                  .asMap()
+                                  .entries
+                                  .map(
+                                    (e) => _buildRow(
+                                      context,
+                                      e.value,
+                                      e.key +
+                                          _frozenTopRows.length +
+                                          _scrollableRows.length,
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary

Closes #355.

The vertical scrollbar is overlaid on the right edge of the grid (via `Positioned(right: 0, top: 0, bottom: 0)` in the body Stack) instead of occupying its own column. As a result, the last column sat permanently underneath the scrollbar overlay and could not be scrolled into view.

Wraps the horizontally-scrolling content in a `Padding` with a trailing inset equal to the vertical scrollbar's footprint (`thickness + 4`). This extends `maxScrollExtent` so the user can scroll the last column out from under the overlaid scrollbar. Uses `EdgeInsetsDirectional.only(end: ...)` so RTL gets the inset on the leading (left) edge automatically.

No effect when `showVertical` is false — padding falls through to `EdgeInsets.zero`.