### PR TITLE
feat: make scrollbar track-click animation configurable (#277)

### DIFF
--- a/doc/features/scrollbars.md
+++ b/doc/features/scrollbars.md
@@ -75,6 +75,8 @@ The `TrinaGridScrollbarConfig` class provides the following key options for scro
 | `trackHoverColor` | `Color?` | `null` | Color of the scrollbar track when hovered (defaults to a more opaque version of trackColor if null). |
 | `isDraggable` | `bool` | `true` | Whether scrollbar thumbs can be dragged with mouse or touch to scroll content. |
 | `smoothScrolling` | `bool` | `true` | Whether to use smooth scrolling animation for mouse wheel input. When enabled, scrolling animates smoothly instead of jumping instantly. |
+| `trackClickDuration` | `Duration` | `Duration(milliseconds: 200)` | Duration of the scroll animation when clicking the scrollbar track to jump to a position. Set to `Duration.zero` to jump instantly. |
+| `trackClickCurve` | `Curve` | `Curves.easeOutCubic` | Easing curve for the track-click jump animation. |
 
 ## Examples
 
@@ -160,6 +162,37 @@ TrinaGrid(
   configuration: TrinaGridConfiguration(
     scrollbar: TrinaGridScrollbarConfig(
       isDraggable: false, // Disable scrollbar thumb dragging
+    ),
+  ),
+)
+```
+
+### Customizing the Track-Click Animation
+
+When you click on the scrollbar track (not the thumb), the grid animates to that position. You can change how long that animation takes and which easing curve it uses:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      trackClickDuration: Duration(milliseconds: 120), // Faster jump
+      trackClickCurve: Curves.linear,                  // Constant speed
+    ),
+  ),
+)
+```
+
+To disable the animation entirely and jump instantly, set the duration to `Duration.zero`:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    scrollbar: TrinaGridScrollbarConfig(
+      trackClickDuration: Duration.zero, // Instant jump on track click
     ),
   ),
 )

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -1198,6 +1198,8 @@ class TrinaGridScrollbarConfig {
     },
     this.isDraggable = true,
     this.smoothScrolling = true,
+    this.trackClickDuration = const Duration(milliseconds: 200),
+    this.trackClickCurve = Curves.easeOutCubic,
 
     // Advanced scrollbar appearance settings
     this.thumbVisible = true,
