### PR TITLE
Make all keyboard shortcuts NumLock-safe; refine clickable sort icon

### DIFF
--- a/lib/src/manager/shortcut/trina_grid_shortcut.dart
+++ b/lib/src/manager/shortcut/trina_grid_shortcut.dart
@@ -66,99 +66,94 @@ class TrinaGridShortcut {
     SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
         const TrinaGridActionMoveSelectedCellFocus(TrinaMoveDirection.down),
     // Move cell focus by page vertically
-    LogicalKeySet(LogicalKeyboardKey.pageUp):
+    SingleActivator(LogicalKeyboardKey.pageUp):
         const TrinaGridActionMoveCellFocusByPage(TrinaMoveDirection.up),
-    LogicalKeySet(LogicalKeyboardKey.pageDown):
+    SingleActivator(LogicalKeyboardKey.pageDown):
         const TrinaGridActionMoveCellFocusByPage(TrinaMoveDirection.down),
-    // Move cell focus by page vertically
-    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.pageUp):
+    // Move selected cell focus by page vertically
+    SingleActivator(LogicalKeyboardKey.pageUp, shift: true):
         const TrinaGridActionMoveSelectedCellFocusByPage(TrinaMoveDirection.up),
-    LogicalKeySet(
-      LogicalKeyboardKey.shift,
+    SingleActivator(
       LogicalKeyboardKey.pageDown,
+      shift: true,
     ): const TrinaGridActionMoveSelectedCellFocusByPage(
       TrinaMoveDirection.down,
     ),
     // Move page when pagination is enabled
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.pageUp):
+    SingleActivator(LogicalKeyboardKey.pageUp, alt: true):
         const TrinaGridActionMoveCellFocusByPage(TrinaMoveDirection.left),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.pageDown):
+    SingleActivator(LogicalKeyboardKey.pageDown, alt: true):
         const TrinaGridActionMoveCellFocusByPage(TrinaMoveDirection.right),
     // Default tab key action
-    LogicalKeySet(LogicalKeyboardKey.tab): const TrinaGridActionDefaultTab(),
-    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab):
+    SingleActivator(LogicalKeyboardKey.tab): const TrinaGridActionDefaultTab(),
+    SingleActivator(LogicalKeyboardKey.tab, shift: true):
         const TrinaGridActionDefaultTab(),
     // Default enter key action
-    LogicalKeySet(LogicalKeyboardKey.enter):
+    SingleActivator(LogicalKeyboardKey.enter):
         const TrinaGridActionDefaultEnterKey(),
-    LogicalKeySet(LogicalKeyboardKey.numpadEnter):
+    SingleActivator(LogicalKeyboardKey.numpadEnter):
         const TrinaGridActionDefaultEnterKey(),
-    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.enter):
+    SingleActivator(LogicalKeyboardKey.enter, shift: true):
         const TrinaGridActionDefaultEnterKey(),
     // Default escape key action
-    LogicalKeySet(LogicalKeyboardKey.escape):
+    SingleActivator(LogicalKeyboardKey.escape):
         const TrinaGridActionDefaultEscapeKey(),
     // Move cell focus to edge
-    LogicalKeySet(LogicalKeyboardKey.home):
+    SingleActivator(LogicalKeyboardKey.home):
         const TrinaGridActionMoveCellFocusToEdge(TrinaMoveDirection.left),
-    LogicalKeySet(LogicalKeyboardKey.end):
+    SingleActivator(LogicalKeyboardKey.end):
         const TrinaGridActionMoveCellFocusToEdge(TrinaMoveDirection.right),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.home):
+    SingleActivator(LogicalKeyboardKey.home, control: true):
         const TrinaGridActionMoveCellFocusToEdge(TrinaMoveDirection.up),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.end):
+    SingleActivator(LogicalKeyboardKey.end, control: true):
         const TrinaGridActionMoveCellFocusToEdge(TrinaMoveDirection.down),
     // Move selected cell focus to edge
