### PR TITLE
fix: default ShadTheme + outdated search tests

### DIFF
--- a/lib/src/ui/miscellaneous/trina_popup_cell_state_with_menu.dart
+++ b/lib/src/ui/miscellaneous/trina_popup_cell_state_with_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/model/trina_column_type_has_menu_popup.dart';
 import 'package:trina_grid/src/ui/cells/popup_cell.dart';
+import 'package:trina_grid/src/ui/widgets/ensure_shad_theme.dart';
 import 'package:trina_grid/src/ui/widgets/trina_default_popup_cell_editing_widget.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 
@@ -57,54 +58,62 @@ abstract class TrinaPopupCellStateWithMenu<T extends PopupCell> extends State<T>
   static const double _menuVerticalChrome = 16.0;
 
   @override
-  Widget get defaultEditWidget => Builder(
-    builder: (context) {
-      final shadTheme = ShadTheme.of(context);
-      final shadColors = shadTheme.colorScheme;
-      return MenuAnchor(
-        alignmentOffset: const Offset(-10, 5),
-        controller: menuController,
-        consumeOutsideTap: true,
-        style: MenuStyle(
-          backgroundColor: WidgetStatePropertyAll(shadColors.popover),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(
-              borderRadius: shadTheme.radius,
-              side: BorderSide(color: shadColors.border),
+  Widget get defaultEditWidget => EnsureShadTheme(
+    child: Builder(
+      builder: (context) {
+        final shadTheme = ShadTheme.of(context);
+        final shadColors = shadTheme.colorScheme;
+        return MenuAnchor(
+          alignmentOffset: const Offset(-10, 5),
+          controller: menuController,
+          consumeOutsideTap: true,
+          style: MenuStyle(
+            backgroundColor: WidgetStatePropertyAll(shadColors.popover),
+            shape: WidgetStatePropertyAll(
+              RoundedRectangleBorder(
+                borderRadius: shadTheme.radius,
+                side: BorderSide(color: shadColors.border),
+              ),
             ),
-          ),
-          padding: const WidgetStatePropertyAll(
-            EdgeInsets.symmetric(vertical: 4),
-          ),
-          elevation: const WidgetStatePropertyAll(4),
-          minimumSize: WidgetStatePropertyAll(
-            Size(_column.menuWidth ?? widget.column.width, 0),
-          ),
-          maximumSize: WidgetStatePropertyAll(
-            Size(double.infinity, _column.menuMaxHeight + _menuVerticalChrome),
-          ),
-          alignment: Alignment.bottomLeft,
-        ),
-        menuChildren: [buildMenu()],
-        builder: (context, controller, child) {
-          return Focus(
-            onKeyEvent: (node, event) =>
-                handleOpeningPopupWithKeyboard(node, event, controller.isOpen),
-            focusNode: textFocus,
-            child: TrinaDefaultPopupCellEditingWidget(
-              popupMenuIcon: popupMenuIcon,
-              controller: textController,
-              stateManager: widget.stateManager,
-              onTap: () {
-                if (widget.column.checkReadOnly(widget.row, widget.cell)) {
-                  return;
-                }
-                controller.isOpen ? controller.close() : controller.open();
-              },
+            padding: const WidgetStatePropertyAll(
+              EdgeInsets.symmetric(vertical: 4),
             ),
-          );
-        },
-      );
-    },
+            elevation: const WidgetStatePropertyAll(4),
+            minimumSize: WidgetStatePropertyAll(
+              Size(_column.menuWidth ?? widget.column.width, 0),
+            ),
+            maximumSize: WidgetStatePropertyAll(
+              Size(
+                double.infinity,
+                _column.menuMaxHeight + _menuVerticalChrome,
+              ),
+            ),
+            alignment: Alignment.bottomLeft,
+          ),
+          menuChildren: [buildMenu()],
+          builder: (context, controller, child) {
+            return Focus(
+              onKeyEvent: (node, event) => handleOpeningPopupWithKeyboard(
+                node,
+                event,
+                controller.isOpen,
+              ),
+              focusNode: textFocus,
+              child: TrinaDefaultPopupCellEditingWidget(
+                popupMenuIcon: popupMenuIcon,
+                controller: textController,
+                stateManager: widget.stateManager,
+                onTap: () {
+                  if (widget.column.checkReadOnly(widget.row, widget.cell)) {
+                    return;
+                  }
+                  controller.isOpen ? controller.close() : controller.open();
+                },
+              ),
+            );
+          },
+        );
+      },
+    ),
   );
 }

--- a/lib/src/ui/widgets/ensure_shad_theme.dart
+++ b/lib/src/ui/widgets/ensure_shad_theme.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+/// Wraps [child] in a default [ShadTheme] when no ancestor [ShadTheme]
+/// is found in the widget tree.
+///
+/// Lets the grid be used inside a plain [MaterialApp] without forcing
+/// consumers to wrap their app in [ShadApp]. The fallback theme adopts
+/// the host Material [Brightness] so dark mode stays consistent.
+class EnsureShadTheme extends StatelessWidget {
+  const EnsureShadTheme({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (ShadTheme.maybeOf(context) != null) return child;
+    return ShadTheme(
+      data: ShadThemeData(brightness: Theme.of(context).brightness),
+      child: child,
+    );
+  }
+}

--- a/lib/src/ui/widgets/trina_dropdown_menu.dart
+++ b/lib/src/ui/widgets/trina_dropdown_menu.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/model/trina_dropdown_menu_filter.dart';
+import 'package:trina_grid/src/ui/widgets/ensure_shad_theme.dart';
 
 typedef ItemBuilder<T> = Widget Function(T item);
 
@@ -332,15 +333,17 @@ base class TrinaDropdownMenuState<T> extends State<TrinaDropdownMenu<T>> {
 
   @override
   Widget build(BuildContext context) {
-    return _InheritedTrinaDropdownMenu<T>(
-      state: this,
-      child: Builder(
-        builder: (context) {
-          return ConstrainedBox(
-            constraints: BoxConstraints(minWidth: widget.width),
-            child: widget.builder(context),
-          );
-        },
+    return EnsureShadTheme(
+      child: _InheritedTrinaDropdownMenu<T>(
+        state: this,
+        child: Builder(
+          builder: (context) {
+            return ConstrainedBox(
+              constraints: BoxConstraints(minWidth: widget.width),
+              child: widget.builder(context),
+            );
+          },
+        ),
       ),
     );
   }

--- a/test/src/ui/cells/trina_select_cell_test.dart
+++ b/test/src/ui/cells/trina_select_cell_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/ui/cells/trina_select_cell.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 import 'package:trina_grid/trina_grid.dart';
@@ -62,17 +63,19 @@ void main() {
   }
 
   group('Search Functionality', () {
-    final searchFieldFinder = find.byWidgetPredicate(
-      (widget) =>
-          widget is TextField && widget.decoration?.hintText == 'Search...',
-    );
+    final searchFieldFinder = find.byType(ShadInput);
+
+    // The search field has a 250ms debounce; pumpAndSettle without a
+    // duration can return before that timer fires, so callers must wait
+    // long enough for the debounce to execute.
+    const searchDebounceWait = Duration(milliseconds: 300);
 
     testWidgets('should filter items based on search text', (tester) async {
       await buildCellAndEdit(tester, enableSearch: true);
       await openPopup(tester);
 
       await tester.enterText(searchFieldFinder, 'a');
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(searchDebounceWait);
 
       expect(find.widgetWithText(MenuItemButton, 'a'), findsOneWidget);
       expect(find.widgetWithText(MenuItemButton, 'b'), findsNothing);
@@ -84,7 +87,7 @@ void main() {
       await openPopup(tester);
 
       await tester.enterText(searchFieldFinder, 'A'); // Uppercase 'A'
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(searchDebounceWait);
 
       expect(find.widgetWithText(MenuItemButton, 'a'), findsOneWidget);
       expect(find.widgetWithText(MenuItemButton, 'b'), findsNothing);
@@ -97,7 +100,7 @@ void main() {
       await openPopup(tester);
 
       await tester.enterText(searchFieldFinder, 'xyz');
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(searchDebounceWait);
 
       expect(find.text('No matches'), findsOneWidget);
       expect(find.widgetWithText(MenuItemButton, 'a'), findsNothing);
@@ -108,16 +111,13 @@ void main() {
       await openPopup(tester);
 
       await tester.enterText(searchFieldFinder, 'a');
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(searchDebounceWait);
       expect(find.widgetWithText(MenuItemButton, 'a'), findsOneWidget);
       expect(find.widgetWithText(MenuItemButton, 'b'), findsNothing);
       expect(find.widgetWithText(MenuItemButton, 'c'), findsNothing);
 
       await tester.enterText(searchFieldFinder, ''); // Clear search
-
-      // Double pumpAndSettle: first for search debounce, second for items to be shown
-      await tester.pumpAndSettle();
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(searchDebounceWait);
 
       expect(find.widgetWithText(MenuItemButton, 'a'), findsOneWidget);
       expect(find.widgetWithText(MenuItemButton, 'b'), findsOneWidget);

--- a/test/src/ui/widgets/trina_dropdown_menu_test.dart
+++ b/test/src/ui/widgets/trina_dropdown_menu_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/model/trina_dropdown_menu_filter.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 
@@ -120,9 +121,9 @@ void main() {
           variant: TrinaDropdownMenuVariant.selectWithSearch,
         );
 
-        // Enter search text
-        await tester.enterText(find.byType(TextField), 'berry');
-        await tester.pumpAndSettle();
+        // Enter search text — wait long enough for the 250ms search debounce.
+        await tester.enterText(find.byType(ShadInput), 'berry');
+        await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
         // Verify filtered list
         expect(find.text('Apple'), findsNothing);
@@ -145,7 +146,7 @@ void main() {
                 const Text('No search results!'),
           );
 
-          await tester.enterText(find.byType(TextField), 'nonexistent');
+          await tester.enterText(find.byType(ShadInput), 'nonexistent');
           await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
           expect(find.text('No search results!'), findsOneWidget);


### PR DESCRIPTION
## Summary

- **Production fix:** `ShadTheme.of(context)` was made a hard requirement by PR #364 (TrinaDropdownMenu + MenuAnchor), which crashed any consumer wrapped in plain `MaterialApp` (including the example app) the moment a select cell opened. Added `EnsureShadTheme` wrapper that falls back to a default `ShadThemeData` matching the host Material `Brightness` when no `ShadTheme` ancestor exists.
- **Outdated tests:** PR #364 swapped the search `TextField` for `ShadInput`, so `find.byType(TextField)` no longer matched. Updated finders to use `ShadInput`, and added an explicit 300ms `pumpAndSettle` duration so the 250ms search debounce timer fires before assertions.

Fixes 13 test failures revealed by the suite; full test run now: **1568 passed, 0 failed**, `dart analyze` clean.