### PR TITLE
feat: add TrinaGrid.fitContent to auto-size grid to its rows

### DIFF
--- a/doc/features/fit-content.md
+++ b/doc/features/fit-content.md
@@ -1,0 +1,62 @@
+# Fit Content (Auto-Size to Rows)
+
+By default, `TrinaGrid` expands to fill its parent's height — placing it inside an unbounded layout (e.g. a `Column` without `Expanded`, a `Card`, a dialog) results in a layout error or an over-sized grid. The `fitContent` option lets the grid size itself to its rows instead.
+
+## Quick start
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  fitContent: true, // grid height = header + rows + footer + borders
+)
+```
+
+With `fitContent: true`, the grid no longer needs `Expanded`, an explicit `SizedBox`, or `IntrinsicHeight` from the surrounding code. It computes its content height from:
+
+- header (if `createHeader` is provided)
+- column titles, column groups, and column filter row (when visible)
+- the sum of every visible row's height (`row.height ?? configuration.style.rowHeight`)
+- column footer (if any column has a `footerRenderer`)
+- footer (if `createFooter` is provided)
+- internal dividers, plus the grid's outer padding
+
+## When to use it
+
+`fitContent` is intended for grids with a **bounded number of visible rows** placed inside layouts that don't supply a fixed height:
+
+- A grid inside a `Column` next to other widgets, scrolled by an outer `SingleChildScrollView`.
+- A grid in a `Card` or `Dialog` that should hug its content.
+- A grid in a `Column` of a `ListView` item.
+
+For data-heavy grids with hundreds of rows, leave `fitContent: false` (the default) and provide a bounded height via `Expanded`, `SizedBox`, or a `Container(height: …)` so the row virtualization in `ListView.builder` keeps doing its job.
+
+## Custom header / footer height
+
+When you supply `createHeader` or `createFooter`, the grid normally measures their actual height during layout. With `fitContent: true` the height has to be computed *before* layout runs, so the grid uses `stateManager.headerHeight` / `stateManager.footerHeight` instead. Set these from inside your callback:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  fitContent: true,
+  createHeader: (stateManager) {
+    stateManager.headerHeight = 48; // declare the header's height
+    return MyHeader();
+  },
+)
+```
+
+If you don't set these values, the grid falls back to `TrinaGridSettings.rowTotalHeight` (≈ 46 px). If your custom header/footer is taller, you'll see clipping or an oversized empty band — declaring the height explicitly avoids both.
+
+## Interaction with other features
+
+- **Filtering, sorting, pagination**: `fitContent` follows the visible row set (`stateManager.refRows`), so the grid resizes when the user filters, when a `TrinaPagination` page changes, or when `stateManager.setRowHeight` is called.
+- **Frozen rows / columns**: fully supported.
+- **`noRowsWidget`**: when there are no rows the body region collapses to zero height. If you need space for a "no rows" placeholder, leave `fitContent: false` and provide an explicit height.
+- **`scrollPhysics`**: vertical scrolling is normally unnecessary, but if a parent ever shrinks the grid below the computed height (e.g. a small dialog), the inner `ListView` still scrolls.
+
+## When *not* to use it
+
+- Grids with thousands of rows — you'll lose the virtualization that lets the grid stay smooth, since every row contributes to the computed height.
+- `TrinaDualGrid` — the dual grid forces tight constraints on its inner grids, so `fitContent` has no effect there.

--- a/doc/index.md
+++ b/doc/index.md
@@ -69,6 +69,7 @@ Welcome to the official documentation for TrinaGrid, a powerful data grid for Fl
 - [Custom Styling](features/custom-styling.md)
 - [Loading Options](features/loading-options.md)
 - [Scrollbars](features/scrollbars.md)
+- [Fit Content (Auto-Size)](features/fit-content.md)
 - [RTL Support](features/rtl-support.md)
 
 ### Other Features

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -132,6 +132,7 @@ class TrinaGrid extends TrinaStatefulWidget {
     this.onValidationFailed,
     this.onLazyFetchCompleted,
     this.scrollPhysics,
+    this.fitContent = false,
   });
 
   final double? rowsCacheExtent;
