### PR TITLE
unfocusedSelectionColor

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -385,6 +385,7 @@ class TrinaGridStyleConfig {
     this.filterIcon = const Icon(Icons.filter_alt_outlined),
     this.filterIconWidget,
     this.gridBackgroundColor = Colors.white,
+    this.unfocusedSelectionColor,
     this.rowColor = Colors.white,
     this.oddRowColor,
     this.evenRowColor,
@@ -470,6 +471,7 @@ class TrinaGridStyleConfig {
     this.filterIcon = const Icon(Icons.filter_alt_outlined),
     this.filterIconWidget,
     this.gridBackgroundColor = const Color(0xFF111111),
+    this.unfocusedSelectionColor,
     this.rowColor = const Color(0xFF111111),
     this.oddRowColor,
     this.evenRowColor,
@@ -582,6 +584,9 @@ class TrinaGridStyleConfig {
   final Widget? filterIconWidget;
 
   final Color gridBackgroundColor;
+
+  final Color? unfocusedSelectionColor;
+
 
   /// Default row background color
   ///
@@ -788,6 +793,7 @@ class TrinaGridStyleConfig {
     Icon? filterIcon,
     TrinaOptional<Widget?>? filterIconWidget,
     Color? gridBackgroundColor,
+    Color? unfocusedSelectionColor,
     Color? rowColor,
     TrinaOptional<Color?>? oddRowColor,
     TrinaOptional<Color?>? evenRowColor,
@@ -864,6 +870,7 @@ class TrinaGridStyleConfig {
             ? this.filterIconWidget
             : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
+        unfocusedSelectionColor: unfocusedSelectionColor??this.unfocusedSelectionColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
         evenRowColor: evenRowColor == null
@@ -954,6 +961,7 @@ class TrinaGridStyleConfig {
             ? this.filterIconWidget
             : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
+        unfocusedSelectionColor: unfocusedSelectionColor??this.unfocusedSelectionColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
         evenRowColor: evenRowColor == null
@@ -1102,6 +1110,7 @@ class TrinaGridStyleConfig {
     filterIcon,
     filterIconWidget,
     gridBackgroundColor,
+    unfocusedSelectionColor,
     rowColor,
     oddRowColor,
     evenRowColor,

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -446,7 +446,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
         activatedBorderColor: style.activatedBorderColor,
         activatedColor: style.activatedColor,
         inactivatedBorderColor: style.inactivatedBorderColor,
-        gridBackgroundColor: style.gridBackgroundColor,
+        unfocusedSelectionColor: style.unfocusedSelectionColor,
         cellColorInEditState: style.cellColorInEditState,
         cellColorInReadOnlyState: style.cellColorInReadOnlyState,
         cellColorGroupedRow: style.cellColorGroupedRow,
@@ -462,13 +462,13 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
     required bool hasFocus,
     required bool isEditing,
     required Color activatedColor,
-    required Color gridBackgroundColor,
+    Color? unfocusedSelectionColor,
     required Color cellColorInEditState,
     required Color cellColorInReadOnlyState,
     required TrinaGridSelectingMode selectingMode,
   }) {
     if (!hasFocus) {
-      return gridBackgroundColor;
+      return unfocusedSelectionColor;
     }
 
     if (!isEditing) {
@@ -506,7 +506,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
     required Color activatedBorderColor,
     required Color activatedColor,
     required Color inactivatedBorderColor,
-    required Color gridBackgroundColor,
+    Color? unfocusedSelectionColor,
     required Color cellColorInEditState,
     required Color cellColorInReadOnlyState,
     required Color? cellColorGroupedRow,
@@ -526,7 +526,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
                 hasFocus: hasFocus,
                 isEditing: isEditing,
                 readOnly: readOnly,
-                gridBackgroundColor: gridBackgroundColor,
+                unfocusedSelectionColor: unfocusedSelectionColor,
                 activatedColor: activatedColor,
                 cellColorInReadOnlyState: cellColorInReadOnlyState,
                 cellColorInEditState: cellColorInEditState,


### PR DESCRIPTION

Currently, in `TrinaGrid`, when a user selects a cell or a row and then clicks outside the grid (causing the grid to lose focus), the selected cell either retains its active, bright selection color or reverts to the default `gridBackgroundColor`. 

In complex desktop-like interfaces with multiple grids or panels, this creates a UX ambiguity. The user cannot visually distinguish which grid is currently active and receiving keyboard inputs, because the "selected" state looks the same whether the grid is focused or unfocused.

It would be extremely helpful to introduce an `unfocusedSelectionColor` (or similar property) in the grid's style/theme configuration. 

When the grid's internal `FocusNode` loses focus, the currently selected cell(s) should automatically transition to this "unfocused" color (e.g., a greyed-out or desaturated version of the primary selection color). When the grid regains focus, it should switch back to the active selection color.

**Proposed API idea:**
```dart
TrinaGrid(
  // ...
  configuration: TrinaGridConfiguration(
    selectionColor: Colors.blue, // Active focus color
    unfocusedSelectionColor: Colors.grey.shade300, // <-- New property
    gridBackgroundColor: Colors.white,
  ),
)