### PR TITLE
fix: dynamic row height not applied (#365)

### DIFF
--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -252,13 +252,22 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                                   controller: _verticalScroll,
                                   scrollDirection: Axis.vertical,
                                   itemCount: _scrollableRows.length,
-                                  itemExtent:
+                                  itemExtentBuilder:
                                       (stateManager.rowWrapper != null &&
                                           !stateManager
                                               .configuration
                                               .rowWrapperIsConstantHeight)
                                       ? null
-                                      : stateManager.rowTotalHeight,
+                                      : (index, _) =>
+                                            (_scrollableRows[index].height ??
+                                                stateManager
+                                                    .configuration
+                                                    .style
+                                                    .rowHeight) +
+                                            stateManager
+                                                .configuration
+                                                .style
+                                                .cellHorizontalBorderWidth,
                                   addRepaintBoundaries: false,
                                   itemBuilder: (ctx, i) => _buildRow(
                                     context,

--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -101,11 +101,17 @@ class TrinaLeftFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            itemExtent:
+            itemExtentBuilder:
                 (stateManager.rowWrapper != null &&
                     !stateManager.configuration.rowWrapperIsConstantHeight)
                 ? null
-                : stateManager.rowTotalHeight,
+                : (index, _) =>
+                      (_scrollableRows[index].height ??
+                          stateManager.configuration.style.rowHeight) +
+                      stateManager
+                          .configuration
+                          .style
+                          .cellHorizontalBorderWidth,
             itemBuilder: (ctx, i) =>
                 _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -101,11 +101,17 @@ class TrinaRightFrozenRowsState
             scrollDirection: Axis.vertical,
             physics: const ClampingScrollPhysics(),
             itemCount: _scrollableRows.length,
-            itemExtent:
+            itemExtentBuilder:
                 (stateManager.rowWrapper != null &&
                     !stateManager.configuration.rowWrapperIsConstantHeight)
                 ? null
-                : stateManager.rowTotalHeight,
+                : (index, _) =>
+                      (_scrollableRows[index].height ??
+                          stateManager.configuration.style.rowHeight) +
+                      stateManager
+                          .configuration
+                          .style
+                          .cellHorizontalBorderWidth,
             itemBuilder: (ctx, i) =>
                 _buildRow(ctx, _scrollableRows[i], i + _frozenTopRows.length),
           ),


### PR DESCRIPTION
## Summary
- Three row `ListView.builder` call sites used a fixed `itemExtent: stateManager.rowTotalHeight`, which makes `SliverFixedExtentList` force every row to the global default height — overriding `TrinaRow.height` and `stateManager.setRowHeight(...)`. The dynamic-row-height feature (originally shipped in 34283f1) silently broke when smooth scrolling (#235) and the frozen-column alignment fix (#293) re-introduced the static `itemExtent`.
- Switched the three sites to `itemExtentBuilder: (i, _) => (_scrollableRows[i].height ?? rowHeight) + cellHorizontalBorderWidth`, backed by `SliverVariedExtentList`. This restores per-row heights while keeping O(1) scroll math and identical per-index extents across body, left-frozen, and right-frozen lists — so the frozen/body alignment fix from #293 still holds.
- No new code: cell layout already reads `stateManager.getRowHeight(rowIdx)` per row, scroll-position math already iterates `getRowHeight(i)`, and `TrinaSmoothListView.builder` already supports `itemExtentBuilder`.

Closes #365

## Test plan
- [x] `dart format` + `dart analyze` clean
- [x] `flutter test` — same pass/fail count as `main` (the 13 pre-existing failures are unrelated)
- [ ] Demo → **Dynamic Row Height**: initial render shows rows 2/5/8/15/25/50/75 at their custom heights; `Set` / `Get` / `Reset` / `Reset All` buttons all take effect immediately
- [ ] Demo → **Frozen Columns**: scroll long lists; left/right frozen rows stay perfectly aligned with body rows (regression guard for #293)