@@ -521,6 +522,26 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// ```
   final ScrollPhysics? scrollPhysics;
 
+  /// When `true`, the grid sizes its overall height to fit its content
+  /// (header + columns + rows + footer + borders) instead of expanding to
+  /// fill the parent. Use this when placing the grid inside a `Column`,
+  /// `Card`, dialog, or any unbounded-height parent without wrapping it
+  /// in `Expanded`.
+  ///
+  /// Defaults to `false` (the grid fills the parent's bounded height).
+  ///
+  /// Notes:
+  /// - For exact sizing with a custom [createHeader] or [createFooter], set
+  ///   `stateManager.headerHeight` / `stateManager.footerHeight` from inside
+  ///   your callback. If unset, a default of `TrinaGridSettings.rowTotalHeight`
+  ///   is assumed.
+  /// - The height is recomputed when row heights change
+  ///   (`TrinaGridStateManager.setRowHeight`) and when filtering or pagination
+  ///   alters the visible row set.
+  /// - When the parent constrains the grid below the computed height (e.g. a
+  ///   small dialog), vertical scrolling is preserved.
+  final bool fitContent;
+
   /// [setDefaultLocale] sets locale when [Intl] package is used in [TrinaGrid].
   ///
   /// {@template intl_default_locale}
@@ -849,186 +870,253 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
     return trinaEvent.isCharacter && hasAllowedModifier;
   }
 
