### PR TITLE
fix: decouple checkbox colors from cell selection colors (#390)

### DIFF
--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -452,12 +452,15 @@ class TrinaGridStyleConfig {
     this.filterHeaderColor,
     this.filterPopupHeaderColor,
     this.filterHeaderIconColor,
-  }) : columnCheckedColor = (columnCheckedColor ?? activatedColor),
-       cellCheckedColor = (cellCheckedColor ?? activatedColor),
+    // Checkbox colors default to their own constants rather than the cell
+    // selection colors, so customizing (or hiding) selection does not affect
+    // checkbox visibility. These constants match the historical light defaults.
+  }) : columnCheckedColor = (columnCheckedColor ?? const Color(0xFFDCF5FF)),
+       cellCheckedColor = (cellCheckedColor ?? const Color(0xFFDCF5FF)),
        columnUnselectedColor = (columnUnselectedColor ?? iconColor),
-       columnActiveColor = (columnActiveColor ?? activatedBorderColor),
+       columnActiveColor = (columnActiveColor ?? Colors.lightBlue),
        cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-       cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+       cellActiveColor = (cellActiveColor ?? Colors.lightBlue),
        isDarkStyle = false;
 
   const TrinaGridStyleConfig.dark({
@@ -538,12 +541,15 @@ class TrinaGridStyleConfig {
     this.filterHeaderColor,
     this.filterPopupHeaderColor,
     this.filterHeaderIconColor,
-  }) : columnCheckedColor = (columnCheckedColor ?? activatedColor),
-       cellCheckedColor = (cellCheckedColor ?? activatedColor),
+    // Checkbox colors default to their own constants rather than the cell
+    // selection colors, so customizing (or hiding) selection does not affect
+    // checkbox visibility. These constants match the historical dark defaults.
+  }) : columnCheckedColor = (columnCheckedColor ?? const Color(0xFF313131)),
+       cellCheckedColor = (cellCheckedColor ?? const Color(0xFF313131)),
        columnUnselectedColor = (columnUnselectedColor ?? iconColor),
-       columnActiveColor = (columnActiveColor ?? activatedBorderColor),
+       columnActiveColor = (columnActiveColor ?? const Color(0xFFFFFFFF)),
        cellUnselectedColor = (cellUnselectedColor ?? iconColor),
-       cellActiveColor = (cellActiveColor ?? activatedBorderColor),
+       cellActiveColor = (cellActiveColor ?? const Color(0xFFFFFFFF)),
        isDarkStyle = true;
 
   /// Enable borderShadow in [TrinaGrid].

--- a/test/scenario/configuration/checkbox_color_decoupling_test.dart
+++ b/test/scenario/configuration/checkbox_color_decoupling_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+/// Regression tests for issue #390.
+///
+/// Checkbox colors must not fall back to the cell-selection colors
+/// ([TrinaGridStyleConfig.activatedColor] / [activatedBorderColor]). Hiding
+/// selection by making those transparent must not make checkboxes disappear.
+void main() {
+  group('Checkbox colors are decoupled from selection colors (#390)', () {
+    test(
+      'transparent selection colors do not make checkbox colors transparent',
+      () {
+        const style = TrinaGridStyleConfig(
+          activatedColor: Colors.transparent,
+          activatedBorderColor: Colors.transparent,
+        );
+
+        expect(style.cellCheckedColor, isNot(Colors.transparent));
+        expect(style.cellActiveColor, isNot(Colors.transparent));
+        expect(style.columnCheckedColor, isNot(Colors.transparent));
+        expect(style.columnActiveColor, isNot(Colors.transparent));
+      },
+    );
+
+    test('default light style keeps the historical checkbox colors', () {
+      const style = TrinaGridStyleConfig();
+
+      expect(style.cellCheckedColor, const Color(0xFFDCF5FF));
+      expect(style.columnCheckedColor, const Color(0xFFDCF5FF));
+      expect(style.cellActiveColor, Colors.lightBlue);
+      expect(style.columnActiveColor, Colors.lightBlue);
+    });
+
+    test('default dark style keeps the historical checkbox colors', () {
+      const style = TrinaGridStyleConfig.dark();
+
+      expect(style.cellCheckedColor, const Color(0xFF313131));
+      expect(style.columnCheckedColor, const Color(0xFF313131));
+      expect(style.cellActiveColor, const Color(0xFFFFFFFF));
+      expect(style.columnActiveColor, const Color(0xFFFFFFFF));
+    });
+
+    test('explicitly provided checkbox colors are still honored', () {
+      const style = TrinaGridStyleConfig(
+        activatedColor: Colors.transparent,
+        activatedBorderColor: Colors.transparent,
+        cellCheckedColor: Colors.red,
+        cellActiveColor: Colors.green,
+        columnCheckedColor: Colors.orange,
+        columnActiveColor: Colors.purple,
+      );
+
+      expect(style.cellCheckedColor, Colors.red);
+      expect(style.cellActiveColor, Colors.green);
+      expect(style.columnCheckedColor, Colors.orange);
+      expect(style.columnActiveColor, Colors.purple);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Issue #390: checkbox colors were implicitly coupled to the cell-selection colors. In `TrinaGridStyleConfig`, the checkbox color fields fell back to the selection colors in the constructor:

```dart
columnCheckedColor = (columnCheckedColor ?? activatedColor),
cellCheckedColor   = (cellCheckedColor   ?? activatedColor),
columnActiveColor  = (columnActiveColor  ?? activatedBorderColor),
cellActiveColor    = (cellActiveColor    ?? activatedBorderColor),
```

These feed `TrinaScaledCheckbox` as the checkmark (`checkColor`) and the fill (`activeColor`). So hiding cell selection with `activatedColor: Colors.transparent` + `activatedBorderColor: Colors.transparent` also made checked checkboxes transparent, so they disappeared on screen.

## Fix

Give the four checkbox color fields their own default constants instead of inheriting from the selection colors. The constants equal the historical defaults (light: `0xFFDCF5FF` checkmark / `Colors.lightBlue` fill; dark: `0xFF313131` / `0xFFFFFFFF`), so default appearance is pixel-identical, but checkbox visibility is no longer affected by selection styling.

This is the minimal, non-breaking version of the request. The reporter also sketched a larger nested theme-data refactor (`selectionTheme` / `checkboxTheme`); that would move/remove ~12 widely-used public fields and force a major version, so it is intentionally left as a possible future enhancement rather than bundled here.

## Behavior note

A previously customized `activatedColor` / `activatedBorderColor` no longer drags the checkbox colors with it. To restyle checkboxes, set `cellCheckedColor` / `cellActiveColor` / `columnCheckedColor` / `columnActiveColor` directly.

## Tests

Added `test/scenario/configuration/checkbox_color_decoupling_test.dart`:
- transparent selection colors no longer make checkbox colors transparent
- default light and dark styles keep the historical checkbox colors
- explicitly provided checkbox colors are still honored

Full suite (1587 tests) passes; `dart analyze` clean.

Closes #390
