### PR TITLE
fix: guard select cell initialValue against type mismatch

### DIFF
--- a/lib/src/ui/cells/trina_select_cell.dart
+++ b/lib/src/ui/cells/trina_select_cell.dart
@@ -72,7 +72,12 @@ class TrinaSelectCellState<T>
         menuController.close();
       },
       width: _column.menuWidth ?? widget.column.width,
-      initialValue: widget.cell.value,
+      // Guard against a cell value whose runtime type does not match the
+      // column's item type [T] (e.g. a select<int?> column fed a String).
+      // Without this, the implicit `value as T?` downcast throws and brings
+      // down the entire grid build. A mismatched value simply means "no item
+      // is pre-selected".
+      initialValue: widget.cell.value is T ? widget.cell.value as T : null,
       itemHeight: _column.menuItemHeight,
       maxHeight: effectiveMaxHeight,
       itemBuilder: _column.menuItemBuilder,


### PR DESCRIPTION
TrinaSelectCell passed widget.cell.value straight into the menu's initialValue (typed T?), forcing an implicit `value as T?` downcast. When a cell's runtime value did not match the column's item type (e.g. a select<int?> column fed a String), the cast threw "type 'String' is not a subtype of type 'int?'" during build and brought down the entire grid.

Now only assign initialValue when the value is actually a T, otherwise pass null so no item is pre-selected. A single mismatched cell can no longer crash the whole grid.