### PR TITLE
fix: include pagination and time picker fields in TrinaGridLocaleText equality

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -2469,7 +2469,6 @@ class TrinaGridLocaleText {
     this.timePickerInvalidValueMessage = '無効な値',
   });
 
-
   const TrinaGridLocaleText.hungarian({
     // Column menu
     this.unfreezeColumn = 'Oszlop rögzítés felold',
@@ -2569,7 +2568,24 @@ class TrinaGridLocaleText {
             selectSearchHint == other.selectSearchHint &&
             multiLineFilterHint == other.multiLineFilterHint &&
             multiLineFilterEditTitle == other.multiLineFilterEditTitle &&
-            multiLineFilterOkButton == other.multiLineFilterOkButton;
+            multiLineFilterOkButton == other.multiLineFilterOkButton &&
+            paginationGoToPageTitle == other.paginationGoToPageTitle &&
+            paginationGoToPageLabel == other.paginationGoToPageLabel &&
+            paginationCancelButton == other.paginationCancelButton &&
+            paginationGoButton == other.paginationGoButton &&
+            paginationInvalidPageNumberMessage ==
+                other.paginationInvalidPageNumberMessage &&
+            paginationGoToPageTooltip == other.paginationGoToPageTooltip &&
+            timePickerHourLabel == other.timePickerHourLabel &&
+            timePickerMinuteLabel == other.timePickerMinuteLabel &&
+            timePickerInvalidHourMessage ==
+                other.timePickerInvalidHourMessage &&
+            timePickerInvalidMinuteMessage ==
+                other.timePickerInvalidMinuteMessage &&
+            timePickerMinTimeMessage == other.timePickerMinTimeMessage &&
+            timePickerMaxTimeMessage == other.timePickerMaxTimeMessage &&
+            timePickerInvalidValueMessage ==
+                other.timePickerInvalidValueMessage;
   }
 
   @override
@@ -2609,6 +2625,19 @@ class TrinaGridLocaleText {
     multiLineFilterHint,
     multiLineFilterEditTitle,
     multiLineFilterOkButton,
+    paginationGoToPageTitle,
+    paginationGoToPageLabel,
+    paginationCancelButton,
+    paginationGoButton,
+    paginationInvalidPageNumberMessage,
+    paginationGoToPageTooltip,
+    timePickerHourLabel,
+    timePickerMinuteLabel,
+    timePickerInvalidHourMessage,
+    timePickerInvalidMinuteMessage,
+    timePickerMinTimeMessage,
+    timePickerMaxTimeMessage,
+    timePickerInvalidValueMessage,
   ]);
 }
 

--- a/test/src/trina_grid_configuration_test.dart
+++ b/test/src/trina_grid_configuration_test.dart
@@ -580,5 +580,33 @@ void main() {
 
       expect(locale.loadingText, 'にゃ〜');
     });
+
+    test('When the locale is called, the value should be correct.', () {
+      const locale = TrinaGridLocaleText.hungarian();
+
+      expect(locale.loadingText, 'Betöltés');
+    });
+
+    test(
+      'When only a pagination field differs, the comparison should be false.',
+      () {
+        const localeA = TrinaGridLocaleText(paginationGoButton: 'Go');
+        const localeB = TrinaGridLocaleText(paginationGoButton: 'Ugrik');
+
+        expect(localeA == localeB, false);
+        expect(localeA.hashCode == localeB.hashCode, false);
+      },
+    );
+
+    test(
+      'When only a time picker field differs, the comparison should be false.',
+      () {
+        const localeA = TrinaGridLocaleText(timePickerHourLabel: 'Hour');
+        const localeB = TrinaGridLocaleText(timePickerHourLabel: 'Óra');
+
+        expect(localeA == localeB, false);
+        expect(localeA.hashCode == localeB.hashCode, false);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Problem

`TrinaGridLocaleText.operator ==` and `hashCode` only compared fields up through `multiLineFilterOkButton`. Every `pagination*` and `timePicker*` field (added to the class later) was left out of both.

Consequence: two `TrinaGridLocaleText` instances differing **only** in a pagination or time-picker label compared as equal and produced the same hash code. Since `TrinaGridConfiguration` equality flows through `localeText`, this could suppress legitimate rebuilds when only those labels changed.

This is a pre-existing gap, surfaced while reviewing #382 (Hungarian locale); it is not caused by that PR.

## Fix

- Add all `pagination*` and `timePicker*` fields to `operator ==` and `hashCode` so equality covers the full set of localized strings.
- Add regression tests: locale texts differing only in a pagination field, and only in a time-picker field, are now correctly unequal with distinct hash codes. (Both would have passed incorrectly before this change.)
- Add a `loadingText` check for `TrinaGridLocaleText.hungarian` for parity with the other locales.

## Testing

- `dart format` + `dart analyze`: clean.
- `flutter test`: full suite green (1569 tests), including the 3 new cases.