-    LogicalKeySet(
-      LogicalKeyboardKey.shift,
+    SingleActivator(
       LogicalKeyboardKey.home,
+      shift: true,
     ): const TrinaGridActionMoveSelectedCellFocusToEdge(
       TrinaMoveDirection.left,
     ),
-    LogicalKeySet(
-      LogicalKeyboardKey.shift,
+    SingleActivator(
       LogicalKeyboardKey.end,
+      shift: true,
     ): const TrinaGridActionMoveSelectedCellFocusToEdge(
       TrinaMoveDirection.right,
     ),
-    LogicalKeySet(
-      LogicalKeyboardKey.control,
-      LogicalKeyboardKey.shift,
-      LogicalKeyboardKey.home,
-    ): const TrinaGridActionMoveSelectedCellFocusToEdge(
-      TrinaMoveDirection.up,
-    ),
-    LogicalKeySet(
-      LogicalKeyboardKey.control,
-      LogicalKeyboardKey.shift,
+    SingleActivator(LogicalKeyboardKey.home, control: true, shift: true):
+        const TrinaGridActionMoveSelectedCellFocusToEdge(TrinaMoveDirection.up),
+    SingleActivator(
       LogicalKeyboardKey.end,
+      control: true,
+      shift: true,
     ): const TrinaGridActionMoveSelectedCellFocusToEdge(
       TrinaMoveDirection.down,
     ),
     // Set editing
-    LogicalKeySet(LogicalKeyboardKey.f2): const TrinaGridActionSetEditing(),
+    SingleActivator(LogicalKeyboardKey.f2): const TrinaGridActionSetEditing(),
     // Focus to column filter
-    LogicalKeySet(LogicalKeyboardKey.f3):
+    SingleActivator(LogicalKeyboardKey.f3):
         const TrinaGridActionFocusToColumnFilter(),
     // Toggle column sort
-    LogicalKeySet(LogicalKeyboardKey.f4):
+    SingleActivator(LogicalKeyboardKey.f4):
         const TrinaGridActionToggleColumnSort(),
     // Copy the values of cells
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyC):
+    SingleActivator(LogicalKeyboardKey.keyC, control: true):
         const TrinaGridActionCopyValues(),
     // Copy the values of cells (Mac)
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyC):
+    SingleActivator(LogicalKeyboardKey.keyC, meta: true):
         const TrinaGridActionCopyValues(),
     // Paste values from clipboard
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
+    SingleActivator(LogicalKeyboardKey.keyV, control: true):
         const TrinaGridActionPasteValues(),
     // Paste values from clipboard (Mac)
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV):
+    SingleActivator(LogicalKeyboardKey.keyV, meta: true):
         const TrinaGridActionPasteValues(),
     // Select all cells or rows
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyA):
+    SingleActivator(LogicalKeyboardKey.keyA, control: true):
         const TrinaGridActionSelectAll(),
     // Select all cells or rows (Mac)
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyA):
+    SingleActivator(LogicalKeyboardKey.keyA, meta: true):
         const TrinaGridActionSelectAll(),
   };
 }

--- a/lib/src/ui/columns/trina_column_title.dart
+++ b/lib/src/ui/columns/trina_column_title.dart
@@ -214,13 +214,18 @@ class TrinaColumnTitleState extends TrinaStateWithChange<TrinaColumnTitle> {
           hoverColor: Colors.transparent,
           splashColor: Colors.transparent,
           highlightColor: Colors.transparent,
-          onPressed: () {
-            if (mounted &&
-                widget.column.enableSorting &&
-                !widget.column.enableContextMenu) {
-              stateManager.toggleSortColumn(widget.column);
-            }
-          },
+          // Only act as a sort toggle when the icon is the sort/resize icon
+          // (no context menu). When the context menu is enabled the tap is
+          // handled by the Listener in `_buildContextMenuWidget`, so keep the
+          // button disabled here instead of leaving an enabled no-op.
+          onPressed:
+              widget.column.enableSorting && !widget.column.enableContextMenu
+              ? () {
+                  if (mounted) {
+                    stateManager.toggleSortColumn(widget.column);
+                  }
+                }
+              : null,
         ),
       ),
     );

