### PR TITLE
feat: add per-row & per-cell text style callbacks

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -16,6 +16,7 @@ import 'screen/feature/add_and_remove_column_row_screen.dart';
 import 'screen/feature/add_rows_asynchronously.dart';
 import 'screen/feature/column_renderer_screen.dart';
 import 'screen/feature/cell_color_screen.dart';
+import 'screen/feature/cell_text_style_screen.dart';
 import 'screen/feature/cell_renderer_screen.dart';
 import 'screen/feature/cell_selection_screen.dart';
 import 'screen/feature/excel_like_selection_screen.dart';
@@ -89,6 +90,7 @@ class MyApp extends StatelessWidget {
         ColumnTitleRendererScreen.routeName: (context) =>
             const ColumnTitleRendererScreen(),
         CellColorScreen.routeName: (context) => const CellColorScreen(),
+        CellTextStyleScreen.routeName: (context) => const CellTextStyleScreen(),
         CellRendererScreen.routeName: (context) => const CellRendererScreen(),
         CellSelectionScreen.routeName: (context) => const CellSelectionScreen(),
         ExcelLikeSelectionScreen.routeName: (context) =>

--- a/demo/lib/screen/feature/cell_text_style_screen.dart
+++ b/demo/lib/screen/feature/cell_text_style_screen.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../widget/trina_example_button.dart';
+import '../../widget/trina_example_screen.dart';
+
+class CellTextStyleScreen extends StatefulWidget {
+  static const routeName = 'feature/cell-text-style';
+
+  const CellTextStyleScreen({super.key});
+
+  @override
+  State<CellTextStyleScreen> createState() => _CellTextStyleScreenState();
+}
+
+class _CellTextStyleScreenState extends State<CellTextStyleScreen> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+  TrinaGridStateManager? stateManager;
+
+  static const List<MapEntry<String, Color>> _colorOptions = [
+    MapEntry('Red', Colors.red),
+    MapEntry('Orange', Colors.orange),
+    MapEntry('Green', Colors.green),
+    MapEntry('Blue', Colors.blue),
+    MapEntry('Purple', Colors.purple),
+    MapEntry('Black', Colors.black),
+  ];
+
+  bool boldOverdueRows = true;
+  int highPriorityColorIdx = 0; // Red
+  int completedColorIdx = 2; // Green
+  int negativeBudgetColorIdx = 0; // Red
+
+  Color get _highPriorityColor => _colorOptions[highPriorityColorIdx].value;
+  Color get _completedColor => _colorOptions[completedColorIdx].value;
+  Color get _negativeBudgetColor => _colorOptions[negativeBudgetColorIdx].value;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 70,
+      ),
+      TrinaColumn(
+        title: 'Task',
+        field: 'task',
+        type: TrinaColumnType.text(),
+        width: 220,
+      ),
+      TrinaColumn(
+        title: 'Priority',
+        field: 'priority',
+        type: TrinaColumnType.select(<String>['High', 'Medium', 'Low']),
+        width: 110,
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select(<String>[
+          'Completed',
+          'Pending',
+          'Cancelled',
+        ]),
+        width: 120,
+      ),
+      TrinaColumn(
+        title: 'Budget',
+        field: 'budget',
+        type: TrinaColumnType.currency(),
+        width: 130,
+      ),
+      TrinaColumn(
+        title: 'Due Date',
+        field: 'due_date',
+        type: TrinaColumnType.date(),
+        width: 130,
+      ),
+    ]);
+
+    final today = DateTime.now();
+    rows.addAll([
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 1),
+          'task': TrinaCell(value: 'Fix login bug'),
+          'priority': TrinaCell(value: 'High'),
+          'status': TrinaCell(value: 'Pending'),
+          'budget': TrinaCell(value: 1500),
+          'due_date': TrinaCell(value: today.subtract(const Duration(days: 3))),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 2),
+          'task': TrinaCell(value: 'Update documentation'),
+          'priority': TrinaCell(value: 'Low'),
+          'status': TrinaCell(value: 'Completed'),
+          'budget': TrinaCell(value: 600),
+          'due_date': TrinaCell(value: today.subtract(const Duration(days: 8))),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 3),
+          'task': TrinaCell(value: 'Implement new feature'),
+          'priority': TrinaCell(value: 'Medium'),
+          'status': TrinaCell(value: 'Pending'),
+          'budget': TrinaCell(value: 4200),
+          'due_date': TrinaCell(value: today.add(const Duration(days: 5))),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 4),
+          'task': TrinaCell(value: 'Refund processing'),
+          'priority': TrinaCell(value: 'High'),
+          'status': TrinaCell(value: 'Pending'),
+          'budget': TrinaCell(value: -250),
+          'due_date': TrinaCell(value: today.subtract(const Duration(days: 1))),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 5),
+          'task': TrinaCell(value: 'Code review'),
+          'priority': TrinaCell(value: 'Medium'),
+          'status': TrinaCell(value: 'Completed'),
+          'budget': TrinaCell(value: 0),
+          'due_date': TrinaCell(value: today.subtract(const Duration(days: 2))),
+        },
+      ),
+      TrinaRow(
+        cells: {
+          'id': TrinaCell(value: 6),
+          'task': TrinaCell(value: 'Database migration'),
+          'priority': TrinaCell(value: 'Low'),
+          'status': TrinaCell(value: 'Cancelled'),
+          'budget': TrinaCell(value: 800),
+          'due_date': TrinaCell(value: today.add(const Duration(days: 10))),
+        },
+      ),
+    ]);
+  }
+
+  bool _isOverdue(TrinaRow row) {
+    final raw = row.cells['due_date']?.value;
+    final status = row.cells['status']?.value;
+    if (status == 'Completed' || status == 'Cancelled') return false;
+    // TrinaColumnType.date() stores the cell value as the formatted string
+    // ("yyyy-MM-dd" by default), so parse it back before comparing.
+    final due = raw is DateTime
+        ? raw
+        : DateTime.tryParse(raw?.toString() ?? '');
+    if (due == null) return false;
+    return due.isBefore(DateTime.now());
+  }
+
+  Widget _colorDropdown(int selectedIdx, ValueChanged<int> onChanged) {
+    return DropdownButton<int>(
+      value: selectedIdx,
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+      items: _colorOptions.asMap().entries.map((entry) {
+        return DropdownMenuItem<int>(
+          value: entry.key,
+          child: Row(
+            children: [
+              Container(
+                width: 16,
+                height: 16,
+                decoration: BoxDecoration(
+                  color: entry.value.value,
+                  borderRadius: BorderRadius.circular(3),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(entry.value.key),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _controlRow(String label, Widget control) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(width: 220, child: Text(label)),
+          control,
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaExampleScreen(
+      title: 'Cell text style',
+      topTitle: 'Cell text style',
+      topButtons: [
+        TrinaExampleButton(
+          url:
+              'https://github.com/doonfrs/trina_grid/blob/master/demo/lib/screen/feature/cell_text_style_screen.dart',
+        ),
+      ],
+      topContents: const [
+        Text(
+          'Customize the cell text style dynamically using rowTextStyleCallback and '
+          'cellTextStyleCallback. Each callback returns a TextStyle (typically with '
+          'just the fields you want to override) which is merged onto cellTextStyle.\n\n'
+          'Merge order: cellTextStyle (base) → rowTextStyleCallback → cellTextStyleCallback.\n'
+          'Cell-level styles win per-field. Returning null is a no-op.',
+        ),
+      ],
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Style settings',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    _controlRow(
+                      'Bold overdue rows (row-level):',
+                      Switch(
+                        value: boldOverdueRows,
+                        onChanged: (v) {
+                          setState(() => boldOverdueRows = v);
+                          // Cells listen to the state manager, not to the
+                          // parent's setState. Notify so they re-run the
+                          // text-style callbacks immediately.
+                          stateManager?.notifyListeners();
+                        },
+                      ),
+                    ),
+                    _controlRow(
+                      'High priority text color (cell-level):',
+                      _colorDropdown(highPriorityColorIdx, (i) {
+                        setState(() => highPriorityColorIdx = i);
+                        stateManager?.notifyListeners();
+                      }),
+                    ),
+                    _controlRow(
+                      'Completed status text color (cell-level):',
+                      _colorDropdown(completedColorIdx, (i) {
+                        setState(() => completedColorIdx = i);
+                        stateManager?.notifyListeners();
+                      }),
+                    ),
+                    _controlRow(
+                      'Negative budget text color (cell-level):',
+                      _colorDropdown(negativeBudgetColorIdx, (i) {
+                        setState(() => negativeBudgetColorIdx = i);
+                        stateManager?.notifyListeners();
+                      }),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (event) =>
+                  setState(() => stateManager = event.stateManager),
+              rowTextStyleCallback: (context) {
+                if (boldOverdueRows && _isOverdue(context.row)) {
+                  return const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontStyle: FontStyle.italic,
+                  );
+                }
+                return null;
+              },
+              cellTextStyleCallback: (context) {
+                final field = context.column.field;
+                final value = context.cell.value;
+
+                if (field == 'priority' && value == 'High') {
+                  return TextStyle(color: _highPriorityColor);
+                }
+                if (field == 'status' && value == 'Completed') {
+                  return TextStyle(color: _completedColor);
+                }
+                if (field == 'status' && value == 'Cancelled') {
+                  return const TextStyle(
+                    color: Colors.grey,
+                    decoration: TextDecoration.lineThrough,
+                  );
+                }
+                if (field == 'budget' && value is num && value < 0) {
+                  return TextStyle(color: _negativeBudgetColor);
+                }
+                return null;
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -26,6 +26,7 @@ import 'feature/add_and_remove_column_row_screen.dart';
 import 'feature/add_rows_asynchronously.dart';
 import 'feature/column_renderer_screen.dart';
 import 'feature/cell_color_screen.dart';
+import 'feature/cell_text_style_screen.dart';
 import 'feature/cell_renderer_screen.dart';
 import 'feature/cell_selection_screen.dart';
 import 'feature/excel_like_selection_screen.dart';
@@ -421,6 +422,14 @@ class _TrinaFeaturesState extends State<TrinaFeatures> {
             'Dynamically change the background color of individual cells.',
         onTapLiveDemo: () {
           Navigator.pushNamed(context, CellColorScreen.routeName);
+        },
+      ),
+      TrinaListTile(
+        title: 'Cell text style',
+        description:
+            'Dynamically change cell text style (color, weight, decoration) per row or per cell.',
+        onTapLiveDemo: () {
+          Navigator.pushNamed(context, CellTextStyleScreen.routeName);
         },
       ),
       TrinaListTile(

--- a/doc/features/cell-color.md
+++ b/doc/features/cell-color.md
@@ -369,3 +369,43 @@ class _CellColorExampleState extends State<CellColorExample> {
 ```
 
 This example demonstrates comprehensive cell coloring based on different column types and values, providing a rich visual experience for users.
+
+## Cell Text Style
+
+In addition to the cell background color, you can customize the **text style** for an individual cell via `cellTextStyleCallback`. The callback returns a `TextStyle?` that is merged on top of `TrinaGridStyleConfig.cellTextStyle` and any value returned by `rowTextStyleCallback`. Return `null` to leave the cell's text style unchanged.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  cellTextStyleCallback: (cellColorContext) {
+    final value = cellColorContext.cell.value;
+    if (value is num && value < 0) {
+      return const TextStyle(color: Colors.red);
+    }
+    return null;
+  },
+)
+```
+
+### Merge Order
+
+When both row- and cell-level text style callbacks are set, the styles are merged in this order:
+
+1. `TrinaGridStyleConfig.cellTextStyle` (base)
+2. `rowTextStyleCallback` result (if non-null)
+3. `cellTextStyleCallback` result (if non-null) — wins per-field
+
+Each callback only needs to set the fields it wants to override (typically `color`); all other fields remain inherited from the base.
+
+### Where the Style Is Applied
+
+- The default cell display widget.
+- The in-place editor for text-based typed cells (`text`, `number`, `currency`, `percentage`).
+- The closed (display) state of date / time / datetime popup cells.
+
+### Limitations
+
+- Cells using a custom renderer (`TrinaColumn.renderer` or `TrinaCell.renderer`) are not affected — those renderers fully own their look. If you need conditional styling for a custom renderer, do it inside the renderer.
+- For `TrinaSelectCell` / `TrinaBooleanCell`, the callback applies to the closed display state but not to the open menu trigger, which uses Material's `MenuStyle`.
+- For date / time popup cells, the resolved style is captured once when editing begins; mid-edit row mutations do not re-evaluate the callbacks for the editing field.

--- a/doc/features/row-color.md
+++ b/doc/features/row-color.md
@@ -295,8 +295,34 @@ class _RowColorExampleState extends State<RowColorExample> {
 }
 ```
 
+## Row Text Style
+
+In addition to the row background color, you can customize the **text style** for every cell in a row via `rowTextStyleCallback`. The callback returns a `TextStyle?` that is merged on top of `TrinaGridStyleConfig.cellTextStyle`. Return `null` to leave the row's text style unchanged.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  rowTextStyleCallback: (rowColorContext) {
+    final status = rowColorContext.row.cells['status']?.value;
+    if (status == 'urgent') {
+      return const TextStyle(color: Colors.red, fontWeight: FontWeight.bold);
+    }
+    return null;
+  },
+)
+```
+
+Notes:
+
+- Only specify the fields you want to override (typically `color`). All other fields are inherited from `cellTextStyle`.
+- If both `rowTextStyleCallback` and `cellTextStyleCallback` are set, the cell-level result is merged on top and wins per-field.
+- The style applies to the default cell display **and** to the in-place editor for text-based typed cells (text, number, currency, percentage, date, time).
+- Cells using `TrinaColumn.renderer` or `TrinaCell.renderer` are not affected — those renderers fully own their look.
+
 ## Related Features
 
+- [Cell Color & Text Style](cell-color.md)
 - [Row Selection](row-selection.md)
 - [Row Moving](row-moving.md)
 - [Row Checking](row-checking.md)

--- a/lib/src/manager/state/row_state.dart
+++ b/lib/src/manager/state/row_state.dart
@@ -52,6 +52,10 @@ abstract class IRowState {
 
   TrinaCellColorCallback? get cellColorCallback;
 
+  TrinaRowTextStyleCallback? get rowTextStyleCallback;
+
+  TrinaCellTextStyleCallback? get cellTextStyleCallback;
+
   int? getRowIdxByOffset(double offset);
 
   TrinaRow? getRowByIdx(int rowIdx);

--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -90,6 +90,8 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
     this.onColumnsMoved,
     this.rowColorCallback,
     this.cellColorCallback,
+    this.rowTextStyleCallback,
+    this.cellTextStyleCallback,
     this.selectDateCallback,
     this.createHeader,
     this.createFooter,
@@ -188,6 +190,12 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
 
   @override
   final TrinaCellColorCallback? cellColorCallback;
+
+  @override
+  final TrinaRowTextStyleCallback? rowTextStyleCallback;
+
+  @override
+  final TrinaCellTextStyleCallback? cellTextStyleCallback;
 
   @override
   final CreateHeaderCallBack? createHeader;
@@ -337,6 +345,8 @@ class TrinaGridStateManager extends TrinaGridStateChangeNotifier {
     super.onColumnsMoved,
     super.rowColorCallback,
     super.cellColorCallback,
+    super.rowTextStyleCallback,
+    super.cellTextStyleCallback,
     super.selectDateCallback,
     super.createHeader,
     super.createFooter,

--- a/lib/src/trina_dual_grid.dart
+++ b/lib/src/trina_dual_grid.dart
@@ -209,6 +209,8 @@ class TrinaDualGridState extends State<TrinaDualGrid> {
         noRowsWidget: props.noRowsWidget,
         rowColorCallback: props.rowColorCallback,
         cellColorCallback: props.cellColorCallback,
+        rowTextStyleCallback: props.rowTextStyleCallback,
+        cellTextStyleCallback: props.cellTextStyleCallback,
         columnMenuDelegate: props.columnMenuDelegate,
         configuration: props.configuration,
         mode: mode,
@@ -631,6 +633,12 @@ class TrinaDualGridProps {
   /// {@macro trina_grid_property_cellColorCallback}
   final TrinaCellColorCallback? cellColorCallback;
 
+  /// {@macro trina_grid_property_rowTextStyleCallback}
+  final TrinaRowTextStyleCallback? rowTextStyleCallback;
+
+  /// {@macro trina_grid_property_cellTextStyleCallback}
+  final TrinaCellTextStyleCallback? cellTextStyleCallback;
+
   /// {@macro trina_grid_property_columnMenuDelegate}
   final TrinaColumnMenuDelegate? columnMenuDelegate;
 
@@ -668,6 +676,8 @@ class TrinaDualGridProps {
     this.noRowsWidget,
     this.rowColorCallback,
     this.cellColorCallback,
+    this.rowTextStyleCallback,
+    this.cellTextStyleCallback,
     this.columnMenuDelegate,
     this.configuration = const TrinaGridConfiguration(),
     this.mode,
@@ -691,6 +701,8 @@ class TrinaDualGridProps {
     TrinaOptional<Widget?>? noRowsWidget,
     TrinaOptional<TrinaRowColorCallback?>? rowColorCallback,
     TrinaOptional<TrinaCellColorCallback?>? cellColorCallback,
+    TrinaOptional<TrinaRowTextStyleCallback?>? rowTextStyleCallback,
+    TrinaOptional<TrinaCellTextStyleCallback?>? cellTextStyleCallback,
     TrinaOptional<TrinaColumnMenuDelegate?>? columnMenuDelegate,
     TrinaGridConfiguration? configuration,
     TrinaOptional<TrinaGridMode?>? mode,
@@ -733,6 +745,12 @@ class TrinaDualGridProps {
       cellColorCallback: cellColorCallback == null
           ? this.cellColorCallback
           : cellColorCallback.value,
+      rowTextStyleCallback: rowTextStyleCallback == null
+          ? this.rowTextStyleCallback
+          : rowTextStyleCallback.value,
+      cellTextStyleCallback: cellTextStyleCallback == null
+          ? this.cellTextStyleCallback
+          : cellTextStyleCallback.value,
       columnMenuDelegate: columnMenuDelegate == null
           ? this.columnMenuDelegate
           : columnMenuDelegate.value,

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -58,6 +58,12 @@ typedef TrinaRowColorCallback =
 typedef TrinaCellColorCallback =
     Color? Function(TrinaCellColorContext cellColorContext);
 
+typedef TrinaRowTextStyleCallback =
+    TextStyle? Function(TrinaRowColorContext rowColorContext);
+
+typedef TrinaCellTextStyleCallback =
+    TextStyle? Function(TrinaCellColorContext cellColorContext);
+
 typedef TrinaSelectDateCallBack =
     Future<DateTime?> Function(TrinaCell dateCell, TrinaColumn column);
 
@@ -116,6 +122,8 @@ class TrinaGrid extends TrinaStatefulWidget {
     this.noRowsWidget,
     this.rowColorCallback,
     this.cellColorCallback,
+    this.rowTextStyleCallback,
+    this.cellTextStyleCallback,
     this.selectDateCallback,
     this.columnMenuDelegate,
     this.configuration = const TrinaGridConfiguration(),
@@ -408,6 +416,57 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// {@endtemplate}
   final TrinaCellColorCallback? cellColorCallback;
 
+  /// {@template trina_grid_property_rowTextStyleCallback}
+  /// [rowTextStyleCallback] can change the cell text style for every cell in a
+  /// row dynamically according to the state.
+  ///
+  /// Return a [TextStyle] (typically with only the fields you want to override,
+  /// such as `color`) and it will be merged on top of
+  /// [TrinaGridStyleConfig.cellTextStyle]. Return `null` to leave the text style
+  /// unchanged for that row.
+  ///
+  /// If both [rowTextStyleCallback] and [cellTextStyleCallback] are set,
+  /// [cellTextStyleCallback] is merged on top and wins per-field.
+  ///
+  /// The style is applied to the default cell display and to the in-place
+  /// editor for text-based typed cells (text, number, currency, percentage,
+  /// date, time). Cells that use [TrinaColumn.renderer] or [TrinaCell.renderer]
+  /// are not affected — those renderers fully own their look.
+  ///
+  /// ```dart
+  /// rowTextStyleCallback = (TrinaRowColorContext context) {
+  ///   return context.row.cells['status']?.value == 'urgent'
+  ///       ? const TextStyle(color: Colors.red, fontWeight: FontWeight.bold)
+  ///       : null;
+  /// };
+  /// ```
+  /// {@endtemplate}
+  final TrinaRowTextStyleCallback? rowTextStyleCallback;
+
+  /// {@template trina_grid_property_cellTextStyleCallback}
+  /// [cellTextStyleCallback] can change the cell text style for an individual
+  /// cell dynamically according to the state.
+  ///
+  /// Return a [TextStyle] (typically with only the fields you want to override)
+  /// and it will be merged on top of [TrinaGridStyleConfig.cellTextStyle] and
+  /// any value returned by [rowTextStyleCallback]. Return `null` to leave the
+  /// text style unchanged for that cell.
+  ///
+  /// The style is applied to the default cell display and to the in-place
+  /// editor for text-based typed cells. Cells using a custom renderer
+  /// (`TrinaColumn.renderer` / `TrinaCell.renderer`) are not affected.
+  ///
+  /// ```dart
+  /// cellTextStyleCallback = (TrinaCellColorContext context) {
+  ///   final value = context.cell.value;
+  ///   return value is num && value < 0
+  ///       ? const TextStyle(color: Colors.red)
+  ///       : null;
+  /// };
+  /// ```
+  /// {@endtemplate}
+  final TrinaCellTextStyleCallback? cellTextStyleCallback;
+
   final TrinaSelectDateCallBack? selectDateCallback;
 
   /// {@template trina_grid_property_columnMenuDelegate}
@@ -670,6 +729,8 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       onColumnsMoved: widget.onColumnsMoved,
       rowColorCallback: widget.rowColorCallback,
       cellColorCallback: widget.cellColorCallback,
+      rowTextStyleCallback: widget.rowTextStyleCallback,
+      cellTextStyleCallback: widget.cellTextStyleCallback,
       selectDateCallback: widget.selectDateCallback,
       createHeader: widget.createHeader,
       createFooter: widget.createFooter,

--- a/lib/src/trina_grid_popup.dart
+++ b/lib/src/trina_grid_popup.dart
@@ -59,6 +59,12 @@ class TrinaGridPopup {
   /// {@macro trina_grid_property_cellColorCallback}
   final TrinaCellColorCallback? cellColorCallback;
 
+  /// {@macro trina_grid_property_rowTextStyleCallback}
+  final TrinaRowTextStyleCallback? rowTextStyleCallback;
+
+  /// {@macro trina_grid_property_cellTextStyleCallback}
+  final TrinaCellTextStyleCallback? cellTextStyleCallback;
+
   /// {@macro trina_grid_property_columnMenuDelegate}
   final TrinaColumnMenuDelegate? columnMenuDelegate;
 
@@ -103,6 +109,8 @@ class TrinaGridPopup {
     this.noRowsWidget,
     this.rowColorCallback,
     this.cellColorCallback,
+    this.rowTextStyleCallback,
+    this.cellTextStyleCallback,
     this.columnMenuDelegate,
     this.configuration = const TrinaGridConfiguration(),
     this.mode = TrinaGridMode.normal,
@@ -168,6 +176,8 @@ class TrinaGridPopup {
                         noRowsWidget: noRowsWidget,
                         rowColorCallback: rowColorCallback,
                         cellColorCallback: cellColorCallback,
+                        rowTextStyleCallback: rowTextStyleCallback,
+                        cellTextStyleCallback: cellTextStyleCallback,
                         columnMenuDelegate: columnMenuDelegate,
                         configuration: configuration,
                         mode: mode,

--- a/lib/src/ui/cells/cell_text_style_resolver.dart
+++ b/lib/src/ui/cells/cell_text_style_resolver.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/widgets.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+/// Resolves the effective [TextStyle] for a cell by merging:
+///
+/// 1. [TrinaGridStyleConfig.cellTextStyle] (base, from configuration)
+/// 2. [TrinaGrid.rowTextStyleCallback] result (if non-null)
+/// 3. [TrinaGrid.cellTextStyleCallback] result (if non-null)
+///
+/// Each callback may return `null` to mean "no change". Non-null returns are
+/// merged via [TextStyle.merge], so callers typically only specify the fields
+/// they want to override (commonly just `color`).
+///
+/// [rowIdx] is optional: edit-mode cell widgets do not carry the visual row
+/// index, in which case it is resolved from `stateManager.refRows.indexOf(row)`.
+TextStyle resolveCellTextStyle({
+  required TrinaGridStateManager stateManager,
+  required TrinaRow row,
+  required TrinaCell cell,
+  required TrinaColumn column,
+  int? rowIdx,
+}) {
+  final base = stateManager.configuration.style.cellTextStyle;
+
+  final rowCallback = stateManager.rowTextStyleCallback;
+  final cellCallback = stateManager.cellTextStyleCallback;
+
+  if (rowCallback == null && cellCallback == null) {
+    return base;
+  }
+
+  final resolvedRowIdx = rowIdx ?? stateManager.refRows.indexOf(row);
+
+  final rowStyle = rowCallback?.call(
+    TrinaRowColorContext(
+      row: row,
+      rowIdx: resolvedRowIdx,
+      stateManager: stateManager,
+    ),
+  );
+
+  final cellStyle = cellCallback?.call(
+    TrinaCellColorContext(
+      cell: cell,
+      column: column,
+      row: row,
+      rowIdx: resolvedRowIdx,
+      stateManager: stateManager,
+    ),
+  );
+
+  return base.merge(rowStyle).merge(cellStyle);
+}

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:trina_grid/src/helper/platform_helper.dart';
+import 'package:trina_grid/src/ui/cells/cell_text_style_resolver.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 abstract class TextCell extends StatefulWidget {
@@ -281,7 +282,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
         onEditingComplete: _handleOnComplete,
         onSubmitted: (_) => _handleOnComplete(),
         onTap: _handleOnTap,
-        style: widget.stateManager.configuration.style.cellTextStyle,
+        style: resolveCellTextStyle(
+          stateManager: widget.stateManager,
+          row: widget.row,
+          cell: widget.cell,
+          column: widget.column,
+        ),
         decoration: const InputDecoration(
           border: InputBorder.none,
           contentPadding: EdgeInsets.zero,

--- a/lib/src/ui/cells/trina_default_cell.dart
+++ b/lib/src/ui/cells/trina_default_cell.dart
@@ -532,9 +532,12 @@ class _DefaultCellWidgetState extends State<_DefaultCellWidget> {
 
     return Text(
       _text,
-      style: widget.stateManager.configuration.style.cellTextStyle.copyWith(
-        decoration: TextDecoration.none,
-        fontWeight: FontWeight.normal,
+      style: resolveCellTextStyle(
+        stateManager: widget.stateManager,
+        row: widget.row,
+        cell: widget.cell,
+        column: widget.column,
+        rowIdx: widget.rowIdx,
       ),
       overflow: TextOverflow.ellipsis,
       textAlign: widget.column.textAlign.value,

--- a/lib/src/ui/miscellaneous/trina_popup_cell_state_with_custom_popup.dart
+++ b/lib/src/ui/miscellaneous/trina_popup_cell_state_with_custom_popup.dart
@@ -1,3 +1,4 @@
+import 'package:trina_grid/src/ui/cells/cell_text_style_resolver.dart';
 import 'package:trina_grid/src/ui/cells/popup_cell.dart';
 import 'package:flutter/material.dart';
 import 'package:trina_grid/src/widgets/trina_popup.dart';
@@ -26,7 +27,12 @@ abstract class TrinaPopupCellStateWithCustomPopup<T extends PopupCell>
       popupContent: popupContent,
       textFocus: textFocus,
       popupMenuIcon: popupMenuIcon,
-      cellTextStyle: widget.stateManager.configuration.style.cellTextStyle,
+      cellTextStyle: resolveCellTextStyle(
+        stateManager: widget.stateManager,
+        row: widget.row,
+        cell: widget.cell,
+        column: widget.column,
+      ),
       onOpenPopup: () => openPopup(context),
       onBeforePopup: () => popupVisibilityNotifier.value = true,
       onAfterPopup: (selectedValue) {

--- a/lib/src/ui/ui.dart
+++ b/lib/src/ui/ui.dart
@@ -1,3 +1,4 @@
+export 'cells/cell_text_style_resolver.dart';
 export 'cells/decimal_input_formatter.dart';
 export 'cells/trina_currency_cell.dart';
 export 'cells/trina_date_cell.dart';

--- a/test/scenario/configuration/text_style_callback_test.dart
+++ b/test/scenario/configuration/text_style_callback_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+
+/// Tests for the per-row / per-cell text-style callbacks (issue #344).
+void main() {
+  Future<TrinaGridStateManager> pumpGrid(
+    WidgetTester tester, {
+    TrinaRowTextStyleCallback? rowTextStyleCallback,
+    TrinaCellTextStyleCallback? cellTextStyleCallback,
+    TrinaGridConfiguration configuration = const TrinaGridConfiguration(),
+  }) async {
+    final columns = ColumnHelper.textColumn('header', count: 3);
+    final rows = RowHelper.count(3, columns);
+
+    late TrinaGridStateManager stateManager;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TrinaGrid(
+            columns: columns,
+            rows: rows,
+            onLoaded: (event) => stateManager = event.stateManager,
+            rowTextStyleCallback: rowTextStyleCallback,
+            cellTextStyleCallback: cellTextStyleCallback,
+            configuration: configuration,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return stateManager;
+  }
+
+  TextStyle styleForText(WidgetTester tester, String value) {
+    final widget = tester.widget<Text>(find.text(value));
+    return widget.style!;
+  }
+
+  testWidgets('rowTextStyleCallback applies to every cell in matched row', (
+    tester,
+  ) async {
+    await pumpGrid(
+      tester,
+      rowTextStyleCallback: (ctx) =>
+          ctx.rowIdx == 1 ? const TextStyle(color: Colors.red) : null,
+    );
+
+    expect(styleForText(tester, 'header0 value 1').color, Colors.red);
+    expect(styleForText(tester, 'header1 value 1').color, Colors.red);
+    expect(styleForText(tester, 'header2 value 1').color, Colors.red);
+    expect(styleForText(tester, 'header0 value 0').color, isNot(Colors.red));
+  });
+
+  testWidgets('cellTextStyleCallback overrides rowTextStyleCallback per cell', (
+    tester,
+  ) async {
+    await pumpGrid(
+      tester,
+      rowTextStyleCallback: (_) => const TextStyle(color: Colors.red),
+      cellTextStyleCallback: (ctx) => ctx.column.field == 'header1'
+          ? const TextStyle(color: Colors.green)
+          : null,
+    );
+
+    expect(styleForText(tester, 'header0 value 0').color, Colors.red);
+    expect(styleForText(tester, 'header1 value 0').color, Colors.green);
+    expect(styleForText(tester, 'header2 value 0').color, Colors.red);
+  });
+
+  testWidgets('returning null falls back to configured cellTextStyle', (
+    tester,
+  ) async {
+    const baseStyle = TextStyle(color: Color(0xFF112233), fontSize: 17);
+    await pumpGrid(
+      tester,
+      configuration: const TrinaGridConfiguration(
+        style: TrinaGridStyleConfig(cellTextStyle: baseStyle),
+      ),
+      rowTextStyleCallback: (_) => null,
+      cellTextStyleCallback: (_) => null,
+    );
+
+    final style = styleForText(tester, 'header0 value 0');
+    expect(style.color, baseStyle.color);
+    expect(style.fontSize, baseStyle.fontSize);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #344.

Adds `rowTextStyleCallback` and `cellTextStyleCallback` as siblings to the existing row/cell color callbacks. Lets callers dynamically style cell text (color, weight, decoration, etc.) without writing a full custom renderer.

```dart
TrinaGrid(
  columns: columns,
  rows: rows,
  rowTextStyleCallback: (ctx) => ctx.row.cells['status']?.value == 'urgent'
      ? const TextStyle(color: Colors.red, fontWeight: FontWeight.bold)
      : null,
  cellTextStyleCallback: (ctx) {
    final v = ctx.cell.value;
    return v is num && v < 0 ? const TextStyle(color: Colors.red) : null;
  },
)
```

- Each callback returns `TextStyle?`; `null` is a no-op.
- Merge order: `cellTextStyle` (base) → `rowTextStyleCallback` → `cellTextStyleCallback`. Cell-level wins per field, so callers only specify the fields they want to override.
- Applied at the default cell display, the in-place editor for text/number/currency/percentage cells, and the closed state of date/time popup cells.
- Cells using `TrinaColumn.renderer` / `TrinaCell.renderer` are unaffected — those renderers fully own their look.

## Changes

- New typedefs and fields on `TrinaGrid`, `TrinaDualGridProps`, `TrinaGridPopup`, plumbed through `TrinaGridStateManager` + `IRowState`.
- New helper `lib/src/ui/cells/cell_text_style_resolver.dart` centralizes the merge logic.
- Demo screen at `demo/lib/screen/feature/cell_text_style_screen.dart` with live controls.
- Docs appended to `doc/features/row-color.md` and `doc/features/cell-color.md`.
- Tests in `test/scenario/configuration/text_style_callback_test.dart`.

## Test plan

- [x] `dart format` clean
- [x] `dart analyze` clean
- [x] `flutter test` (1559 tests pass)
- [x] Manual smoke test in the demo: toggle bold on overdue rows, change priority/status/budget cell colors, confirm custom renderers are unaffected