### PR TITLE
feat: add scaleOnlyFlexibleColumns option to scale only columns without explicit widths

### DIFF
--- a/bin/trina_grid.dart
+++ b/bin/trina_grid.dart
@@ -382,8 +382,9 @@ void generateLlmsFull() {
   // Build a map of relative path -> File for quick lookup
   final fileMap = <String, File>{};
   for (final file in allDocFiles) {
-    final relativePath =
-        path.relative(file.path, from: docDir.path).replaceAll('\\', '/');
+    final relativePath = path
+        .relative(file.path, from: docDir.path)
+        .replaceAll('\\', '/');
     fileMap[relativePath] = file;
   }
 
@@ -403,13 +404,16 @@ void generateLlmsFull() {
   }
 
   // Append any .md files not referenced in index.md
-  final remainingPaths = fileMap.keys
-      .where((p) =>
-          !processedPaths.contains(p) &&
-          p != 'index.md' &&
-          !p.startsWith('contributing/'))
-      .toList()
-    ..sort();
+  final remainingPaths =
+      fileMap.keys
+          .where(
+            (p) =>
+                !processedPaths.contains(p) &&
+                p != 'index.md' &&
+                !p.startsWith('contributing/'),
+          )
+          .toList()
+        ..sort();
   finalOrder.addAll(remainingPaths);
 
   // 4. Extract header from llm.txt (everything before the first ## section)
@@ -421,8 +425,7 @@ void generateLlmsFull() {
   final buffer = StringBuffer();
 
   // Write header with modified H1
-  final headerWithoutH1 =
-      header.replaceFirst(RegExp(r'^# .+'), '').trimLeft();
+  final headerWithoutH1 = header.replaceFirst(RegExp(r'^# .+'), '').trimLeft();
   buffer.writeln('# TrinaGrid - Complete Documentation');
   buffer.writeln();
   buffer.write(headerWithoutH1);
@@ -447,8 +450,9 @@ void generateLlmsFull() {
         final linkPath = match.group(1)!;
         final anchor = match.group(2) ?? '';
         // Resolve the relative path
-        final resolved =
-            path.normalize('doc/$docRelDir/$linkPath').replaceAll('\\', '/');
+        final resolved = path
+            .normalize('doc/$docRelDir/$linkPath')
+            .replaceAll('\\', '/');
         return ']($baseUrl/$resolved$anchor)';
       },
     );
@@ -471,7 +475,9 @@ void generateLlmsFull() {
 
   outputFile.writeAsStringSync(buffer.toString());
   final lineCount = buffer.toString().split('\n').length;
-  print('Generated llms-full.txt ($filesProcessed doc files, $lineCount lines)');
+  print(
+    'Generated llms-full.txt ($filesProcessed doc files, $lineCount lines)',
+  );
 }
 
 void printUsage() {
@@ -483,9 +489,7 @@ void printUsage() {
   print(
     '  --migrate-from-pluto-grid  Migrate your codebase from PlutoGrid to TrinaGrid',
   );
-  print(
-    '  --generate-llms            Generate llms-full.txt from doc/ files',
-  );
+  print('  --generate-llms            Generate llms-full.txt from doc/ files');
   print('');
   print('Examples:');
   print('  flutter pub run trina_grid --migrate-from-pluto-grid');

--- a/doc/features/column-resizing.md
+++ b/doc/features/column-resizing.md
@@ -43,6 +43,8 @@ All columns are sized equally, regardless of their content.
 
 Columns are sized proportionally based on their current widths.
 
+By default, all columns participate in the scaling. However, you can use the `scaleOnlyFlexibleColumns` option to exclude columns that have an explicitly set width from the scaling. This is useful when you want some columns (like an ID column) to maintain a fixed width while others grow to fill available space.
+
 ## How to Configure Column Resizing
 
 ### Basic Configuration
@@ -82,6 +84,48 @@ final List<TrinaColumn> columns = [
   ),
 ];
 ```
+
+### Scaling Only Flexible Columns
+
+When using `TrinaAutoSizeMode.scale`, you can choose to only scale columns that don't have an explicitly set width. This is controlled by the `scaleOnlyFlexibleColumns` option in `TrinaGridColumnSizeConfig`.
+
+By default, `scaleOnlyFlexibleColumns` is `false`, which maintains backward compatibility — all columns participate in scaling. When set to `true`, only columns without an explicit `width:` parameter will be scaled proportionally, while columns with explicit widths maintain their declared sizes.
+
+```dart
+final List<TrinaColumn> columns = [
+  TrinaColumn(
+    title: 'ID',
+    field: 'id',
+    type: TrinaColumnType.number(),
+    width: 80,  // Explicit width — will NOT scale when scaleOnlyFlexibleColumns: true
+  ),
+  TrinaColumn(
+    title: 'Name',
+    field: 'name',
+    type: TrinaColumnType.text(),
+    // No explicit width — WILL scale when scaleOnlyFlexibleColumns: true
+  ),
+  TrinaColumn(
+    title: 'Email',
+    field: 'email',
+    type: TrinaColumnType.text(),
+    // No explicit width — WILL scale when scaleOnlyFlexibleColumns: true
+  ),
+];
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    columnSize: TrinaGridColumnSizeConfig(
+      autoSizeMode: TrinaAutoSizeMode.scale,
+      scaleOnlyFlexibleColumns: true,  // Only scale columns without explicit widths
+    ),
+  ),
+)
+```
+
+In this example, the ID column stays at 80px, while the Name and Email columns divide the remaining space proportionally.
 
 ### Using the State Manager
 

--- a/lib/src/manager/state/column_sizing_state.dart
+++ b/lib/src/manager/state/column_sizing_state.dart
@@ -94,7 +94,11 @@ mixin ColumnSizingState implements ITrinaGridState {
     return TrinaAutoSizeHelper.items<TrinaColumn>(
       maxSize: maxWidth,
       items: columns,
-      isSuppressed: (e) => e.suppressedAutoSize,
+      isSuppressed: (e) =>
+          e.suppressedAutoSize ||
+          (columnSizeConfig.scaleOnlyFlexibleColumns &&
+              columnsAutoSizeMode.isScale &&
+              e.hasExplicitWidth),
       getItemSize: (e) => e.width,
       getItemMinSize: (e) => e.minWidth,
       setItemSize: (e, size) => e.width = size,

--- a/lib/src/model/trina_column.dart
+++ b/lib/src/model/trina_column.dart
@@ -41,6 +41,8 @@ class TrinaColumn {
 
   double minWidth;
 
+  bool hasExplicitWidth;
+
   /// Customisable title padding.
   /// It takes precedence over defaultColumnTitlePadding in TrinaGridConfiguration.
   EdgeInsets? titlePadding;
@@ -292,7 +294,7 @@ class TrinaColumn {
     required this.type,
     this.readOnly = false,
     TrinaColumnCheckReadOnly? checkReadOnly,
-    this.width = TrinaGridSettings.columnWidth,
+    double? width,
     this.minWidth = TrinaGridSettings.minColumnWidth,
     this.titlePadding,
     this.filterPadding,
@@ -330,7 +332,9 @@ class TrinaColumn {
     this.editCellRenderer,
     this.filterEnterKeyAction,
     this.metadata,
-  }) : _key = UniqueKey(),
+  }) : width = width ?? TrinaGridSettings.columnWidth,
+       hasExplicitWidth = width != null,
+       _key = UniqueKey(),
        _checkReadOnly = checkReadOnly;
 
   final Key _key;

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -1453,6 +1453,7 @@ class TrinaGridColumnSizeConfig {
     this.restoreAutoSizeAfterMoveColumn = true,
     this.restoreAutoSizeAfterInsertColumn = true,
     this.restoreAutoSizeAfterRemoveColumn = true,
+    this.scaleOnlyFlexibleColumns = false,
   });
 
   /// Automatically change the column width.
@@ -1486,6 +1487,12 @@ class TrinaGridColumnSizeConfig {
   /// and the state after change is maintained.
   final bool restoreAutoSizeAfterRemoveColumn;
 
+  /// When using [TrinaAutoSizeMode.scale], only columns without an explicitly set width
+  /// participate in the scaling. Columns with an explicit width are kept at their declared widths.
+  /// This is determined by whether the column was constructed with a `width:` parameter.
+  /// Default is false, which maintains backward compatibility (all columns scale).
+  final bool scaleOnlyFlexibleColumns;
+
   TrinaGridColumnSizeConfig copyWith({
     TrinaAutoSizeMode? autoSizeMode,
     TrinaResizeMode? resizeMode,
@@ -1494,6 +1501,7 @@ class TrinaGridColumnSizeConfig {
     bool? restoreAutoSizeAfterMoveColumn,
     bool? restoreAutoSizeAfterInsertColumn,
     bool? restoreAutoSizeAfterRemoveColumn,
+    bool? scaleOnlyFlexibleColumns,
   }) {
     return TrinaGridColumnSizeConfig(
       autoSizeMode: autoSizeMode ?? this.autoSizeMode,
@@ -1511,6 +1519,8 @@ class TrinaGridColumnSizeConfig {
       restoreAutoSizeAfterRemoveColumn:
           restoreAutoSizeAfterRemoveColumn ??
           this.restoreAutoSizeAfterRemoveColumn,
+      scaleOnlyFlexibleColumns:
+          scaleOnlyFlexibleColumns ?? this.scaleOnlyFlexibleColumns,
     );
   }
 
@@ -1530,7 +1540,8 @@ class TrinaGridColumnSizeConfig {
             restoreAutoSizeAfterInsertColumn ==
                 other.restoreAutoSizeAfterInsertColumn &&
             restoreAutoSizeAfterRemoveColumn ==
-                other.restoreAutoSizeAfterRemoveColumn;
+                other.restoreAutoSizeAfterRemoveColumn &&
+            scaleOnlyFlexibleColumns == other.scaleOnlyFlexibleColumns;
   }
 
   @override
@@ -1542,6 +1553,7 @@ class TrinaGridColumnSizeConfig {
     restoreAutoSizeAfterMoveColumn,
     restoreAutoSizeAfterInsertColumn,
     restoreAutoSizeAfterRemoveColumn,
+    scaleOnlyFlexibleColumns,
   );
 }
 

--- a/test/scenario/column_sizing_scale_flexible_test.dart
+++ b/test/scenario/column_sizing_scale_flexible_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  group('Column Sizing - Scale Only Flexible Columns', () {
+    testWidgets(
+      'With scaleOnlyFlexibleColumns: true, explicit-width columns stay fixed while flexible columns scale',
+      (WidgetTester tester) async {
+        const double gridWidth = 600.0;
+        const double explicitWidth = 80.0;
+
+        final List<TrinaColumn> columns = [
+          TrinaColumn(
+            title: 'ID',
+            field: 'id',
+            type: TrinaColumnType.number(),
+            width: explicitWidth, // Explicit width
+          ),
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            // No explicit width - should scale
+          ),
+          TrinaColumn(
+            title: 'Email',
+            field: 'email',
+            type: TrinaColumnType.text(),
+            // No explicit width - should scale
+          ),
+        ];
+
+        final List<TrinaRow> rows = [
+          TrinaRow(
+            cells: {
+              'id': TrinaCell(value: 1),
+              'name': TrinaCell(value: 'Alice'),
+              'email': TrinaCell(value: 'alice@example.com'),
+            },
+          ),
+        ];
+
+        final widget = MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: gridWidth,
+              height: 600,
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                configuration: const TrinaGridConfiguration(
+                  columnSize: TrinaGridColumnSizeConfig(
+                    autoSizeMode: TrinaAutoSizeMode.scale,
+                    scaleOnlyFlexibleColumns: true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        await tester.pumpAndSettle();
+
+        // The ID column should be at its explicit width (80)
+        expect(columns[0].width, equals(explicitWidth));
+
+        // The Name and Email columns should share the remaining space proportionally
+        // Available width accounts for scrollbar and padding (~16px), so 600 - 16 = 584
+        // Remaining after ID = 584 - 80 = 504
+        // Each flexible column should get 504 / 2 = 252
+        const expectedFlexibleWidth = 252.0;
+
+        expect(columns[1].width, closeTo(expectedFlexibleWidth, 1.0));
+        expect(columns[2].width, closeTo(expectedFlexibleWidth, 1.0));
+      },
+    );
+
+    testWidgets(
+      'With scaleOnlyFlexibleColumns: false (default), all columns scale',
+      (WidgetTester tester) async {
+        const double gridWidth = 600.0;
+
+        final List<TrinaColumn> columns = [
+          TrinaColumn(
+            title: 'ID',
+            field: 'id',
+            type: TrinaColumnType.number(),
+            width: 80.0, // Explicit width
+          ),
+          TrinaColumn(
+            title: 'Name',
+            field: 'name',
+            type: TrinaColumnType.text(),
+            // Default width
+          ),
+          TrinaColumn(
+            title: 'Email',
+            field: 'email',
+            type: TrinaColumnType.text(),
+            // Default width
+          ),
+        ];
+
+        final List<TrinaRow> rows = [
+          TrinaRow(
+            cells: {
+              'id': TrinaCell(value: 1),
+              'name': TrinaCell(value: 'Alice'),
+              'email': TrinaCell(value: 'alice@example.com'),
+            },
+          ),
+        ];
+
+        final widget = MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: gridWidth,
+              height: 600,
+              child: TrinaGrid(
+                columns: columns,
+                rows: rows,
+                configuration: const TrinaGridConfiguration(
+                  columnSize: TrinaGridColumnSizeConfig(
+                    autoSizeMode: TrinaAutoSizeMode.scale,
+                    scaleOnlyFlexibleColumns: false, // Default behavior
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        await tester.pumpAndSettle();
+
+        // All columns should scale proportionally based on their initial widths
+        // Total initial width = 80 + 200 + 200 = 480
+        // Available width = 584 (accounting for scrollbar and padding)
+        // Scale factor = 584 / 480 = 1.21666...
+        // ID column: 80 * 1.21666... = 97.33
+        // Name column: 200 * 1.21666... = 243.33
+        // Email column: 200 * 1.21666... = 243.33
+
+        expect(columns[0].width, closeTo(97.33, 1.0));
+        expect(columns[1].width, closeTo(243.33, 1.0));
+        expect(columns[2].width, closeTo(243.33, 1.0));
+      },
+    );
+
+    testWidgets('hasExplicitWidth is set correctly on columns', (
+      WidgetTester tester,
+    ) async {
+      final List<TrinaColumn> columns = [
+        TrinaColumn(
+          title: 'ID',
+          field: 'id',
+          type: TrinaColumnType.number(),
+          width: 80.0, // Explicit width
+        ),
+        TrinaColumn(
+          title: 'Name',
+          field: 'name',
+          type: TrinaColumnType.text(),
+          // No explicit width
+        ),
+      ];
+
+      // Column with explicit width should have hasExplicitWidth = true
+      expect(columns[0].hasExplicitWidth, isTrue);
+
+      // Column without explicit width should have hasExplicitWidth = false
+      expect(columns[1].hasExplicitWidth, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #342

## Summary
Implements feature request to make TrinaAutoSizeMode.scale only scale columns without an explicitly set width.

## Changes
- Add hasExplicitWidth tracking to TrinaColumn to distinguish developer-set widths from defaults
- Add scaleOnlyFlexibleColumns configuration option (default false) to TrinaGridColumnSizeConfig  
- Update column sizing state to suppress explicit-width columns from scaling when flag is enabled
- Maintain backward compatibility: existing code uses default false and scales all columns
- Add comprehensive tests verifying the feature works for both enabled and disabled states
- Update documentation with examples

## Test Plan
- [x] All new tests pass (scaleOnlyFlexibleColumns: true/false behavior verified)
- [x] All existing tests pass (backward compatibility maintained)
- [x] Code analysis passes with no errors
- [x] Code formatting verified