### PR TITLE
fix: correct RTL scrollbar positioning and drag direction

### DIFF
--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -290,10 +290,11 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                   ),
                 ),
 
-                // Vertical scrollbar overlaid on the right
+                // Vertical scrollbar overlaid on the trailing edge
+                // (right in LTR, left in RTL).
                 if (scrollConfig.showVertical)
-                  Positioned(
-                    right: 0,
+                  PositionedDirectional(
+                    end: 0,
                     top: 0,
                     bottom: 0,
                     child: LayoutBuilder(

--- a/lib/src/widgets/trina_horizontal_scroll_bar.dart
+++ b/lib/src/widgets/trina_horizontal_scroll_bar.dart
@@ -343,9 +343,17 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
                                     onHorizontalDragUpdate:
                                         scrollConfig.isDraggable
                                         ? (details) {
-                                            // Direct thumb manipulation approach
+                                            // Direct thumb manipulation approach.
+                                            // In RTL, the visual thumb position is
+                                            // mirrored (width - thumb - position),
+                                            // so a physical drag-right must
+                                            // *decrease* the underlying scroll
+                                            // offset to keep the thumb tracking
+                                            // the finger.
                                             final double dragDelta =
-                                                details.delta.dx;
+                                                widget.stateManager.isRTL
+                                                ? -details.delta.dx
+                                                : details.delta.dx;
 
                                             // Calculate how much to scroll based on thumb movement
                                             // The available space for the thumb to move is (widget.width - thumbWidth)


### PR DESCRIPTION
## Summary
- Vertical scrollbar overlay now uses `PositionedDirectional(end: 0)` so it sits on the right in LTR and on the left in RTL (matching the existing `EdgeInsetsDirectional` trailing content padding from #355).
- Horizontal scrollbar drag handler negates `details.delta.dx` in RTL so the thumb tracks the finger instead of feeling inverted (the displayed thumb position is mirrored as `width - thumb - position`, so a physical drag-right must decrease the underlying scroll offset).

## Test plan
- [ ] Open the **RTL Scrollbar Demo** screen and toggle to RTL: vertical scrollbar appears on the left edge.
- [ ] In RTL, drag the horizontal thumb right and confirm it tracks the finger and reveals content as expected (no mirrored feel).
- [ ] In RTL, tap on the horizontal track at various positions; the thumb still snaps to the tap (regression check — track-tap was already RTL-aware).
- [ ] Toggle back to LTR and confirm vertical scrollbar is back on the right and horizontal drag/tap still feel normal.