### PR TITLE
fix: prevent contextMenuIcon drag in custom titleRenderer (#318)

### DIFF
--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -238,9 +238,12 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
   /// Builds the context menu widget, wrapping it with gesture detectors.
   ///
   /// If [hasTitleRenderer] is true, the widget is also wrapped in a
-  /// [GestureDetector] to absorb tap events. This prevents the tap from
-  /// propagating to the parent `_SortableWidget`, which would otherwise
-  /// trigger a column sort when the context menu icon is clicked.
+  /// [GestureDetector] that absorbs tap and horizontal-drag gestures. The tap
+  /// absorption prevents the parent `_SortableWidget` from triggering a sort
+  /// when the icon is clicked. The horizontal-drag absorption claims the pan
+  /// gesture in the arena so the parent `_DraggableWidget` cannot start a
+  /// column-reorder drag from the icon — matching the default header layout,
+  /// where the icon sits outside the draggable subtree (see #318).
   Widget _buildContextMenuWidget(
     Widget contextMenuIcon, {
     bool hasTitleRenderer = false,
@@ -260,6 +263,9 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
       return GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () {}, // Absorb the tap to prevent sorting.
+        onHorizontalDragStart: (_) {},
+        onHorizontalDragUpdate: (_) {},
+        onHorizontalDragEnd: (_) {},
         child: listener,
       );
     }

--- a/test/src/ui/columns/trina_column_title_test.dart
+++ b/test/src/ui/columns/trina_column_title_test.dart
@@ -648,6 +648,50 @@ void main() {
 
       expect(columnTitleDraggableFinder, findsOneWidget);
     });
+    testWidgets(
+      'WHEN titleRenderer embeds contextMenuIcon AND a horizontal drag '
+      'starts on that icon, THEN no column-reorder Draggable feedback '
+      'should appear (#318)',
+      (tester) async {
+        final column = buildColumn(
+          enableColumnDrag: true,
+          title: originalTitleText,
+          titleRenderer: (ctx) => Row(
+            children: [
+              Expanded(child: Text(ctx.column.title)),
+              if (ctx.showContextIcon) ctx.contextMenuIcon,
+            ],
+          ),
+        );
+        await buildGrid(tester, columns: [column]);
+
+        final iconFinder = find.descendant(
+          of: find.byType(TrinaColumnTitle),
+          matching: find.byType(IconButton),
+        );
+        expect(iconFinder, findsOneWidget);
+
+        // Manually drive the gesture so we can inspect the widget tree
+        // mid-drag. Releasing the pointer would tear down any Draggable
+        // feedback before we could observe it.
+        final gesture = await tester.startGesture(
+          tester.getCenter(iconFinder),
+        );
+        // kTouchSlop is 18 px; move well past it so any pan recognizer
+        // (including the parent Draggable) would have claimed by now.
+        for (var i = 0; i < 20; i++) {
+          await gesture.moveBy(const Offset(8, 0));
+          await tester.pump();
+        }
+
+        // If column-reorder erroneously kicked in, the Draggable would
+        // mount its feedback (TrinaShadowContainer) into the overlay.
+        expect(find.byType(TrinaShadowContainer), findsNothing);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+      },
+    );
     testWidgets('When enableSorting is false and titleRender is provided, '
         'GestureDetector widget should not exist', (tester) async {
       final column = buildColumn(


### PR DESCRIPTION
## Summary

- Closes #318.
- When a custom `TrinaColumn.titleRenderer` embeds the provided `rendererContext.contextMenuIcon`, dragging the icon was triggering the column-reorder `Draggable` instead of behaving like the standard built-in column icon.
- Root cause: the user's title (icon included) is wrapped wholesale by `_DraggableWidget`, while the existing `GestureDetector` around the icon only absorbed `onTap`. Nothing claimed pan, so the parent `Draggable<TrinaColumn>` won the gesture arena.
- Fix: add empty `onHorizontalDrag{Start,Update,End}` handlers to the same `GestureDetector` so the descendant claims horizontal pan and starves the parent's recognizer. The inner `Listener` for column resize / tap-to-open-menu is unaffected (it fires on raw pointer events outside the gesture arena).
- Single-file change in [lib/src/ui/columns/trina_column_title.dart](https://github.com/doonfrs/trina_grid/blob/fix/issue-318-context-menu-icon-drag/lib/src/ui/columns/trina_column_title.dart) plus a regression test.

## Test plan

- [x] New regression test added in `test/src/ui/columns/trina_column_title_test.dart` — manually drives a horizontal gesture on the embedded `contextMenuIcon` mid-drag and asserts that no `TrinaShadowContainer` (Draggable feedback ghost) is mounted. Verified to fail without the fix and pass with it.
- [x] `flutter test test/src/ui/columns/trina_column_title_test.dart` — 42/42 pass.
- [x] `flutter test` (full suite) — 1560/1560 pass.
- [x] `dart analyze` — clean.