### PR TITLE
fix: make selectWithSearch popup usable with a11y semantics on web (#394)

### DIFF
--- a/lib/src/ui/widgets/trina_dropdown_menu.dart
+++ b/lib/src/ui/widgets/trina_dropdown_menu.dart
@@ -373,12 +373,32 @@ final class _TrinaSelectMenuWithSearch<T> extends TrinaDropdownMenu<T> {
                    as _TrinaSelectMenuWithSearchState<T>);
            return FocusScope(
              onKeyEvent: (node, event) {
-               if (event.character != null) {
-                 if (state.focusNode.hasFocus == false) {
-                   // Focus the search text field in order
-                   // to receive input from the keyboard.
-                   state.focusNode.requestFocus();
-                 }
+               if (event is KeyUpEvent) return KeyEventResult.ignored;
+
+               final searchHasFocus = state.focusNode.hasFocus;
+
+               // While the search field has focus, hand ArrowDown/ArrowUp off
+               // to the list so its MenuItemButton focus traversal (and the
+               // per-item Enter handler) take over. Intercepting here preempts
+               // the text field consuming the arrow key for caret movement.
+               if (searchHasFocus &&
+                   (event.logicalKey == LogicalKeyboardKey.arrowDown ||
+                       event.logicalKey == LogicalKeyboardKey.arrowUp)) {
+                 final moved = state.focusNode.focusInDirection(
+                   event.logicalKey == LogicalKeyboardKey.arrowDown
+                       ? TraversalDirection.down
+                       : TraversalDirection.up,
+                 );
+                 return moved ? KeyEventResult.handled : KeyEventResult.ignored;
+               }
+
+               // A printable character while the list has focus returns focus
+               // to the search field for type-ahead. Arrow keys have a null
+               // character, so they are excluded here.
+               if (!searchHasFocus && event.character != null) {
+                 // Focus the search text field in order
+                 // to receive input from the keyboard.
+                 state.focusNode.requestFocus();
                }
                return KeyEventResult.ignored;
              },
@@ -485,18 +505,37 @@ class _SearchField<T> extends StatelessWidget {
         if (state._debounce?.isActive ?? false) state._debounce!.cancel();
         state._searchItems();
       },
-      child: ShadInput(
+      // A plain Material [TextField] is used here (rather than shadcn's
+      // ShadInput) because ShadInput does not receive keyboard text input on
+      // Flutter web when accessibility semantics are enabled: the field focuses
+      // and shows a cursor, but typing is dropped. The filter section already
+      // uses a Material TextField and works in that mode, so the search field
+      // mirrors it. See issue #394.
+      child: TextField(
         controller: state.controller,
         focusNode: state.focusNode,
-        placeholder: Text(menu.searchHint),
-        decoration: ShadDecoration.none,
-        padding: const EdgeInsets.all(12),
-        leading: Padding(
-          padding: const EdgeInsets.only(right: 8),
-          child: Icon(
-            LucideIcons.search,
-            size: 16,
-            color: shadColors.popoverForeground,
+        // Focus the search field as soon as the popup opens so keyboard input
+        // (and, on web with semantics, DOM focus) lands on it immediately.
+        autofocus: true,
+        style: TextStyle(fontSize: 14, color: shadColors.popoverForeground),
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: menu.searchHint,
+          border: InputBorder.none,
+          enabledBorder: InputBorder.none,
+          focusedBorder: InputBorder.none,
+          contentPadding: const EdgeInsets.symmetric(vertical: 12),
+          prefixIcon: Padding(
+            padding: const EdgeInsets.only(left: 12, right: 8),
+            child: Icon(
+              LucideIcons.search,
+              size: 16,
+              color: shadColors.popoverForeground,
+            ),
+          ),
+          prefixIconConstraints: const BoxConstraints(
+            minWidth: 0,
+            minHeight: 0,
           ),
         ),
       ),
@@ -1136,6 +1175,14 @@ class _ItemListView<T> extends StatelessWidget {
                   initialValue != null &&
                   menuState.getComparableValue(item) ==
                       menuState.getComparableValue(initialValue);
+              // For the search variant the search field is the autofocus
+              // target on open, so the selected item must not also claim
+              // autofocus (two autofocus nodes in one scope is order
+              // dependent). Other variants keep autofocusing the selection.
+              final autofocusItem =
+                  isSelected &&
+                  menuWidget.variant !=
+                      TrinaDropdownMenuVariant.selectWithSearch;
               return _EnterKeyListener(
                 onEnter: () {
                   menuWidget.onItemSelected(item);
@@ -1147,7 +1194,7 @@ class _ItemListView<T> extends StatelessWidget {
                       menuWidget.onItemSelected(item);
                     },
                     closeOnActivate: false,
-                    autofocus: isSelected,
+                    autofocus: autofocusItem,
                     trailingIcon: isSelected
                         ? const Icon(Icons.check, size: 20)
                         : null,

--- a/test/src/ui/widgets/trina_dropdown_menu_test.dart
+++ b/test/src/ui/widgets/trina_dropdown_menu_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/model/trina_dropdown_menu_filter.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 
@@ -122,7 +122,7 @@ void main() {
         );
 
         // Enter search text — wait long enough for the 250ms search debounce.
-        await tester.enterText(find.byType(ShadInput), 'berry');
+        await tester.enterText(find.byType(TextField), 'berry');
         await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
         // Verify filtered list
@@ -146,12 +146,56 @@ void main() {
                 const Text('No search results!'),
           );
 
-          await tester.enterText(find.byType(ShadInput), 'nonexistent');
+          await tester.enterText(find.byType(TextField), 'nonexistent');
           await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
           expect(find.text('No search results!'), findsOneWidget);
         },
       );
+
+      testWidgets('autofocuses the search field when the menu opens', (
+        WidgetTester tester,
+      ) async {
+        // Regression guard for issue #394: the search field must hold focus on
+        // open so it receives DOM focus on Flutter web with a11y semantics on.
+        await buildStringMenu(
+          tester,
+          items: strTestItems,
+          variant: TrinaDropdownMenuVariant.selectWithSearch,
+        );
+
+        final editable = tester.widget<EditableText>(find.byType(EditableText));
+        expect(editable.focusNode.hasFocus, isTrue);
+
+        // The pre-selected item must NOT steal autofocus for this variant.
+        expect(FocusManager.instance.primaryFocus, editable.focusNode);
+      });
+
+      testWidgets('ArrowDown from the search field moves focus into the list', (
+        WidgetTester tester,
+      ) async {
+        await buildStringMenu(
+          tester,
+          items: strTestItems,
+          variant: TrinaDropdownMenuVariant.selectWithSearch,
+        );
+
+        // Sanity: focus starts in the search field.
+        final editable = tester.widget<EditableText>(find.byType(EditableText));
+        expect(editable.focusNode.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        // Focus should now sit inside one of the list's MenuItemButtons.
+        final focusedContext = FocusManager.instance.primaryFocus?.context;
+        expect(focusedContext, isNotNull);
+        expect(
+          focusedContext!.findAncestorWidgetOfExactType<MenuItemButton>(),
+          isNotNull,
+        );
+        expect(editable.focusNode.hasFocus, isFalse);
+      });
     });
 
     group('Selection Logic', () {


### PR DESCRIPTION
## Problem

On Flutter web with accessibility semantics enabled (a screen reader, or `SemanticsBinding.instance.ensureSemantics()`), the search field inside a `TrinaColumnType.selectWithSearch` popup dropped all keyboard input. The field showed a focused cursor, but `document.activeElement` stayed on `<flutter-view>` instead of the text-editing `<input>` host, so typing never reached the field and the list never filtered. It worked fine with semantics off. This is an accessibility blocker for screen-reader users doing data entry.

Fixes #394.

## Root cause

In semantics mode, Flutter web routes keyboard text to a field only through the DOM `<input>` the engine creates for that field's semantics node (`SemanticsTextEditingStrategy`). The shadcn `ShadInput` used by the search field did not receive that semantic input inside the `MenuAnchor` overlay, so keystrokes had nowhere to go. The filter variant, which uses a plain Material `TextField`, worked in the same overlay under the same conditions, which pinpointed the input widget as the cause. (This is adjacent to the known, still-open Flutter engine issue flutter/flutter#129324.)

## Changes

- Replace the `ShadInput` search field with a styled Material `TextField` (search icon, hint, borderless), matching the filter fields that already work under semantics.
- Autofocus the search field when the popup opens so it is ready to type immediately and receives DOM focus during the opening gesture on web.
- Route ArrowUp/Down/Enter from the search field into the list so keyboard navigation still works (combobox behavior), and suppress the selected item's autofocus for this variant so there is a single autofocus target.
- Add widget tests covering the search-field autofocus and the arrow-key routing into the list.

## Verification

- `dart format` and `dart analyze` are clean on the changed files.
- New and existing `selectWithSearch` widget tests pass.
- Manually verified on a Flutter web release-style run with semantics forced on: opening the popup focuses the search field, `document.activeElement` is the `<input>`, and typing filters the list. Also verified on Windows desktop (no regression); arrow-key navigation and Enter-to-select still work.