### PR TITLE
fix: column header alignment (#301) and scrollbar thumb overflow

### DIFF
--- a/lib/src/ui/trina_body_columns.dart
+++ b/lib/src/ui/trina_body_columns.dart
@@ -98,23 +98,35 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
 
   @override
   Widget build(BuildContext context) {
+    final scrollConfig = stateManager.configuration.scrollbar;
+
     return SingleChildScrollView(
       controller: _scroll,
       scrollDirection: Axis.horizontal,
       physics: const ClampingScrollPhysics(),
-      child: TrinaVisibilityLayout(
-        delegate: MainColumnLayoutDelegate(
-          stateManager: stateManager,
-          columns: _columns,
-          columnGroups: _columnGroups,
-          frozen: TrinaColumnFrozen.none,
-          textDirection: stateManager.textDirection,
+      child: Padding(
+        // Mirror the trailing padding applied to the body rows so that the
+        // header and body share the same maxScrollExtent. Without this, fast
+        // horizontal scrolling pushes the body into its padded overscroll
+        // region while the linked header clamps short, visibly misaligning
+        // header titles from their data cells.
+        padding: scrollConfig.showVertical
+            ? EdgeInsetsDirectional.only(end: scrollConfig.thickness + 4)
+            : EdgeInsets.zero,
+        child: TrinaVisibilityLayout(
+          delegate: MainColumnLayoutDelegate(
+            stateManager: stateManager,
+            columns: _columns,
+            columnGroups: _columnGroups,
+            frozen: TrinaColumnFrozen.none,
+            textDirection: stateManager.textDirection,
+          ),
+          scrollController: _scroll,
+          initialViewportDimension: MediaQuery.of(context).size.width,
+          children: _showColumnGroups == true
+              ? _columnGroups.map(_makeColumnGroup).toList(growable: false)
+              : _columns.map(_makeColumn).toList(growable: false),
         ),
-        scrollController: _scroll,
-        initialViewportDimension: MediaQuery.of(context).size.width,
-        children: _showColumnGroups == true
-            ? _columnGroups.map(_makeColumnGroup).toList(growable: false)
-            : _columns.map(_makeColumn).toList(growable: false),
       ),
     );
   }

--- a/lib/src/widgets/trina_horizontal_scroll_bar.dart
+++ b/lib/src/widgets/trina_horizontal_scroll_bar.dart
@@ -8,6 +8,14 @@ import 'package:trina_grid/trina_grid.dart';
 bool get _isTestEnvironment =>
     WidgetsBinding.instance.toString().contains('TestWidgetsFlutterBinding');
 
+// Mirror the clamp used by the rendered thumb so position, hit-testing and
+// drag math all share the same effective size as the visible rectangle.
+double _effectiveThumbExtent(double proportional, double track, double minLen) {
+  if (proportional.isNaN) return track;
+  final double effectiveMin = minLen > track ? track : minLen;
+  return proportional.clamp(effectiveMin, track);
+}
+
 class TrinaHorizontalScrollBar extends StatefulWidget {
   const TrinaHorizontalScrollBar({
     super.key,
@@ -197,8 +205,11 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
 
           if (scrollExtent <= 0) return;
 
-          final double thumbWidth =
-              (viewportExtent / (viewportExtent + scrollExtent)) * widget.width;
+          final double thumbWidth = _effectiveThumbExtent(
+            (viewportExtent / (viewportExtent + scrollExtent)) * widget.width,
+            widget.width,
+            scrollConfig.minThumbLength,
+          );
 
           // Get the local X position of the tap
           final tapX = details.localPosition.dx;
@@ -262,9 +273,12 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
               return ValueListenableBuilder<double>(
                 valueListenable: widget.horizontalViewportExtentNotifier,
                 builder: (context, viewportExtent, _) {
-                  final double thumbWidth =
-                      (viewportExtent / (viewportExtent + scrollExtent)) *
-                      widget.width;
+                  final double thumbWidth = _effectiveThumbExtent(
+                    (viewportExtent / (viewportExtent + scrollExtent)) *
+                        widget.width,
+                    widget.width,
+                    scrollConfig.minThumbLength,
+                  );
 
                   return ValueListenableBuilder<double>(
                     valueListenable: widget.horizontalScrollOffsetNotifier,
@@ -304,15 +318,7 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
                                 left: adjustedThumbPosition.isNaN
                                     ? 0
                                     : adjustedThumbPosition,
-                                width: thumbWidth.isNaN
-                                    ? widget.width
-                                    : thumbWidth.clamp(
-                                        scrollConfig.minThumbLength >
-                                                widget.width
-                                            ? widget.width
-                                            : scrollConfig.minThumbLength,
-                                        widget.width,
-                                      ),
+                                width: thumbWidth,
                                 height: scrollConfig.thickness,
                                 top: 2,
                                 child: MouseRegion(

--- a/lib/src/widgets/trina_vertical_scroll_bar.dart
+++ b/lib/src/widgets/trina_vertical_scroll_bar.dart
@@ -8,6 +8,14 @@ import 'package:trina_grid/trina_grid.dart';
 bool get _isTestEnvironment =>
     WidgetsBinding.instance.toString().contains('TestWidgetsFlutterBinding');
 
+// Mirror the clamp used by the rendered thumb so position, hit-testing and
+// drag math all share the same effective size as the visible rectangle.
+double _effectiveThumbExtent(double proportional, double track, double minLen) {
+  if (proportional.isNaN) return track;
+  final double effectiveMin = minLen > track ? track : minLen;
+  return proportional.clamp(effectiveMin, track);
+}
+
 class TrinaVerticalScrollBar extends StatefulWidget {
   const TrinaVerticalScrollBar({
     super.key,
@@ -206,9 +214,12 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
 
             if (scrollExtent <= 0) return;
 
-            final double thumbHeight =
-                (viewportExtent / (viewportExtent + scrollExtent)) *
-                widget.height;
+            final double thumbHeight = _effectiveThumbExtent(
+              (viewportExtent / (viewportExtent + scrollExtent)) *
+                  widget.height,
+              widget.height,
+              scrollConfig.minThumbLength,
+            );
 
             // Get the local Y position of the tap
             final tapY = details.localPosition.dy;
@@ -267,9 +278,12 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
                 return ValueListenableBuilder<double>(
                   valueListenable: widget.verticalViewportExtentNotifier,
                   builder: (context, viewportExtent, _) {
-                    final double thumbHeight =
-                        (viewportExtent / (viewportExtent + scrollExtent)) *
-                        widget.height;
+                    final double thumbHeight = _effectiveThumbExtent(
+                      (viewportExtent / (viewportExtent + scrollExtent)) *
+                          widget.height,
+                      widget.height,
+                      scrollConfig.minThumbLength,
+                    );
 
                     return ValueListenableBuilder<double>(
                       valueListenable: widget.verticalScrollOffsetNotifier,
@@ -303,15 +317,7 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
                               if (scrollConfig.thumbVisible)
                                 Positioned(
                                   top: thumbPosition.isNaN ? 0 : thumbPosition,
-                                  height: thumbHeight.isNaN
-                                      ? widget.height
-                                      : thumbHeight.clamp(
-                                          scrollConfig.minThumbLength >
-                                                  widget.height
-                                              ? widget.height
-                                              : scrollConfig.minThumbLength,
-                                          widget.height,
-                                        ),
+                                  height: thumbHeight,
                                   width: scrollConfig.thickness,
                                   left: widget.stateManager.isRTL ? 2 : null,
                                   right: widget.stateManager.isRTL ? null : 2,


### PR DESCRIPTION
## Summary

Two related scroll-end fixes uncovered by the demo's Scrollbar Customization screen (500 rows x 20 columns):

- **Header/body column misalignment at the right edge** (Closes #301). The body rows pad their horizontal scroll content with `scrollbar.thickness + 4` so the last column can be scrolled out from under the overlaid vertical scrollbar (added in #358), but the column header never received the same padding. A fast horizontal fling pushed the body past where the linked header could follow, offsetting the header titles from their data cells. Mirror the same trailing padding on the header so both halves share an identical maxScrollExtent.
- **Scrollbar thumb clipped at end of scroll.** Both fake scrollbar widgets computed the proportional thumb size, then clamped only the rendered thumb up to `minThumbLength` (default 40px). Position, track-tap-to-jump and drag-delta scale all kept using the smaller unclamped value, so at max scroll the larger rendered thumb overflowed the end of the track and the Stack clipped everything but the leading edge. Compute one effective thumb extent (with the existing min-length clamp) and reuse it everywhere the rendered geometry matters.

## Test plan

- `dart format` + `dart analyze` clean on all touched files.
- `flutter test` -> 1568 tests passing.
- Manual repro on demo Scrollbar Customization screen: fast horizontal fling now keeps header titles locked above their data cells at the right edge; the vertical and horizontal thumbs sit flush against the trailing edge of the track at max scroll, and dragging the thumb covers the full content range.