@@ -1237,6 +1239,21 @@ class TrinaGridScrollbarConfig {
   ///
   /// Defaults to true.
   final bool smoothScrolling;
+
+  /// Duration of the scroll animation when clicking on the scrollbar track
+  /// to jump to a position.
+  ///
+  /// Thumb dragging is not affected (it jumps instantly). Set to
+  /// [Duration.zero] to jump immediately without animation.
+  ///
+  /// Defaults to const Duration(milliseconds: 200).
+  final Duration trackClickDuration;
+
+  /// Curve of the scroll animation when clicking on the scrollbar track
+  /// to jump to a position.
+  ///
+  /// Defaults to Curves.easeOutCubic.
+  final Curve trackClickCurve;
 
   /// Whether the scrollbar thumb is visible
   final bool thumbVisible;
@@ -1301,6 +1318,8 @@ class TrinaGridScrollbarConfig {
             dragDevices == other.dragDevices &&
             isDraggable == other.isDraggable &&
             smoothScrolling == other.smoothScrolling &&
+            trackClickDuration == other.trackClickDuration &&
+            trackClickCurve == other.trackClickCurve &&
             thumbVisible == other.thumbVisible &&
             showTrack == other.showTrack &&
             showHorizontal == other.showHorizontal &&
@@ -1321,6 +1340,8 @@ class TrinaGridScrollbarConfig {
     dragDevices,
     isDraggable,
     smoothScrolling,
+    trackClickDuration,
+    trackClickCurve,
     thumbVisible,
     showTrack,
     showHorizontal,

--- a/lib/src/widgets/trina_horizontal_scroll_bar.dart
+++ b/lib/src/widgets/trina_horizontal_scroll_bar.dart
@@ -236,8 +236,8 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
           // Use animateTo for smooth scrolling instead of jumpTo
           scrollController.animateTo(
             clampedOffset,
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOutCubic,
+            duration: scrollConfig.trackClickDuration,
+            curve: scrollConfig.trackClickCurve,
           );
         },
         onPanDown: (_) {

--- a/lib/src/widgets/trina_vertical_scroll_bar.dart
+++ b/lib/src/widgets/trina_vertical_scroll_bar.dart
@@ -241,8 +241,8 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
             // Use animateTo for smooth scrolling instead of jumpTo
             scrollController.animateTo(
               clampedOffset,
-              duration: const Duration(milliseconds: 200),
-              curve: Curves.easeOutCubic,
+              duration: scrollConfig.trackClickDuration,
+              curve: scrollConfig.trackClickCurve,
             );
           },
           onPanDown: (_) {

--- a/test/src/trina_grid_configuration_test.dart
+++ b/test/src/trina_grid_configuration_test.dart
@@ -180,6 +180,64 @@ void main() {
     );
   });
 
+  group('scrollbar', () {
+    test(
+      'The default track-click animation should preserve the legacy behavior.',
+      () {
+        const config = TrinaGridScrollbarConfig();
+
+        expect(config.trackClickDuration, const Duration(milliseconds: 200));
+        expect(config.trackClickCurve, Curves.easeOutCubic);
+      },
+    );
+
+    test(
+      'When the trackClickDuration is different, the comparison should be false.',
+      () {
+        const configA = TrinaGridScrollbarConfig();
+
+        const configB = TrinaGridScrollbarConfig(
+          trackClickDuration: Duration(milliseconds: 120),
+        );
+
+        expect(configA == configB, false);
+        expect(configA.hashCode == configB.hashCode, false);
+      },
+    );
+
+    test(
+      'When the trackClickCurve is different, the comparison should be false.',
+      () {
+        const configA = TrinaGridScrollbarConfig();
+
+        const configB = TrinaGridScrollbarConfig(
+          trackClickCurve: Curves.linear,
+        );
+
+        expect(configA == configB, false);
+        expect(configA.hashCode == configB.hashCode, false);
+      },
+    );
+
+    test(
+      'When the track-click values are the same, the comparison should be true.',
+      () {
+        const configA = TrinaGridScrollbarConfig(
+          trackClickDuration: Duration(milliseconds: 350),
+          trackClickCurve: Curves.easeInOut,
+        );
+
+        const configB = TrinaGridScrollbarConfig(
+          trackClickDuration: Duration(milliseconds: 350),
+          trackClickCurve: Curves.easeInOut,
+        );
+
+        expect(configA == configB, true);
+        expect(configA.hashCode == configB.hashCode, true);
+      },
+    );
+  });
+
   group('style', () {
     test(
       'When the values of style A and B are the same, the comparison should be true.',


### PR DESCRIPTION
## Summary

Closes #277.

The scroll animation triggered by clicking the scrollbar **track** (to jump to a position) was hardcoded to `Duration(milliseconds: 200)` with `Curves.easeOutCubic`, duplicated in both the vertical and horizontal scroll bars. This adds two configurable fields so applications can tune the feel of that animation.

## Changes

- `TrinaGridScrollbarConfig` gains two new fields:
  - `trackClickDuration` (`Duration`, default `Duration(milliseconds: 200)`)
  - `trackClickCurve` (`Curve`, default `Curves.easeOutCubic`)
- Both scroll bars now read these from the config instead of hardcoded values.
- `operator ==` / `hashCode` updated accordingly.
- Setting `trackClickDuration: Duration.zero` makes track clicks jump instantly (no animation).
- Docs updated (`doc/features/scrollbars.md`): options table plus a usage example.
- Tests added in `test/src/trina_grid_configuration_test.dart`: a default-value guard (backward-compat) and equality/hashCode coverage.

Thumb dragging (uses `jumpTo`) and mouse-wheel smooth scrolling (physics-based) are unaffected.

## Backward compatibility

Fully additive and non-breaking. The defaults exactly match the previous hardcoded behavior, so existing apps see no change.

## Verification

- `dart format` clean, `dart analyze` no issues
- `flutter test` - all 1583 tests pass (4 new)
