### PR TITLE
feat: enhance unfocusedSelectionColor (fallback, multi-cell selection, dark default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.0] - 2026. 05. 15
+
+* Feature: Added `unfocusedSelectionColor` to `TrinaGridStyleConfig` for visually distinguishing focused vs. unfocused grids in multi-grid layouts (#372). @vasco-feltrin
+* Enhancement: `unfocusedSelectionColor` now also applies to multi-cell selections (not just the current cell), and falls back to `gridBackgroundColor` when unset so existing apps see no behavior change. Dark theme ships with a sensible default. @doonfrs
+
 ## [2.2.2] - 2026. 05. 15
 
 * Feature: Added TrinaGrid.fitContent to auto-size grid to its rows (#218). @doonfrs

--- a/doc/features/cell-color.md
+++ b/doc/features/cell-color.md
@@ -370,6 +370,37 @@ class _CellColorExampleState extends State<CellColorExample> {
 
 This example demonstrates comprehensive cell coloring based on different column types and values, providing a rich visual experience for users.
 
+## Unfocused Selection Color
+
+When a `TrinaGrid` loses focus (for example, the user clicks into another grid or input on the page), the current cell and any multi-cell selection can switch to a desaturated color so it is visually obvious which grid is currently receiving keyboard input. This is configured via `TrinaGridStyleConfig.unfocusedSelectionColor`:
+
+```dart
+TrinaGrid(
+  configuration: TrinaGridConfiguration(
+    style: TrinaGridStyleConfig(
+      activatedColor: Colors.blue.shade100,        // focused state
+      unfocusedSelectionColor: Colors.grey.shade300, // unfocused state
+    ),
+  ),
+)
+```
+
+### Behavior
+
+- **Current cell, grid focused**: uses `activatedColor` (for row selecting mode) or no overlay (for cell selecting mode); unchanged from previous behavior.
+- **Current cell, grid unfocused**: uses `unfocusedSelectionColor` if set; otherwise falls back to `gridBackgroundColor` (matching pre-2.3.0 behavior, so existing apps see no visual change after upgrading).
+- **Multi-cell selection, grid focused**: uses `activatedColor`.
+- **Multi-cell selection, grid unfocused**: uses `unfocusedSelectionColor` if set; otherwise keeps `activatedColor`.
+
+### Defaults
+
+- Light theme (`TrinaGridStyleConfig()`): `null` (opt in by setting it explicitly).
+- Dark theme (`TrinaGridStyleConfig.dark()`): `Color(0xFF4A4A4A)`, a mid-grey that reads as "inactive" against the dark grid background.
+
+### Typical use case: multi-grid dashboards
+
+Apps that show several grids on one screen (master/detail panels, side-by-side comparison views) benefit most. Without this property, the "current cell" in every grid looks equally active; with it, only the focused grid stands out.
+
 ## Cell Text Style
 
 In addition to the cell background color, you can customize the **text style** for an individual cell via `cellTextStyleCallback`. The callback returns a `TextStyle?` that is merged on top of `TrinaGridStyleConfig.cellTextStyle` and any value returned by `rowTextStyleCallback`. Return `null` to leave the cell's text style unchanged.

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -471,7 +471,7 @@ class TrinaGridStyleConfig {
     this.filterIcon = const Icon(Icons.filter_alt_outlined),
     this.filterIconWidget,
     this.gridBackgroundColor = const Color(0xFF111111),
-    this.unfocusedSelectionColor,
+    this.unfocusedSelectionColor = const Color(0xFF4A4A4A),
     this.rowColor = const Color(0xFF111111),
     this.oddRowColor,
     this.evenRowColor,
@@ -585,8 +585,14 @@ class TrinaGridStyleConfig {
 
   final Color gridBackgroundColor;
 
+  /// Background color for the current cell (and selected cells) when the grid
+  /// loses focus.
+  ///
+  /// Useful in multi-grid layouts to visually distinguish which grid currently
+  /// holds keyboard focus. When `null`, the current cell falls back to
+  /// [gridBackgroundColor] on focus loss (matching pre-2.3.0 behavior) and
+  /// multi-cell selections keep their [activatedColor].
   final Color? unfocusedSelectionColor;
-
 
   /// Default row background color
   ///
@@ -870,7 +876,8 @@ class TrinaGridStyleConfig {
             ? this.filterIconWidget
             : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
-        unfocusedSelectionColor: unfocusedSelectionColor??this.unfocusedSelectionColor,
+        unfocusedSelectionColor:
+            unfocusedSelectionColor ?? this.unfocusedSelectionColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
         evenRowColor: evenRowColor == null
@@ -961,7 +968,8 @@ class TrinaGridStyleConfig {
             ? this.filterIconWidget
             : filterIconWidget.value,
         gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
-        unfocusedSelectionColor: unfocusedSelectionColor??this.unfocusedSelectionColor,
+        unfocusedSelectionColor:
+            unfocusedSelectionColor ?? this.unfocusedSelectionColor,
         rowColor: rowColor ?? this.rowColor,
         oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
         evenRowColor: evenRowColor == null

--- a/lib/src/ui/trina_base_cell.dart
+++ b/lib/src/ui/trina_base_cell.dart
@@ -446,6 +446,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
         activatedBorderColor: style.activatedBorderColor,
         activatedColor: style.activatedColor,
         inactivatedBorderColor: style.inactivatedBorderColor,
+        gridBackgroundColor: style.gridBackgroundColor,
         unfocusedSelectionColor: style.unfocusedSelectionColor,
         cellColorInEditState: style.cellColorInEditState,
         cellColorInReadOnlyState: style.cellColorInReadOnlyState,
@@ -462,13 +463,14 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
     required bool hasFocus,
     required bool isEditing,
     required Color activatedColor,
+    required Color gridBackgroundColor,
     Color? unfocusedSelectionColor,
     required Color cellColorInEditState,
     required Color cellColorInReadOnlyState,
     required TrinaGridSelectingMode selectingMode,
   }) {
     if (!hasFocus) {
-      return unfocusedSelectionColor;
+      return unfocusedSelectionColor ?? gridBackgroundColor;
     }
 
     if (!isEditing) {
@@ -506,6 +508,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
     required Color activatedBorderColor,
     required Color activatedColor,
     required Color inactivatedBorderColor,
+    required Color gridBackgroundColor,
     Color? unfocusedSelectionColor,
     required Color cellColorInEditState,
     required Color cellColorInReadOnlyState,
@@ -526,6 +529,7 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
                 hasFocus: hasFocus,
                 isEditing: isEditing,
                 readOnly: readOnly,
+                gridBackgroundColor: gridBackgroundColor,
                 unfocusedSelectionColor: unfocusedSelectionColor,
                 activatedColor: activatedColor,
                 cellColorInReadOnlyState: cellColorInReadOnlyState,
@@ -539,7 +543,11 @@ class _CellContainerState extends TrinaStateWithChange<_CellContainer> {
       );
     } else if (isSelectedCell) {
       return BoxDecoration(
-        color: isDirty ? dirtyColor : activatedColor,
+        color: isDirty
+            ? dirtyColor
+            : (hasFocus
+                  ? activatedColor
+                  : (unfocusedSelectionColor ?? activatedColor)),
         border: Border.all(
           color: hasFocus ? activatedBorderColor : inactivatedBorderColor,
           width: 1,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: trina_grid
 description: A data grid that can be controlled by the keyboard on desktop and web. Of course, it works well on Android and IOS. (DataGrid, DataTable, Data Grid, Data Table, Sticky)
-version: 2.2.2
+version: 2.3.0
 repository: https://github.com/doonfrs/trina_grid
 issue_tracker: https://github.com/doonfrs/trina_grid/issues
 

--- a/test/scenario/selecting/cell_color_focus_test.dart
+++ b/test/scenario/selecting/cell_color_focus_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/src/ui/trina_base_cell.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+
+/// Verifies how cell decoration responds to grid focus changes and the
+/// [TrinaGridStyleConfig.unfocusedSelectionColor] option.
+void main() {
+  Future<TrinaGridStateManager> pumpGrid(
+    WidgetTester tester, {
+    Color? unfocusedSelectionColor,
+    TrinaGridSelectingMode selectingMode = TrinaGridSelectingMode.cell,
+  }) async {
+    late TrinaGridStateManager stateManager;
+    final columns = ColumnHelper.textColumn('header', count: 3);
+    final rows = RowHelper.count(3, columns);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TrinaGrid(
+            columns: columns,
+            rows: rows,
+            configuration: TrinaGridConfiguration(
+              style: TrinaGridStyleConfig(
+                unfocusedSelectionColor: unfocusedSelectionColor,
+              ),
+            ),
+            onLoaded: (event) {
+              stateManager = event.stateManager;
+              stateManager.setSelectingMode(selectingMode);
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return stateManager;
+  }
+
+  Color? cellColorAt(WidgetTester tester, int index) {
+    final cellFinder = find.byType(TrinaBaseCell).at(index);
+    final decoration =
+        tester
+                .widget<DecoratedBox>(
+                  find.descendant(
+                    of: cellFinder,
+                    matching: find.byType(DecoratedBox),
+                  ),
+                )
+                .decoration
+            as BoxDecoration;
+    return decoration.color;
+  }
+
+  testWidgets(
+    'current cell falls back to gridBackgroundColor on focus loss when '
+    'unfocusedSelectionColor is not configured',
+    (tester) async {
+      final stateManager = await pumpGrid(tester);
+      final defaultGridBg = stateManager.style.gridBackgroundColor;
+
+      await tester.tap(find.byType(TrinaBaseCell).first);
+      await tester.pumpAndSettle();
+
+      stateManager.setKeepFocus(false);
+      await tester.pumpAndSettle();
+
+      expect(cellColorAt(tester, 0), defaultGridBg);
+    },
+  );
+
+  testWidgets(
+    'current cell uses unfocusedSelectionColor on focus loss when configured',
+    (tester) async {
+      const configured = Color(0xFF8E44AD);
+      final stateManager = await pumpGrid(
+        tester,
+        unfocusedSelectionColor: configured,
+      );
+
+      await tester.tap(find.byType(TrinaBaseCell).first);
+      await tester.pumpAndSettle();
+
+      stateManager.setKeepFocus(false);
+      await tester.pumpAndSettle();
+
+      expect(cellColorAt(tester, 0), configured);
+    },
+  );
+
+  testWidgets('multi-cell selection uses unfocusedSelectionColor on focus loss', (
+    tester,
+  ) async {
+    const configured = Color(0xFF8E44AD);
+    final stateManager = await pumpGrid(
+      tester,
+      unfocusedSelectionColor: configured,
+    );
+
+    stateManager.setCurrentCell(stateManager.rows[0].cells['header0'], 0);
+    stateManager.setCurrentSelectingPosition(
+      cellPosition: const TrinaGridCellPosition(columnIdx: 1, rowIdx: 1),
+    );
+    await tester.pumpAndSettle();
+
+    stateManager.setKeepFocus(false);
+    await tester.pumpAndSettle();
+
+    // Cell at row 1, column 1 is selected (not current). Index = row * cols + col.
+    expect(cellColorAt(tester, 1 * 3 + 1), configured);
+  });
+
+  testWidgets('multi-cell selection keeps activatedColor on focus loss when '
+      'unfocusedSelectionColor is not configured (regression guard)', (
+    tester,
+  ) async {
+    final stateManager = await pumpGrid(tester);
+    final activated = stateManager.style.activatedColor;
+
+    stateManager.setCurrentCell(stateManager.rows[0].cells['header0'], 0);
+    stateManager.setCurrentSelectingPosition(
+      cellPosition: const TrinaGridCellPosition(columnIdx: 1, rowIdx: 1),
+    );
+    await tester.pumpAndSettle();
+
+    stateManager.setKeepFocus(false);
+    await tester.pumpAndSettle();
+
+    expect(cellColorAt(tester, 1 * 3 + 1), activated);
+  });
+}


### PR DESCRIPTION
@
Builds on #372 (thanks @vasco-feltrin) and addresses three follow-ups:

## Summary

- **Restore default behavior on focus loss.** PR #372 changed the current cell to render with `BoxDecoration(color: null)` (transparent) when `unfocusedSelectionColor` is unset, which would change existing apps visually on upgrade. This PR re-introduces the `gridBackgroundColor` fallback so apps that do not configure the new property get the pre-PR-372 visuals back.
- **Extend to multi-cell selections.** The property is named `unfocusedSelectionColor` and the PR #372 description promised that "the currently selected cell(s) should automatically transition to this unfocused color". Previously only the single *current* cell honored it; the multi-cell `isSelectedCell` branch always used `activatedColor`. Now both honor the property when set, with `activatedColor` as the fallback so unset users see no change.
- **Dark theme default.** `TrinaGridStyleConfig.dark()` now defaults `unfocusedSelectionColor` to `Color(0xFF4A4A4A)` so dark-mode users get the focus-distinction UX out of the box. Light theme stays `null` (opt in).
- Polish: spaces around `??` in the two `copyWith`-style methods, drop the stray double blank line, add a dartdoc to the field.

Version bumped to **2.3.0**, changelog updated, contributor credited.

## Test plan

- [x] `dart format` clean
- [x] `dart analyze` clean
- [x] New tests in `test/scenario/selecting/cell_color_focus_test.dart` cover four cases:
  1. current cell, unfocused, no `unfocusedSelectionColor` set => falls back to `gridBackgroundColor`
  2. current cell, unfocused, `unfocusedSelectionColor` set => uses configured color
  3. multi-cell selection, unfocused, `unfocusedSelectionColor` set => uses configured color
  4. multi-cell selection, unfocused, no `unfocusedSelectionColor` => stays on `activatedColor` (regression guard)
- [x] All four tests pass; rest of `test/scenario/selecting/` still green
- [x] Pre-existing failing tests in `trina_dropdown_menu_test.dart`, `trina_time_picker_test.dart`, `trina_date_time_cell_test.dart` are unrelated to this change (verified by running them on `main` pre-changes)

## Docs

`doc/features/cell-color.md` gained an "Unfocused Selection Color" section covering behavior, defaults, and the multi-grid use case.
@