--- a/test/scenario/columns/sort_icon_click_test.dart
+++ b/test/scenario/columns/sort_icon_click_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/src/ui/columns/trina_column_title.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  testWidgets(
+    'Tapping the sort icon toggles the column sort direction (#379)',
+    (tester) async {
+      // A sortable column with no context menu and no resize handle: once the
+      // column is sorted, the only header icon is the sort indicator, which
+      // must itself be clickable so narrow columns can still be re-sorted.
+      final column = TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        enableContextMenu: false,
+        enableDropToResize: false,
+        type: TrinaColumnType.number(),
+      );
+
+      late TrinaGridStateManager stateManager;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TrinaGrid(
+              columns: [column],
+              rows: [
+                TrinaRow(cells: {'id': TrinaCell(value: 1)}),
+                TrinaRow(cells: {'id': TrinaCell(value: 2)}),
+                TrinaRow(cells: {'id': TrinaCell(value: 3)}),
+              ],
+              onLoaded: (event) => stateManager = event.stateManager,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // No sort yet, so the header shows no icon.
+      expect(column.sort.isNone, isTrue);
+
+      // Sort once so the ascending icon appears in the header.
+      stateManager.toggleSortColumn(column);
+      await tester.pumpAndSettle();
+      expect(column.sort, TrinaColumnSort.ascending);
+
+      // The icon is now visible; tapping it should toggle to descending
+      // rather than be an inert button.
+      final iconButton = find.descendant(
+        of: find.byType(TrinaColumnTitle),
+        matching: find.byType(IconButton),
+      );
+      expect(iconButton, findsOneWidget);
+
+      await tester.tap(iconButton);
+      await tester.pumpAndSettle();
+
+      expect(column.sort, TrinaColumnSort.descending);
+    },
+  );
+
+  testWidgets('Sort icon button is disabled when the context menu is enabled', (
+    tester,
+  ) async {
+    // With the context menu enabled the tap is handled by the menu Listener,
+    // so the IconButton itself must stay disabled (no enabled no-op button).
+    final column = TrinaColumn(
+      title: 'ID',
+      field: 'id',
+      type: TrinaColumnType.number(),
+    );
+
+    late TrinaGridStateManager stateManager;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TrinaGrid(
+            columns: [column],
+            rows: [
+              TrinaRow(cells: {'id': TrinaCell(value: 1)}),
+            ],
+            onLoaded: (event) => stateManager = event.stateManager,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Sort so the icon is rendered.
+    stateManager.toggleSortColumn(column);
+    await tester.pumpAndSettle();
+
+    final iconButton = tester.widget<IconButton>(
+      find.descendant(
+        of: find.byType(TrinaColumnTitle),
+        matching: find.byType(IconButton),
+      ),
+    );
+
+    expect(iconButton.onPressed, isNull);
+  });
+}

--- a/test/scenario/keyboard/shortcuts_and_focus_test.dart
+++ b/test/scenario/keyboard/shortcuts_and_focus_test.dart
@@ -87,6 +87,23 @@ void main() {
     await tester.pump();
   }
 
+  group('Default shortcuts (NumLock-safe)', () {
+    test('every default shortcut uses SingleActivator', () {
+      // SingleActivator defaults to `numLock: LockState.ignored`, so a lock
+      // key (NumLock, CapsLock, ScrollLock) can never block a shortcut from
+      // matching. LogicalKeySet does not ignore lock keys, which broke arrow
+      // and navigation keys on Linux when NumLock was on (issue #381). Guard
+      // against any default shortcut regressing back to LogicalKeySet.
+      for (final activator in TrinaGridShortcut.defaultActions.keys) {
+        expect(
+          activator,
+          isA<SingleActivator>(),
+          reason: '$activator must be a SingleActivator to stay NumLock-safe',
+        );
+      }
+    });
+  });
+
   testWidgets('Alt + character combos should not start editing', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Follow-up that completes and polishes the work merged in #380.

## Shortcuts: complete the NumLock fix (#381)
#380 switched only the 8 arrow shortcuts from `LogicalKeySet` to `SingleActivator`. The root cause (lock-key state blocking `LogicalKeySet` matches on Linux) affects **every** shortcut, so the remaining ones (PageUp/PageDown, Home/End, Tab, Enter, Escape, F2-F4, Ctrl/Meta + C/V/A) were still broken with NumLock on.

This converts the rest of `TrinaGridShortcut.defaultActions` to `SingleActivator`, which defaults to `numLock: LockState.ignored`. The conversion is behavior-preserving (exact modifier matching is the same), and user-supplied custom shortcuts can still use `LogicalKeySet`.

## Sort icon: small cleanup (#379)
When the context menu is enabled, the icon button's `onPressed` was a non-null no-op (its `!enableContextMenu` guard always failed), leaving an enabled-but-dead button. The tap is already handled by the `Listener` in `_buildContextMenuWidget`, so the button is now correctly disabled in that case. The clickable-sort behavior for non-menu columns is unchanged.

## Tests
- Regression guard: every key in `defaultActions` must be a `SingleActivator` (prevents reintroducing the NumLock bug).
- Sort icon: tapping the visible sort icon toggles the sort direction; the button is disabled when a context menu is enabled.

Full suite: 1575 tests passing. `dart analyze` clean.

Closes the follow-up tracked by #379 and #381 (both already resolved by #380).