+  /// Computes the inner height the [CustomMultiChildLayout] needs to lay out
+  /// its children when [TrinaGrid.fitContent] is enabled. This is the size
+  /// the inner [LayoutBuilder] receives, not the outer widget's height —
+  /// the surrounding [_GridContainer] adds `2 * style.gridPadding` of padding
+  /// to produce the final rendered size.
+  ///
+  /// Returns a non-finite or non-positive value when the inputs are nonsense;
+  /// callers fall back to the default constraint-based layout.
+  double _computeContentHeight() {
+    final style = widget.configuration.style;
+    final double border = style.gridBorderWidth;
+    final double cellHorizontalBorder = style.cellHorizontalBorderWidth;
+    final double defaultRowHeight = style.rowHeight;
+
+    double height = 0;
+
+    if (widget.createHeader != null) {
+      final double headerHeight = _stateManager.headerHeight > 0
+          ? _stateManager.headerHeight
+          : TrinaGridSettings.rowTotalHeight;
+      height += headerHeight + border; // header + header divider
+    }
+
+    if (_stateManager.showColumnGroups) {
+      height +=
+          _stateManager.columnGroupDepth(_stateManager.refColumnGroups) *
+          style.columnHeight;
+    }
+    if (_stateManager.showColumnTitle) {
+      height += style.columnHeight;
+    }
+    if (_stateManager.showColumnFilter) {
+      height += style.columnFilterHeight;
+    }
+
+    height += border; // column-row divider (always added in performLayout)
+
+    for (final row in _stateManager.refRows) {
+      height += (row.height ?? defaultRowHeight) + cellHorizontalBorder;
+    }
+
+    if (_stateManager.showColumnFooter) {
+      final double columnFooterHeight = _stateManager.columnFooterHeight > 0
+          ? _stateManager.columnFooterHeight
+          : TrinaGridSettings.rowTotalHeight;
+      height += columnFooterHeight + border;
+    }
+
+    if (widget.createFooter != null) {
+      final double footerHeight = _stateManager.footerHeight > 0
+          ? _stateManager.footerHeight
+          : TrinaGridSettings.rowTotalHeight;
+      height += footerHeight + border;
+    }
+
+    return height;
+  }
+
   @override
   Widget build(BuildContext context) {
+    Widget body = LayoutBuilder(
+      builder: (c, size) {
+        _stateManager.setLayout(size);
+
+        final style = _stateManager.style;
+
+        final bool showLeftFrozen =
+            _stateManager.showFrozenColumn &&
+            _stateManager.hasLeftFrozenColumns;
+
+        final bool showRightFrozen =
+            _stateManager.showFrozenColumn &&
+            _stateManager.hasRightFrozenColumns;
+
+        final bool showColumnRowDivider =
+            _stateManager.showColumnTitle || _stateManager.showColumnFilter;
+
+        final bool showColumnFooter = _stateManager.showColumnFooter;
+
+        return CustomMultiChildLayout(
+          key: _stateManager.gridKey,
+          delegate: TrinaGridLayoutDelegate(
+            _stateManager,
+            Directionality.of(context),
+          ),
+          children: [
+            /// Body columns and rows.
+            LayoutId(
+              id: _StackName.bodyRows,
+              child: TrinaBodyRows(_stateManager),
+            ),
+            LayoutId(
+              id: _StackName.bodyColumns,
+              child: TrinaBodyColumns(_stateManager),
+            ),
+
+            /// Body columns footer.
+            if (showColumnFooter)
+              LayoutId(
+                id: _StackName.bodyColumnFooters,
+                child: TrinaBodyColumnsFooter(stateManager),
+              ),
+
+            /// Left columns and rows.
+            if (showLeftFrozen) ...[
+              LayoutId(
+                id: _StackName.leftFrozenColumns,
+                child: TrinaLeftFrozenColumns(_stateManager),
+              ),
+              LayoutId(
+                id: _StackName.leftFrozenRows,
+                child: TrinaLeftFrozenRows(_stateManager),
+              ),
+              LayoutId(
+                id: _StackName.leftFrozenDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.vertical,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                  reverse: _stateManager.isRTL,
+                ),
+              ),
+              if (showColumnFooter)
+                LayoutId(
+                  id: _StackName.leftFrozenColumnFooters,
+                  child: TrinaLeftFrozenColumnsFooter(stateManager),
+                ),
+            ],
+
+            /// Right columns and rows.
+            if (showRightFrozen) ...[
+              LayoutId(
+                id: _StackName.rightFrozenColumns,
+                child: TrinaRightFrozenColumns(_stateManager),
+              ),
+              LayoutId(
+                id: _StackName.rightFrozenRows,
+                child: TrinaRightFrozenRows(_stateManager),
+              ),
+              LayoutId(
+                id: _StackName.rightFrozenDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.vertical,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                  reverse: !_stateManager.isRTL,
+                ),
+              ),
+              if (showColumnFooter)
+                LayoutId(
+                  id: _StackName.rightFrozenColumnFooters,
+                  child: TrinaRightFrozenColumnsFooter(stateManager),
+                ),
+            ],
+
+            /// Column and row divider.
+            if (showColumnRowDivider)
+              LayoutId(
+                id: _StackName.columnRowDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.horizontal,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                ),
+              ),
+
+            /// Header and divider.
+            if (_stateManager.showHeader) ...[
+              LayoutId(
+                id: _StackName.headerDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.horizontal,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                ),
+              ),
+              LayoutId(id: _StackName.header, child: _header!),
+            ],
+
+            /// Column footer divider.
+            if (showColumnFooter)
+              LayoutId(
+                id: _StackName.columnFooterDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.horizontal,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                ),
+              ),
+
+            /// Footer and divider.
+            if (_stateManager.showFooter) ...[
+              LayoutId(
+                id: _StackName.footerDivider,
+                child: TrinaShadowLine(
+                  axis: Axis.horizontal,
+                  color: style.gridBorderColor,
+                  shadow: style.enableGridBorderShadow,
+                  reverse: true,
+                ),
+              ),
+              LayoutId(id: _StackName.footer, child: _footer!),
+            ],
+
+            /// Loading screen.
+            if (_stateManager.showLoading)
+              LayoutId(
+                id: _StackName.loading,
+                child:
+                    _stateManager.customLoadingWidget ??
+                    TrinaLoading(
+                      level: _stateManager.loadingLevel,
+                      backgroundColor: style.gridBackgroundColor,
+                      indicatorColor: style.activatedBorderColor,
+                      text: _stateManager.localeText.loadingText,
+                      textStyle: style.cellTextStyle,
+                    ),
+              ),
+
+            /// NoRows
+            if (widget.noRowsWidget != null)
+              LayoutId(
+                id: _StackName.noRows,
+                child: TrinaNoRowsWidget(
+                  stateManager: _stateManager,
+                  child: widget.noRowsWidget!,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+
+    if (widget.fitContent) {
+      final double computed = _computeContentHeight();
+      if (computed.isFinite && computed > 0) {
+        body = SizedBox(height: computed, child: body);
+      }
+    }
+
     return FocusScope(
       onFocusChange: _stateManager.setKeepFocus,
       onKeyEvent: _handleGridFocusOnKey,
       child: _GridContainer(
         stateManager: _stateManager,
         scrollPhysics: widget.scrollPhysics,
-        child: LayoutBuilder(
-          builder: (c, size) {
-            _stateManager.setLayout(size);
-
-            final style = _stateManager.style;
-
-            final bool showLeftFrozen =
-                _stateManager.showFrozenColumn &&
-                _stateManager.hasLeftFrozenColumns;
-
-            final bool showRightFrozen =
-                _stateManager.showFrozenColumn &&
-                _stateManager.hasRightFrozenColumns;
-
-            final bool showColumnRowDivider =
-                _stateManager.showColumnTitle || _stateManager.showColumnFilter;
-
-            final bool showColumnFooter = _stateManager.showColumnFooter;
-
-            return CustomMultiChildLayout(
-              key: _stateManager.gridKey,
-              delegate: TrinaGridLayoutDelegate(
-                _stateManager,
-                Directionality.of(context),
-              ),
-              children: [
-                /// Body columns and rows.
-                LayoutId(
-                  id: _StackName.bodyRows,
-                  child: TrinaBodyRows(_stateManager),
-                ),
-                LayoutId(
-                  id: _StackName.bodyColumns,
-                  child: TrinaBodyColumns(_stateManager),
-                ),
-
-                /// Body columns footer.
-                if (showColumnFooter)
-                  LayoutId(
-                    id: _StackName.bodyColumnFooters,
-                    child: TrinaBodyColumnsFooter(stateManager),
-                  ),
-
-                /// Left columns and rows.
-                if (showLeftFrozen) ...[
-                  LayoutId(
-                    id: _StackName.leftFrozenColumns,
-                    child: TrinaLeftFrozenColumns(_stateManager),
-                  ),
-                  LayoutId(
-                    id: _StackName.leftFrozenRows,
-                    child: TrinaLeftFrozenRows(_stateManager),
-                  ),
-                  LayoutId(
-                    id: _StackName.leftFrozenDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.vertical,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                      reverse: _stateManager.isRTL,
-                    ),
-                  ),
-                  if (showColumnFooter)
-                    LayoutId(
-                      id: _StackName.leftFrozenColumnFooters,
-                      child: TrinaLeftFrozenColumnsFooter(stateManager),
-                    ),
-                ],
-
-                /// Right columns and rows.
-                if (showRightFrozen) ...[
-                  LayoutId(
-                    id: _StackName.rightFrozenColumns,
-                    child: TrinaRightFrozenColumns(_stateManager),
-                  ),
-                  LayoutId(
-                    id: _StackName.rightFrozenRows,
-                    child: TrinaRightFrozenRows(_stateManager),
-                  ),
-                  LayoutId(
-                    id: _StackName.rightFrozenDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.vertical,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                      reverse: !_stateManager.isRTL,
-                    ),
-                  ),
-                  if (showColumnFooter)
-                    LayoutId(
-                      id: _StackName.rightFrozenColumnFooters,
-                      child: TrinaRightFrozenColumnsFooter(stateManager),
-                    ),
-                ],
-
-                /// Column and row divider.
-                if (showColumnRowDivider)
-                  LayoutId(
-                    id: _StackName.columnRowDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.horizontal,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                    ),
-                  ),
-
-                /// Header and divider.
-                if (_stateManager.showHeader) ...[
-                  LayoutId(
-                    id: _StackName.headerDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.horizontal,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                    ),
-                  ),
-                  LayoutId(id: _StackName.header, child: _header!),
-                ],
-
-                /// Column footer divider.
-                if (showColumnFooter)
-                  LayoutId(
-                    id: _StackName.columnFooterDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.horizontal,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                    ),
-                  ),
-
-                /// Footer and divider.
-                if (_stateManager.showFooter) ...[
-                  LayoutId(
-                    id: _StackName.footerDivider,
-                    child: TrinaShadowLine(
-                      axis: Axis.horizontal,
-                      color: style.gridBorderColor,
-                      shadow: style.enableGridBorderShadow,
-                      reverse: true,
-                    ),
-                  ),
-                  LayoutId(id: _StackName.footer, child: _footer!),
-                ],
-
-                /// Loading screen.
-                if (_stateManager.showLoading)
-                  LayoutId(
-                    id: _StackName.loading,
-                    child:
-                        _stateManager.customLoadingWidget ??
-                        TrinaLoading(
-                          level: _stateManager.loadingLevel,
-                          backgroundColor: style.gridBackgroundColor,
-                          indicatorColor: style.activatedBorderColor,
-                          text: _stateManager.localeText.loadingText,
-                          textStyle: style.cellTextStyle,
-                        ),
-                  ),
-
-                /// NoRows
-                if (widget.noRowsWidget != null)
-                  LayoutId(
-                    id: _StackName.noRows,
-                    child: TrinaNoRowsWidget(
-                      stateManager: _stateManager,
-                      child: widget.noRowsWidget!,
-                    ),
-                  ),
-              ],
-            );
-          },
-        ),
+        child: body,
       ),
     );
   }

