### PR TITLE
fix: scope column filter rebuilds to filter events (#367)

### DIFF
--- a/lib/src/manager/trina_change_notifier_filter.dart
+++ b/lib/src/manager/trina_change_notifier_filter.dart
@@ -169,6 +169,13 @@ class TrinaNotifierFilterResolverDefault
       case const (TrinaRightFrozenColumns):
       case const (TrinaRightFrozenColumnsFooter):
         return defaultColumnsFilter(stateManager);
+      case const (TrinaBaseColumn):
+        return {
+          ...defaultColumnsFilter(stateManager),
+          stateManager.setShowColumnFilter.hashCode,
+        };
+      case const (TrinaColumnFilter):
+        return defaultColumnFilterFilter(stateManager);
       case const (TrinaBodyRows):
       case const (TrinaLeftFrozenRows):
       case const (TrinaRightFrozenRows):
@@ -215,6 +222,22 @@ class TrinaNotifierFilterResolverDefault
       stateManager.setShowColumnGroups.hashCode,
       stateManager.removeColumnsInColumnGroup.hashCode,
       stateManager.notifyChangedShowFrozenColumn.hashCode,
+    };
+  }
+
+  static Set<int> defaultColumnFilterFilter(
+    TrinaGridStateManager stateManager,
+  ) {
+    return {
+      // Structural column changes (insert/remove/move/hide/frozen/groups) so
+      // the filter field stays in sync with the column it belongs to.
+      ...defaultColumnsFilter(stateManager),
+
+      // Filter values changed -> refresh _filterRows / _text / _enabled.
+      stateManager.setFilter.hashCode,
+
+      // Filter row shown/hidden.
+      stateManager.setShowColumnFilter.hashCode,
     };
   }
 

--- a/test/src/manager/trina_change_notifier_filter_test.dart
+++ b/test/src/manager/trina_change_notifier_filter_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:trina_grid/src/ui/ui.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../mock/shared_mocks.mocks.dart';
+
+/// Regression coverage for issue #367 (grid flickers when the column filter
+/// row is enabled).
+///
+/// The per-column filter widgets ([TrinaColumnFilter]) and their host
+/// ([TrinaBaseColumn]) used to be missing from the notifier-filter resolver,
+/// so they fell through to an empty filter and reacted to *every* state event,
+/// including cell navigation. These tests pin down that they now only react to
+/// filter / column-structural events and ignore cell-navigation events.
+void main() {
+  late TrinaGridStateManager stateManager;
+
+  setUp(() {
+    final columns = [
+      ...ColumnHelper.textColumn('column', count: 2, width: 150),
+    ];
+    final rows = RowHelper.count(10, columns);
+
+    stateManager = TrinaGridStateManager(
+      columns: columns,
+      rows: rows,
+      gridFocusNode: MockFocusNode(),
+      scroll: MockTrinaGridScrollController(),
+    );
+  });
+
+  TrinaNotifierEvent eventOf(int hash) => TrinaNotifierEvent({hash});
+
+  group('TrinaColumnFilter notifier filter', () {
+    test('ignores cell-navigation events', () {
+      final filter = stateManager.resolveNotifierFilter<TrinaColumnFilter>();
+
+      expect(
+        filter.any(eventOf(stateManager.setCurrentCell.hashCode)),
+        isFalse,
+      );
+      expect(
+        filter.any(eventOf(stateManager.setCurrentCellPosition.hashCode)),
+        isFalse,
+      );
+      expect(
+        filter.any(eventOf(stateManager.updateCurrentCellPosition.hashCode)),
+        isFalse,
+      );
+      expect(
+        filter.any(eventOf(stateManager.clearCurrentCell.hashCode)),
+        isFalse,
+      );
+    });
+
+    test('reacts to filter and structural column changes', () {
+      final filter = stateManager.resolveNotifierFilter<TrinaColumnFilter>();
+
+      expect(filter.any(eventOf(stateManager.setFilter.hashCode)), isTrue);
+      expect(
+        filter.any(eventOf(stateManager.setShowColumnFilter.hashCode)),
+        isTrue,
+      );
+      expect(filter.any(eventOf(stateManager.insertColumns.hashCode)), isTrue);
+      expect(filter.any(eventOf(stateManager.removeColumns.hashCode)), isTrue);
+      expect(filter.any(eventOf(stateManager.moveColumn.hashCode)), isTrue);
+      expect(filter.any(eventOf(stateManager.hideColumn.hashCode)), isTrue);
+    });
+  });
+
+  group('TrinaBaseColumn notifier filter', () {
+    test('ignores cell-navigation events', () {
+      final filter = stateManager.resolveNotifierFilter<TrinaBaseColumn>();
+
+      expect(
+        filter.any(eventOf(stateManager.setCurrentCell.hashCode)),
+        isFalse,
+      );
+      expect(
+        filter.any(eventOf(stateManager.setCurrentCellPosition.hashCode)),
+        isFalse,
+      );
+    });
+
+    test('reacts to show-column-filter toggling', () {
+      final filter = stateManager.resolveNotifierFilter<TrinaBaseColumn>();
+
+      expect(
+        filter.any(eventOf(stateManager.setShowColumnFilter.hashCode)),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #367

## Problem

When the column filter ("search") row is shown, the grid flickers as the user moves between cells. An otherwise identical grid without the filter row does not flicker.

## Root cause

`TrinaColumnFilter` (the per-column filter field) and its host `TrinaBaseColumn` were missing from the notifier-filter resolver switch in `TrinaNotifierFilterResolverDefault.resolve()`. They fell through to `return <int>{}` (an empty filter set), and an empty set makes `TrinaChangeNotifierFilter.any()` return `true` for **every** state event.

As a result, on every cell move (`setCurrentCell` / `setCurrentCellPosition`) every column filter ran `updateState()` and re-computed `filterRowsByField(...)`, doing wasted work on each navigation that manifested as flicker.

## Fix

Add explicit resolver cases so the filter row only reacts to events it actually depends on:

- `TrinaColumnFilter` -> new `defaultColumnFilterFilter()`: structural column changes (insert/remove/move/hide/frozen/groups) + `setFilter` (filter values) + `setShowColumnFilter` (filter visibility).
- `TrinaBaseColumn` -> column-structural changes + `setShowColumnFilter`.

Cell-navigation events are deliberately excluded. This mirrors the existing pattern already used for `TrinaBodyColumns` and `TrinaAggregateColumnFooter`.

## Tests

- New unit test `test/src/manager/trina_change_notifier_filter_test.dart` pins down that the resolved notifier sets for `TrinaColumnFilter` and `TrinaBaseColumn` ignore `setCurrentCell`/`setCurrentCellPosition` while still reacting to `setFilter`, `setShowColumnFilter`, and structural column changes.
- Full suite green (1575 passing); `dart analyze` clean; `dart format` applied.

## Note

This change scopes rebuilds and is the confirmed, low-risk part of the fix. If any residual flicker remains from cell-selection repaints bleeding into the header band, the follow-up is a `RepaintBoundary` around the column header/filter in `trina_base_column.dart`; left out here pending visual confirmation.