### PR TITLE
fix: TrinaCell not initialized after appending row while column hidden (#354)

### DIFF
--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -709,8 +709,11 @@ class _ApplyCellForSetColumnRow implements _Apply {
     }
 
     for (var element in refColumns) {
-      final cell = row.cells[element.field];
-      if (cell == null) continue;
+      var cell = row.cells[element.field];
+      if (cell == null) {
+        cell = TrinaCell(value: element.type.defaultValue);
+        row.cells[element.field] = cell;
+      }
       cell
         ..setColumn(element)
         ..setRow(row);

--- a/test/scenario/hide_columns/hide_column_test.dart
+++ b/test/scenario/hide_columns/hide_column_test.dart
@@ -266,4 +266,85 @@ void main() {
       },
     );
   });
+
+  group(
+    'Regression: appending a row while a column is hidden, then unhiding it',
+    () {
+      // https://github.com/doonfrs/trina_grid/issues/354
+      late List<TrinaColumn> columns;
+      late List<TrinaRow> rows;
+      late TrinaGridStateManager stateManager;
+
+      final hideThenAppendThenShow = TrinaWidgetTestHelper(
+        'hide column 1, append row with cells only for visible columns, '
+        'then unhide column 1',
+        (tester) async {
+          columns = [...ColumnHelper.textColumn('header', count: 3)];
+          rows = RowHelper.count(2, columns);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Material(
+                child: TrinaGrid(
+                  columns: columns,
+                  rows: rows,
+                  onLoaded: (TrinaGridOnLoadedEvent event) {
+                    stateManager = event.stateManager;
+                  },
+                ),
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          stateManager.hideColumn(columns[1], true);
+          await tester.pumpAndSettle();
+
+          stateManager.appendRows([
+            TrinaRow(
+              cells: {
+                columns[0].field: TrinaCell(value: 'a'),
+                columns[2].field: TrinaCell(value: 'c'),
+              },
+            ),
+          ]);
+          await tester.pumpAndSettle();
+
+          stateManager.hideColumn(columns[1], false);
+          await tester.pumpAndSettle();
+        },
+      );
+
+      hideThenAppendThenShow.test(
+        'the appended row has an initialized cell for the previously hidden column',
+        (tester) async {
+          final appendedRow = stateManager.refRows.last;
+          final hiddenFieldCell = appendedRow.cells[columns[1].field];
+
+          expect(hiddenFieldCell, isNotNull);
+          expect(hiddenFieldCell!.initialized, isTrue);
+          // Accessing column / row must not trip the initialization assertion.
+          expect(hiddenFieldCell.column.field, columns[1].field);
+          expect(hiddenFieldCell.row, same(appendedRow));
+        },
+      );
+
+      hideThenAppendThenShow.test(
+        'setCurrentCell on the previously hidden cell of the appended row '
+        'does not throw',
+        (tester) async {
+          final appendedRowIdx = stateManager.refRows.length - 1;
+          final appendedRow = stateManager.refRows[appendedRowIdx];
+          final hiddenFieldCell = appendedRow.cells[columns[1].field]!;
+
+          stateManager.setCurrentCell(hiddenFieldCell, appendedRowIdx);
+
+          await tester.pumpAndSettle();
+
+          expect(stateManager.currentCell, same(hiddenFieldCell));
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Fixes #354 — `TrinaCell is not initialized.` assertion thrown when interacting with a newly appended row after a previously hidden column is shown again.
- `_ApplyCellForSetColumnRow.execute` (called from every `initializeRows` path: initial load, `appendRows` / `prependRows` / `insertRows`, and the async variant) now auto-creates a default `TrinaCell` for any column in `refColumns` that the row's cells map is missing, instead of silently skipping it. This mirrors the existing `_fillCellsInRows` pattern in `column_state.dart` used when new columns are added.
- Added a regression test in `test/scenario/hide_columns/hide_column_test.dart` covering the exact scenario from the issue: hide column → `appendRows` with cells only for visible columns → unhide column → confirm the previously-hidden cell exists, is initialized, and `setCurrentCell` on it does not throw.

## Root cause

`_ApplyCellForSetColumnRow.execute` iterated `refColumns.originalList` (all columns including hidden) but `if (cell == null) continue;` silently skipped any column the user hadn't provided a cell for. So a row constructed as `TrinaRow(cells: { visibleA: ..., visibleC: ... })` while column B was hidden never got a cell for column B; when column B was later unhidden, render / interaction code tripped the assertion in `trina_cell.dart`.