--- a/test/scenario/layout/fit_content_test.dart
+++ b/test/scenario/layout/fit_content_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../helper/test_helper_util.dart';
+
+void main() {
+  group('TrinaGrid fitContent', () {
+    late List<TrinaColumn> columns;
+    late List<TrinaRow> rows;
+
+    setUp(() {
+      columns = ColumnHelper.textColumn('column', count: 3);
+      rows = RowHelper.count(3, columns);
+    });
+
+    // For the no-header / no-footer / no-filter case the outer grid height
+    // is the inner CustomMultiChildLayout content plus 2 * gridPadding from
+    // _GridContainer's outer Padding.
+    //
+    // Inner content (no header/footer/groups/filter):
+    //   columnHeight                        (column titles)
+    // + gridBorderWidth                     (column-row divider)
+    // + rows * (rowHeight + cellHorizontalBorderWidth)
+    double expectedHeightFor(int rowCount) {
+      const style = TrinaGridStyleConfig();
+      final inner =
+          style.columnHeight +
+          style.gridBorderWidth +
+          rowCount * (style.rowHeight + style.cellHorizontalBorderWidth);
+      return inner + 2 * style.gridPadding;
+    }
+
+    testWidgets(
+      'sizes itself to its content inside an unbounded Column without throwing',
+      (tester) async {
+        await TestHelperUtil.changeWidth(
+          tester: tester,
+          width: 800,
+          height: 1000,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    const SizedBox(height: 50, child: Placeholder()),
+                    TrinaGrid(columns: columns, rows: rows, fitContent: true),
+                    const SizedBox(height: 50, child: Placeholder()),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        final gridSize = tester.getSize(find.byType(TrinaGrid));
+        expect(gridSize.height, expectedHeightFor(3));
+      },
+    );
+
+    testWidgets(
+      'works inside IntrinsicHeight without throwing the LayoutBuilder error',
+      (tester) async {
+        await TestHelperUtil.changeWidth(
+          tester: tester,
+          width: 800,
+          height: 1000,
+        );
+
+        // IntrinsicHeight only kicks in when its parent supplies loose
+        // height — wrap in SingleChildScrollView so this exercises the
+        // scenario from issue #218 where IntrinsicHeight previously threw
+        // "LayoutBuilder does not support returning intrinsic dimensions".
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: SingleChildScrollView(
+                child: IntrinsicHeight(
+                  child: TrinaGrid(
+                    columns: columns,
+                    rows: rows,
+                    fitContent: true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        final gridSize = tester.getSize(find.byType(TrinaGrid));
+        expect(gridSize.height, expectedHeightFor(3));
+      },
+    );
+
+    testWidgets('honors per-row TrinaRow.height when fitContent is enabled', (
+      tester,
+    ) async {
+      await TestHelperUtil.changeWidth(
+        tester: tester,
+        width: 800,
+        height: 1000,
+      );
+
+      // Replace the second row with a custom 100px row.
+      rows[1] = TrinaRow(cells: rows[1].cells, height: 100);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: SingleChildScrollView(
+              child: TrinaGrid(columns: columns, rows: rows, fitContent: true),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      const style = TrinaGridStyleConfig();
+      final inner =
+          style.columnHeight +
+          style.gridBorderWidth +
+          // two default rows + one 100px row
+          2 * (style.rowHeight + style.cellHorizontalBorderWidth) +
+          (100 + style.cellHorizontalBorderWidth);
+      final expected = inner + 2 * style.gridPadding;
+
+      final gridSize = tester.getSize(find.byType(TrinaGrid));
+      expect(gridSize.height, expected);
+    });
+
+    testWidgets('fitContent: false (default) still expands to parent height', (
+      tester,
+    ) async {
+      await TestHelperUtil.changeWidth(tester: tester, width: 800, height: 600);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: SizedBox(
+              height: 600,
+              child: TrinaGrid(columns: columns, rows: rows),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final gridSize = tester.getSize(find.byType(TrinaGrid));
+      expect(gridSize.height, 600);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #218.

`TrinaGrid` previously required a bounded-height ancestor (`Expanded`, `SizedBox`, etc.). Wrapping it in `IntrinsicHeight` failed with:

```
LayoutBuilder does not support returning intrinsic dimensions.
```

This adds a new `fitContent: bool = false` parameter. When enabled, the grid computes its own content height (header + columns + filter + rows + column footer + footer + dividers) and wraps the existing `LayoutBuilder` in a `SizedBox`, so the grid sizes to its content and works correctly inside `Column`, `Card`, dialogs, or `IntrinsicHeight` — no `Expanded` needed.

Default behavior (`fitContent: false`) is unchanged: parent-bounded, virtualized rows.

## Changes

- `lib/src/trina_grid.dart` — new `fitContent` field + `_computeContentHeight()` helper. When enabled, the inner layout chain is wrapped in `SizedBox(height: computed)`. Layout delegate, scrollbars, frozen columns, virtualization untouched.
- `test/scenario/layout/fit_content_test.dart` — 4 widget tests: shrink-wrap inside an unbounded `Column`, no-throw inside `IntrinsicHeight` (regression for #218), per-row `TrinaRow.height` honored, and `fitContent: false` default still expands to parent height.
- `doc/features/fit-content.md` (+ `doc/index.md` link) — usage, custom header/footer height caveat (set `stateManager.headerHeight` / `footerHeight` from `createHeader`/`createFooter`), and the limitations: large datasets lose virtualization benefits; `TrinaDualGrid` forces tight constraints on inner grids so `fitContent` has no effect there.

## Test plan

- [x] `dart analyze lib test` — no issues
- [x] `flutter test test/scenario/layout/` — 11/11 pass (4 new + 7 existing)
- [x] Pre-existing failures elsewhere reproduce on clean `main` and are unrelated