### PR TITLE
feat: add built-in record sidebar (docked and floating)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
     - [Custom Styling](#custom-styling)
     - [Loading Options](#loading-options)
     - [Enhanced Scrollbars](#enhanced-scrollbars)
+    - [Record Sidebar](#record-sidebar)
     - [RTL Support](#rtl-support)
     - [Dark Mode](#dark-mode)
     - [Value Formatter](#value-formatter)
@@ -448,6 +449,9 @@ Customize loading states and indicators
 
 #### Enhanced Scrollbars
 Draggable scrollbars with hover effects, custom colors, and improved desktop experience
+
+#### Record Sidebar
+Show all fields of the selected row in a searchable, editable panel, docked (pushes the grid) or floating (slides over it)
 
 #### RTL Support
 Right-to-left language support

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -49,6 +49,7 @@ import 'screen/feature/row_infinity_scroll_screen.dart';
 import 'screen/feature/row_lazy_pagination_screen.dart';
 import 'screen/feature/row_moving_screen.dart';
 import 'screen/feature/row_pagination_screen.dart';
+import 'screen/feature/record_sidebar_screen.dart';
 import 'screen/feature/row_selection_screen.dart';
 import 'screen/feature/row_with_checkbox_screen.dart';
 import 'screen/feature/rtl_screen.dart';
@@ -150,6 +151,7 @@ class MyApp extends StatelessWidget {
             const RowLazyPaginationScreen(),
         RowMovingScreen.routeName: (context) => const RowMovingScreen(),
         RowPaginationScreen.routeName: (context) => const RowPaginationScreen(),
+        RecordSidebarScreen.routeName: (context) => const RecordSidebarScreen(),
         RowSelectionScreen.routeName: (context) => const RowSelectionScreen(),
         RowWithCheckboxScreen.routeName: (context) =>
             const RowWithCheckboxScreen(),

--- a/demo/lib/screen/feature/record_sidebar_screen.dart
+++ b/demo/lib/screen/feature/record_sidebar_screen.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../dummy_data/development.dart';
+import '../../widget/trina_example_button.dart';
+import '../../widget/trina_example_screen.dart';
+
+class RecordSidebarScreen extends StatefulWidget {
+  static const routeName = 'feature/record-sidebar';
+
+  const RecordSidebarScreen({super.key});
+
+  @override
+  State<RecordSidebarScreen> createState() => _RecordSidebarScreenState();
+}
+
+class _RecordSidebarScreenState extends State<RecordSidebarScreen> {
+  final List<TrinaColumn> columns = [];
+
+  final List<TrinaRow> rows = [];
+
+  TrinaGridStateManager? stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final dummyData = DummyData(10, 100);
+    columns.addAll(dummyData.columns);
+    rows.addAll(dummyData.rows);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaExampleScreen(
+      title: 'Record Sidebar',
+      topTitle: 'Record Sidebar',
+      topContents: const [
+        Text(
+          'A sidebar that shows every field of the selected row, with a search '
+          'box and inline editing. It is a built-in grid feature toggled '
+          'through the state manager.',
+        ),
+        Text(
+          'Use the buttons above the grid to show/hide it, switch between '
+          'docked (pushes the grid) and floating (slides over the grid) modes, '
+          'and change its width.',
+        ),
+      ],
+      topButtons: [
+        TrinaExampleButton(
+          url:
+              'https://github.com/doonfrs/trina_grid/blob/master/demo/lib/screen/feature/record_sidebar_screen.dart',
+        ),
+      ],
+      body: TrinaGrid(
+        columns: columns,
+        rows: rows,
+        configuration: const TrinaGridConfiguration(
+          sidebar: TrinaGridSidebarConfig(width: 340),
+        ),
+        createHeader: (stateManager) => _Header(stateManager: stateManager),
+        onLoaded: (TrinaGridOnLoadedEvent event) {
+          event.stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+          event.stateManager.showSidebar();
+          stateManager = event.stateManager;
+        },
+      ),
+    );
+  }
+}
+
+class _Header extends StatefulWidget {
+  const _Header({required this.stateManager});
+
+  final TrinaGridStateManager stateManager;
+
+  @override
+  State<_Header> createState() => _HeaderState();
+}
+
+class _HeaderState extends State<_Header> {
+  TrinaGridStateManager get stateManager => widget.stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+    stateManager.addListener(_update);
+  }
+
+  @override
+  void dispose() {
+    stateManager.removeListener(_update);
+    super.dispose();
+  }
+
+  void _update() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          children: [
+            ElevatedButton.icon(
+              icon: Icon(
+                stateManager.isSidebarVisible
+                    ? Icons.view_sidebar
+                    : Icons.view_sidebar_outlined,
+              ),
+              label: Text(
+                stateManager.isSidebarVisible ? 'Hide sidebar' : 'Show sidebar',
+              ),
+              onPressed: () => stateManager.toggleSidebar(),
+            ),
+            const SizedBox(width: 16),
+            const Text('Mode:'),
+            const SizedBox(width: 8),
+            SegmentedButton<TrinaGridSidebarMode>(
+              segments: const [
+                ButtonSegment(
+                  value: TrinaGridSidebarMode.docked,
+                  label: Text('Docked'),
+                  icon: Icon(Icons.vertical_split),
+                ),
+                ButtonSegment(
+                  value: TrinaGridSidebarMode.floating,
+                  label: Text('Floating'),
+                  icon: Icon(Icons.flip_to_front),
+                ),
+              ],
+              selected: {stateManager.sidebarMode},
+              onSelectionChanged: (selection) {
+                stateManager.setSidebarMode(selection.first);
+              },
+            ),
+            const SizedBox(width: 16),
+            const Text('Width:'),
+            const SizedBox(width: 8),
+            for (final width in const [280.0, 340.0, 420.0])
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: ChoiceChip(
+                  label: Text('${width.toInt()}'),
+                  selected: stateManager.sidebarWidth == width,
+                  onSelected: (_) => stateManager.setSidebarWidth(width),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -51,6 +51,7 @@ import 'feature/grid_as_popup_screen.dart';
 import 'feature/listing_mode_screen.dart';
 import 'feature/moving_screen.dart';
 import 'feature/number_type_column_screen.dart';
+import 'feature/record_sidebar_screen.dart';
 import 'feature/row_color_screen.dart';
 import 'feature/row_group_screen.dart';
 import 'feature/row_infinity_scroll_screen.dart';
@@ -439,6 +440,16 @@ class _TrinaFeaturesState extends State<TrinaFeatures> {
         onTapLiveDemo: () {
           Navigator.pushNamed(context, RowSelectionScreen.routeName);
         },
+      ),
+      TrinaListTile(
+        title: 'Record Sidebar',
+        description:
+            'Sidebar showing all fields of the selected row, with search and '
+            'inline editing. Docked or floating.',
+        onTapLiveDemo: () {
+          Navigator.pushNamed(context, RecordSidebarScreen.routeName);
+        },
+        trailing: newIcon,
       ),
       TrinaListTile(
         title: 'Row moving',

--- a/doc/features/sidebar.md
+++ b/doc/features/sidebar.md
@@ -1,0 +1,119 @@
+# Record Sidebar
+
+The record sidebar is a built-in panel that shows every field of the currently selected row as a `label -> value` list, with a search box to filter fields and inline editing that writes changes back to the grid.
+
+## Overview
+
+The sidebar is configured through the `sidebar` property in `TrinaGridConfiguration` and toggled at runtime through the `TrinaGridStateManager`. It supports two display modes:
+
+- **Docked** (default): the sidebar takes horizontal space and pushes the grid area to the left.
+- **Floating**: the sidebar slides in from the right over the grid as an overlay with a close button, and slides back out when hidden.
+
+The sidebar is hidden by default. It updates automatically as the selected (active) row changes.
+
+## Basic Usage
+
+Enable and size the sidebar via configuration, then toggle it through the state manager:
+
+```dart
+late TrinaGridStateManager stateManager;
+
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration(
+    sidebar: TrinaGridSidebarConfig(
+      width: 340,
+      mode: TrinaGridSidebarMode.docked,
+    ),
+  ),
+  onLoaded: (event) {
+    stateManager = event.stateManager;
+    // Highlight whole rows so the sidebar tracks the selected record.
+    stateManager.setSelectingMode(TrinaGridSelectingMode.row);
+  },
+)
+
+// Somewhere in your UI (e.g. a toolbar button):
+ElevatedButton(
+  onPressed: () => stateManager.toggleSidebar(),
+  child: const Text('Toggle sidebar'),
+)
+```
+
+## Controlling the sidebar
+
+The following actions are available on `TrinaGridStateManager`:
+
+```dart
+stateManager.showSidebar();                                  // show (default mode)
+stateManager.showSidebar(mode: TrinaGridSidebarMode.floating); // show as floating
+stateManager.hideSidebar();                                  // hide
+stateManager.toggleSidebar();                                // flip visibility
+stateManager.toggleSidebar(mode: TrinaGridSidebarMode.docked); // flip + set mode
+stateManager.setSidebarMode(TrinaGridSidebarMode.floating);  // change mode
+stateManager.setSidebarWidth(420);                           // change width
+```
+
+Read the current state:
+
+```dart
+stateManager.isSidebarVisible; // bool
+stateManager.sidebarMode;      // TrinaGridSidebarMode
+stateManager.sidebarWidth;     // double
+```
+
+## Custom content
+
+By default the sidebar renders the built-in record view (field list + search + inline editing). To render your own content, provide a `contentBuilder`. It receives the grid's `stateManager`, so you can read the current row (`stateManager.currentRow`) and write values back.
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration(
+    sidebar: TrinaGridSidebarConfig(
+      contentBuilder: (context, stateManager) {
+        final row = stateManager.currentRow;
+        if (row == null) {
+          return const Center(child: Text('Select a row'));
+        }
+        return ListView(
+          children: [
+            for (final column in stateManager.columns)
+              ListTile(
+                title: Text(column.title),
+                subtitle: Text(
+                  row.cells[column.field]?.value?.toString() ?? '',
+                ),
+              ),
+          ],
+        );
+      },
+    ),
+  ),
+)
+```
+
+> Note: in floating mode the built-in view shows a close button next to its search field. Custom content is responsible for its own close affordance - call `stateManager.hideSidebar()` from your widget.
+
+> Note: passing an inline closure to `contentBuilder` makes each `TrinaGridConfiguration` compare as unequal (closures compare by identity). Use a stable function reference if you rely on configuration equality.
+
+## Configuration Options
+
+### TrinaGridSidebarConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `enabled` | `bool` | `true` | Whether the sidebar feature responds to show/toggle actions. |
+| `mode` | `TrinaGridSidebarMode` | `docked` | Default display mode when none is passed to show/toggle. |
+| `width` | `double` | `320` | Default panel width in logical pixels. |
+| `animationDuration` | `Duration` | `250ms` | Slide animation duration used in floating mode. |
+| `contentBuilder` | `TrinaGridSidebarContentBuilder?` | `null` | Optional builder to replace the built-in record view. |
+
+### TrinaGridSidebarMode
+
+| Value | Description |
+|-------|-------------|
+| `docked` | Takes horizontal space and pushes the grid. |
+| `floating` | Slides in over the grid with a close button. |

--- a/doc/index.md
+++ b/doc/index.md
@@ -69,6 +69,7 @@ Welcome to the official documentation for TrinaGrid, a powerful data grid for Fl
 - [Custom Styling](features/custom-styling.md)
 - [Loading Options](features/loading-options.md)
 - [Scrollbars](features/scrollbars.md)
+- [Record Sidebar](features/sidebar.md)
 - [Fit Content (Auto-Size)](features/fit-content.md)
 - [RTL Support](features/rtl-support.md)
 

--- a/lib/src/manager/state/sidebar_state.dart
+++ b/lib/src/manager/state/sidebar_state.dart
@@ -1,0 +1,123 @@
+import 'package:trina_grid/trina_grid.dart';
+
+/// State for the record sidebar - a panel showing all fields of the currently
+/// selected row, with a search box and inline editing.
+///
+/// Defaults (mode/width) come from [TrinaGridConfiguration.sidebar] until they
+/// are overridden through the setters below.
+abstract class ISidebarState {
+  /// Whether the sidebar is currently visible.
+  bool get isSidebarVisible;
+
+  /// The current display mode (docked or floating).
+  TrinaGridSidebarMode get sidebarMode;
+
+  /// The current sidebar width in logical pixels.
+  double get sidebarWidth;
+
+  /// Show or hide the sidebar.
+  ///
+  /// Optionally set the [mode] at the same time. Does nothing when the sidebar
+  /// feature is disabled via [TrinaGridConfiguration.sidebar].
+  void setSidebarVisible(
+    bool flag, {
+    TrinaGridSidebarMode? mode,
+    bool notify = true,
+  });
+
+  /// Set the sidebar display mode.
+  void setSidebarMode(TrinaGridSidebarMode mode, {bool notify = true});
+
+  /// Set the sidebar width.
+  void setSidebarWidth(double width, {bool notify = true});
+
+  /// Show the sidebar, optionally in the given [mode].
+  void showSidebar({TrinaGridSidebarMode? mode});
+
+  /// Hide the sidebar.
+  void hideSidebar();
+
+  /// Toggle the sidebar visibility, optionally setting the [mode] when showing.
+  void toggleSidebar({TrinaGridSidebarMode? mode});
+}
+
+class _State {
+  bool? _visible;
+
+  TrinaGridSidebarMode? _mode;
+
+  double? _width;
+}
+
+mixin SidebarState implements ITrinaGridState {
+  final _State _state = _State();
+
+  @override
+  bool get isSidebarVisible => _state._visible ?? false;
+
+  @override
+  TrinaGridSidebarMode get sidebarMode =>
+      _state._mode ?? configuration.sidebar.mode;
+
+  @override
+  double get sidebarWidth => _state._width ?? configuration.sidebar.width;
+
+  @override
+  void setSidebarVisible(
+    bool flag, {
+    TrinaGridSidebarMode? mode,
+    bool notify = true,
+  }) {
+    if (!configuration.sidebar.enabled) {
+      return;
+    }
+
+    final newMode = mode ?? sidebarMode;
+
+    if (isSidebarVisible == flag && sidebarMode == newMode) {
+      return;
+    }
+
+    _state._visible = flag;
+    _state._mode = newMode;
+
+    notifyListeners(notify, setSidebarVisible.hashCode);
+  }
+
+  @override
+  void setSidebarMode(TrinaGridSidebarMode mode, {bool notify = true}) {
+    if (sidebarMode == mode) {
+      return;
+    }
+
+    _state._mode = mode;
+
+    notifyListeners(notify, setSidebarMode.hashCode);
+  }
+
+  @override
+  void setSidebarWidth(double width, {bool notify = true}) {
+    if (sidebarWidth == width) {
+      return;
+    }
+
+    _state._width = width;
+
+    notifyListeners(notify, setSidebarWidth.hashCode);
+  }
+
+  @override
+  void showSidebar({TrinaGridSidebarMode? mode}) {
+    setSidebarVisible(true, mode: mode);
+  }
+
+  @override
+  void hideSidebar() {
+    setSidebarVisible(false);
+  }
+
+  @override
+  void toggleSidebar({TrinaGridSidebarMode? mode}) {
+    setSidebarVisible(!isSidebarVisible, mode: mode);
+  }
+}

--- a/lib/src/manager/trina_change_notifier_filter.dart
+++ b/lib/src/manager/trina_change_notifier_filter.dart
@@ -149,6 +149,11 @@ abstract class TrinaChangeNotifierFilterResolver {
       /// hovering_state
       stateManager.setHoveredRowIdx.hashCode: 'setHoveredRowIdx',
       stateManager.isRowIdxHovered.hashCode: 'isRowIdxHovered',
+
+      /// sidebar_state
+      stateManager.setSidebarVisible.hashCode: 'setSidebarVisible',
+      stateManager.setSidebarMode.hashCode: 'setSidebarMode',
+      stateManager.setSidebarWidth.hashCode: 'setSidebarWidth',
     };
   }
 }
@@ -209,6 +214,9 @@ class TrinaNotifierFilterResolverDefault
       stateManager.moveColumn.hashCode,
       stateManager.hideColumn.hashCode,
       stateManager.notifyChangedShowFrozenColumn.hashCode,
+      stateManager.setSidebarVisible.hashCode,
+      stateManager.setSidebarMode.hashCode,
+      stateManager.setSidebarWidth.hashCode,
     };
   }
 

--- a/lib/src/manager/trina_grid_state_manager.dart
+++ b/lib/src/manager/trina_grid_state_manager.dart
@@ -22,6 +22,7 @@ import 'state/row_group_state.dart';
 import 'state/row_state.dart';
 import 'state/scroll_state.dart';
 import 'state/selecting_state.dart';
+import 'state/sidebar_state.dart';
 import 'state/visibility_layout_state.dart';
 import 'state/hovering_state.dart';
 
@@ -44,6 +45,7 @@ abstract class ITrinaGridState
         IRowState,
         IScrollState,
         ISelectingState,
+        ISidebarState,
         IVisibilityLayoutState,
         IHoveringState {}
 
@@ -65,6 +67,7 @@ class TrinaGridStateChangeNotifier extends TrinaChangeNotifier
         RowState,
         ScrollState,
         SelectingState,
+        SidebarState,
         VisibilityLayoutState,
         HoveringState {
   TrinaGridStateChangeNotifier({

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -584,6 +584,12 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
 
   bool _showLoading = false;
 
+  bool _isSidebarVisible = false;
+
+  TrinaGridSidebarMode _sidebarMode = TrinaGridSidebarMode.docked;
+
+  double _sidebarWidth = 320;
+
   bool _hasLeftFrozenColumns = false;
 
   bool _hasRightFrozenColumns = false;
@@ -696,6 +702,18 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
     );
 
     _showLoading = update<bool>(_showLoading, stateManager.showLoading);
+
+    _isSidebarVisible = update<bool>(
+      _isSidebarVisible,
+      stateManager.isSidebarVisible,
+    );
+
+    _sidebarMode = update<TrinaGridSidebarMode>(
+      _sidebarMode,
+      stateManager.sidebarMode,
+    );
+
+    _sidebarWidth = update<double>(_sidebarWidth, stateManager.sidebarWidth);
 
     _hasLeftFrozenColumns = update<bool>(
       _hasLeftFrozenColumns,
@@ -1110,14 +1128,69 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       }
     }
 
+    final Widget grid = _GridContainer(
+      stateManager: _stateManager,
+      scrollPhysics: widget.scrollPhysics,
+      child: body,
+    );
+
     return FocusScope(
       onFocusChange: _stateManager.setKeepFocus,
       onKeyEvent: _handleGridFocusOnKey,
-      child: _GridContainer(
-        stateManager: _stateManager,
-        scrollPhysics: widget.scrollPhysics,
-        child: body,
-      ),
+      child: _wrapWithSidebar(grid),
+    );
+  }
+
+  /// Wraps the grid with the record sidebar according to the current sidebar
+  /// state. Docked mode pushes the grid; floating mode slides a panel over it.
+  Widget _wrapWithSidebar(Widget grid) {
+    final sidebar = _stateManager.configuration.sidebar;
+    if (!sidebar.enabled) {
+      return grid;
+    }
+
+    Widget panel(bool floating) {
+      final content =
+          sidebar.contentBuilder?.call(context, _stateManager) ??
+          TrinaSidebar(stateManager: _stateManager, showCloseButton: floating);
+
+      return TrinaSidebarContainer(stateManager: _stateManager, child: content);
+    }
+
+    if (_stateManager.sidebarMode.isFloating) {
+      final visible = _stateManager.isSidebarVisible;
+      final width = _stateManager.sidebarWidth;
+
+      // Animate the panel position so the Stack fully clips it when hidden
+      // (a paint-time transform would spill outside the Stack bounds).
+      return Stack(
+        clipBehavior: Clip.hardEdge,
+        children: [
+          Positioned.fill(child: grid),
+          AnimatedPositioned(
+            duration: sidebar.animationDuration,
+            curve: Curves.easeInOut,
+            top: 0,
+            bottom: 0,
+            width: width,
+            right: visible ? 0 : -width,
+            child: IgnorePointer(ignoring: !visible, child: panel(true)),
+          ),
+        ],
+      );
+    }
+
+    // Docked mode: take space and push the grid. When hidden, leave the grid
+    // untouched so grids that never use the sidebar keep their original tree.
+    if (!_stateManager.isSidebarVisible) {
+      return grid;
+    }
+
+    return Row(
+      children: [
+        Expanded(child: grid),
+        SizedBox(width: _stateManager.sidebarWidth, child: panel(false)),
+      ],
     );
   }
 }

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -106,6 +106,13 @@ class TrinaGridConfiguration {
 
   final TrinaGridLocaleText localeText;
 
+  /// Configure the record sidebar (a panel showing the selected row's fields).
+  ///
+  /// Toggle it at runtime with [TrinaGridStateManager.toggleSidebar],
+  /// [TrinaGridStateManager.showSidebar] and
+  /// [TrinaGridStateManager.hideSidebar].
+  final TrinaGridSidebarConfig sidebar;
+
   /// Display total number of rows in pagination footer.
   ///
   /// Default is true.
@@ -193,6 +200,7 @@ class TrinaGridConfiguration {
     this.columnFilter = const TrinaGridColumnFilterConfig(),
     this.columnSize = const TrinaGridColumnSizeConfig(),
     this.localeText = const TrinaGridLocaleText(),
+    this.sidebar = const TrinaGridSidebarConfig(),
     this.paginationShowTotalRows = true,
     this.paginationEnableGotoPage = true,
     this.enableDragSelection = false,
@@ -218,6 +226,7 @@ class TrinaGridConfiguration {
     this.columnFilter = const TrinaGridColumnFilterConfig(),
     this.columnSize = const TrinaGridColumnSizeConfig(),
     this.localeText = const TrinaGridLocaleText(),
+    this.sidebar = const TrinaGridSidebarConfig(),
     this.paginationShowTotalRows = true,
     this.paginationEnableGotoPage = true,
     this.enableDragSelection = false,
@@ -269,6 +278,7 @@ class TrinaGridConfiguration {
     TrinaGridColumnFilterConfig? columnFilter,
     TrinaGridColumnSizeConfig? columnSize,
     TrinaGridLocaleText? localeText,
+    TrinaGridSidebarConfig? sidebar,
     bool? enableDragSelection,
     bool? enableCtrlClickMultiSelect,
     Duration? dragSelectionDelayDuration,
@@ -294,6 +304,7 @@ class TrinaGridConfiguration {
       columnFilter: columnFilter ?? this.columnFilter,
       columnSize: columnSize ?? this.columnSize,
       localeText: localeText ?? this.localeText,
+      sidebar: sidebar ?? this.sidebar,
       enableDragSelection: enableDragSelection ?? this.enableDragSelection,
       enableCtrlClickMultiSelect:
           enableCtrlClickMultiSelect ?? this.enableCtrlClickMultiSelect,
@@ -329,6 +340,7 @@ class TrinaGridConfiguration {
             columnFilter == other.columnFilter &&
             columnSize == other.columnSize &&
             localeText == other.localeText &&
+            sidebar == other.sidebar &&
             enableDragSelection == other.enableDragSelection &&
             enableCtrlClickMultiSelect == other.enableCtrlClickMultiSelect &&
             dragSelectionDelayDuration == other.dragSelectionDelayDuration &&
@@ -352,6 +364,7 @@ class TrinaGridConfiguration {
     columnFilter,
     columnSize,
     localeText,
+    sidebar,
     enableDragSelection,
     enableCtrlClickMultiSelect,
     Object.hash(
@@ -1587,6 +1600,92 @@ class TrinaGridColumnSizeConfig {
     restoreAutoSizeAfterInsertColumn,
     restoreAutoSizeAfterRemoveColumn,
   );
+}
+
+/// Builds custom content for the record sidebar.
+///
+/// Receives the grid's [stateManager] so the content can read the current row
+/// (`stateManager.currentRow`), columns and write values back. Return the
+/// widget to display inside the sidebar panel. When null, the built-in record
+/// view (field list with search and inline editing) is used.
+typedef TrinaGridSidebarContentBuilder =
+    Widget Function(BuildContext context, TrinaGridStateManager stateManager);
+
+/// Configuration for the record sidebar - a panel that shows all fields of the
+/// currently selected row, with a search box and inline editing.
+///
+/// The sidebar is hidden by default. Toggle it at runtime through the state
+/// manager: [TrinaGridStateManager.showSidebar],
+/// [TrinaGridStateManager.hideSidebar] and
+/// [TrinaGridStateManager.toggleSidebar].
+class TrinaGridSidebarConfig {
+  const TrinaGridSidebarConfig({
+    this.enabled = true,
+    this.mode = TrinaGridSidebarMode.docked,
+    this.width = 320,
+    this.animationDuration = const Duration(milliseconds: 250),
+    this.contentBuilder,
+  });
+
+  /// Whether the sidebar feature is enabled.
+  ///
+  /// When false, [TrinaGridStateManager.showSidebar] and
+  /// [TrinaGridStateManager.toggleSidebar] have no effect.
+  final bool enabled;
+
+  /// The default display mode used when a mode is not passed to
+  /// [TrinaGridStateManager.showSidebar] / [TrinaGridStateManager.toggleSidebar].
+  ///
+  /// [TrinaGridSidebarMode.docked] takes space and pushes the grid.
+  /// [TrinaGridSidebarMode.floating] slides in over the grid.
+  final TrinaGridSidebarMode mode;
+
+  /// The default width of the sidebar panel in logical pixels.
+  ///
+  /// Change it at runtime with [TrinaGridStateManager.setSidebarWidth].
+  final double width;
+
+  /// Slide animation duration used in [TrinaGridSidebarMode.floating].
+  final Duration animationDuration;
+
+  /// Optional builder to replace the built-in record view with custom content.
+  ///
+  /// Note: because a new closure is not equal to the previous one, passing an
+  /// inline builder makes each [TrinaGridConfiguration] compare as unequal. Use
+  /// a stable function reference if you rely on configuration equality.
+  final TrinaGridSidebarContentBuilder? contentBuilder;
+
+  TrinaGridSidebarConfig copyWith({
+    bool? enabled,
+    TrinaGridSidebarMode? mode,
+    double? width,
+    Duration? animationDuration,
+    TrinaGridSidebarContentBuilder? contentBuilder,
+  }) {
+    return TrinaGridSidebarConfig(
+      enabled: enabled ?? this.enabled,
+      mode: mode ?? this.mode,
+      width: width ?? this.width,
+      animationDuration: animationDuration ?? this.animationDuration,
+      contentBuilder: contentBuilder ?? this.contentBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(covariant Object other) {
+    return identical(this, other) ||
+        other is TrinaGridSidebarConfig &&
+            runtimeType == other.runtimeType &&
+            enabled == other.enabled &&
+            mode == other.mode &&
+            width == other.width &&
+            animationDuration == other.animationDuration &&
+            contentBuilder == other.contentBuilder;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(enabled, mode, width, animationDuration, contentBuilder);
 }
 
 class TrinaGridLocaleText {

--- a/lib/src/trina_grid_enums.dart
+++ b/lib/src/trina_grid_enums.dart
@@ -142,3 +142,19 @@ enum TrinaTimePickerAutoFocusMode {
   /// Returns true if any field should be focused.
   bool get isEnabled => this != TrinaTimePickerAutoFocusMode.none;
 }
+
+/// Controls how the record sidebar is displayed relative to the grid.
+enum TrinaGridSidebarMode {
+  /// The sidebar takes horizontal space and pushes the grid area to the left.
+  docked,
+
+  /// The sidebar slides in from the right over the grid as an overlay with a
+  /// close button.
+  floating;
+
+  /// Returns true if the sidebar is docked (takes space next to the grid).
+  bool get isDocked => this == TrinaGridSidebarMode.docked;
+
+  /// Returns true if the sidebar floats over the grid.
+  bool get isFloating => this == TrinaGridSidebarMode.floating;
+}

--- a/lib/src/ui/trina_sidebar.dart
+++ b/lib/src/ui/trina_sidebar.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+/// Chrome for the record sidebar panel.
+///
+/// Provides the panel background and a left border from the grid style around
+/// its [child] (the built-in record view or a custom builder result).
+class TrinaSidebarContainer extends StatelessWidget {
+  const TrinaSidebarContainer({
+    super.key,
+    required this.stateManager,
+    required this.child,
+  });
+
+  final TrinaGridStateManager stateManager;
+
+  /// The sidebar content (built-in record view or a custom builder result).
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = stateManager.style;
+
+    return FocusTraversalGroup(
+      child: Container(
+        decoration: BoxDecoration(
+          color: style.gridBackgroundColor,
+          border: Border(
+            left: BorderSide(
+              color: style.gridBorderColor,
+              width: style.gridBorderWidth,
+            ),
+          ),
+        ),
+        child: child,
+      ),
+    );
+  }
+}
+
+/// The built-in record view for the sidebar.
+///
+/// Lists every field of the grid's currently selected/active row as a
+/// `label -> value` list, with a search box to filter fields and inline editing
+/// that writes changes back to the grid.
+///
+/// It subscribes to the [TrinaGridStateManager] and rebuilds its field editors
+/// whenever the active row changes.
+class TrinaSidebar extends StatefulWidget {
+  const TrinaSidebar({
+    super.key,
+    required this.stateManager,
+    this.showCloseButton = false,
+  });
+
+  final TrinaGridStateManager stateManager;
+
+  /// Whether to show a close button next to the search field (floating mode).
+  final bool showCloseButton;
+
+  @override
+  State<TrinaSidebar> createState() => _TrinaSidebarState();
+}
+
+class _TrinaSidebarState extends State<TrinaSidebar> {
+  TrinaGridStateManager get stateManager => widget.stateManager;
+
+  /// Controllers/focus nodes keyed by column field, rebuilt on row change.
+  final Map<String, TextEditingController> _controllers = {};
+  final Map<String, FocusNode> _focusNodes = {};
+
+  /// The key of the row currently shown, used to detect row changes.
+  Key? _currentRowKey;
+
+  /// Current field search query (lower-cased).
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _currentRowKey = stateManager.currentRow?.key;
+    _rebuildControllers();
+    stateManager.addListener(_onGridChanged);
+  }
+
+  @override
+  void dispose() {
+    stateManager.removeListener(_onGridChanged);
+    _disposeControllers();
+    super.dispose();
+  }
+
+  /// Fires on any grid state change. We only rebuild when the active row
+  /// changes so that in-progress typing is never clobbered and edits that
+  /// themselves trigger a notification do not cause a rebuild loop.
+  void _onGridChanged() {
+    final newKey = stateManager.currentRow?.key;
+    if (newKey != _currentRowKey) {
+      _currentRowKey = newKey;
+      _rebuildControllers();
+      if (mounted) setState(() {});
+    }
+  }
+
+  void _disposeControllers() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    for (final node in _focusNodes.values) {
+      node.dispose();
+    }
+    _controllers.clear();
+    _focusNodes.clear();
+  }
+
+  void _rebuildControllers() {
+    _disposeControllers();
+
+    final row = stateManager.currentRow;
+    if (row == null) return;
+
+    for (final column in stateManager.columns) {
+      final value = row.cells[column.field]?.value;
+      _controllers[column.field] = TextEditingController(
+        text: value?.toString() ?? '',
+      );
+
+      final node = FocusNode();
+      node.addListener(() {
+        // Commit the value when the field loses focus.
+        if (!node.hasFocus) _commit(column);
+      });
+      _focusNodes[column.field] = node;
+    }
+  }
+
+  /// Writes the edited text back to the grid cell.
+  void _commit(TrinaColumn column) {
+    if (column.readOnly) return;
+
+    final row = stateManager.currentRow;
+    if (row == null) return;
+
+    final cell = row.cells[column.field];
+    final controller = _controllers[column.field];
+    if (cell == null || controller == null) return;
+
+    final text = controller.text;
+    if ((cell.value?.toString() ?? '') == text) return;
+
+    // changeCellValue casts the text according to the column type.
+    stateManager.changeCellValue(cell, text);
+
+    // Re-sync the field with the stored value (it may be reformatted, e.g.
+    // number/currency columns).
+    final storedText = cell.value?.toString() ?? '';
+    if (controller.text != storedText) {
+      controller.text = storedText;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = stateManager.style;
+    final row = stateManager.currentRow;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 4, 12),
+          child: Row(
+            children: [
+              Expanded(child: _buildSearchField(style)),
+              if (widget.showCloseButton)
+                IconButton(
+                  icon: Icon(
+                    Icons.close,
+                    color: style.iconColor,
+                    size: style.iconSize,
+                  ),
+                  tooltip: 'Hide sidebar',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: stateManager.hideSidebar,
+                ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: row == null
+              ? _buildEmptyState(style)
+              : _buildFields(style, row),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSearchField(TrinaGridStyleConfig style) {
+    return TextField(
+      style: style.cellTextStyle,
+      decoration: InputDecoration(
+        hintText: 'Search for field...',
+        prefixIcon: Icon(Icons.search, color: style.iconColor),
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (value) {
+        setState(() => _query = value.trim().toLowerCase());
+      },
+    );
+  }
+
+  Widget _buildEmptyState(TrinaGridStyleConfig style) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Select a row to view its fields.',
+          textAlign: TextAlign.center,
+          style: style.cellTextStyle.copyWith(
+            color: style.cellTextStyle.color?.withValues(alpha: 0.6),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFields(TrinaGridStyleConfig style, TrinaRow row) {
+    final columns = stateManager.columns.where((column) {
+      if (_query.isEmpty) return true;
+      final value = row.cells[column.field]?.value?.toString() ?? '';
+      return column.title.toLowerCase().contains(_query) ||
+          column.field.toLowerCase().contains(_query) ||
+          value.toLowerCase().contains(_query);
+    }).toList();
+
+    if (columns.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'No fields match "$_query".',
+            textAlign: TextAlign.center,
+            style: style.cellTextStyle.copyWith(
+              color: style.cellTextStyle.color?.withValues(alpha: 0.6),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      itemCount: columns.length,
+      separatorBuilder: (_, _) => const SizedBox(height: 12),
+      itemBuilder: (context, index) => _buildFieldRow(style, columns[index]),
+    );
+  }
+
+  Widget _buildFieldRow(TrinaGridStyleConfig style, TrinaColumn column) {
+    final controller = _controllers[column.field];
+    final labelColor = style.cellTextStyle.color?.withValues(alpha: 0.6);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                column.title,
+                style: style.cellTextStyle.copyWith(
+                  fontSize: (style.cellTextStyle.fontSize ?? 14) - 2,
+                  color: labelColor,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (column.readOnly)
+              Icon(Icons.lock_outline, size: 14, color: labelColor),
+          ],
+        ),
+        const SizedBox(height: 4),
+        TextField(
+          controller: controller,
+          focusNode: _focusNodes[column.field],
+          readOnly: column.readOnly,
+          style: style.cellTextStyle,
+          decoration: InputDecoration(
+            isDense: true,
+            filled: column.readOnly,
+            fillColor: column.readOnly ? style.cellColorInReadOnlyState : null,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 10,
+              vertical: 8,
+            ),
+            border: const OutlineInputBorder(),
+          ),
+          onSubmitted: (_) => _commit(column),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/ui.dart
+++ b/lib/src/ui/ui.dart
@@ -27,3 +27,4 @@ export 'trina_left_frozen_rows.dart';
 export 'trina_right_frozen_columns.dart';
 export 'trina_right_frozen_columns_footer.dart';
 export 'trina_right_frozen_rows.dart';
+export 'trina_sidebar.dart';

--- a/test/scenario/sidebar/sidebar_state_test.dart
+++ b/test/scenario/sidebar/sidebar_state_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../mock/shared_mocks.mocks.dart';
+
+void main() {
+  TrinaGridStateManager createStateManager({
+    TrinaGridConfiguration configuration = const TrinaGridConfiguration(),
+  }) {
+    final columns = ColumnHelper.textColumn('col', count: 3, width: 150);
+    final rows = RowHelper.count(5, columns);
+
+    final stateManager = TrinaGridStateManager(
+      columns: columns,
+      rows: rows,
+      gridFocusNode: MockFocusNode(),
+      scroll: MockTrinaGridScrollController(),
+      configuration: configuration,
+    );
+
+    stateManager.setEventManager(MockTrinaGridEventManager());
+    stateManager.setLayout(const BoxConstraints(maxWidth: 500, maxHeight: 500));
+
+    return stateManager;
+  }
+
+  group('Record sidebar state', () {
+    test('is hidden by default and reads mode/width from configuration', () {
+      final stateManager = createStateManager();
+
+      expect(stateManager.isSidebarVisible, false);
+      expect(stateManager.sidebarMode, TrinaGridSidebarMode.docked);
+      expect(stateManager.sidebarWidth, 320);
+    });
+
+    test('reads defaults from a custom configuration', () {
+      final stateManager = createStateManager(
+        configuration: const TrinaGridConfiguration(
+          sidebar: TrinaGridSidebarConfig(
+            width: 400,
+            mode: TrinaGridSidebarMode.floating,
+          ),
+        ),
+      );
+
+      expect(stateManager.sidebarMode, TrinaGridSidebarMode.floating);
+      expect(stateManager.sidebarWidth, 400);
+    });
+
+    test('showSidebar makes it visible and can set the mode', () {
+      final stateManager = createStateManager();
+
+      stateManager.showSidebar(mode: TrinaGridSidebarMode.floating);
+
+      expect(stateManager.isSidebarVisible, true);
+      expect(stateManager.sidebarMode, TrinaGridSidebarMode.floating);
+    });
+
+    test('hideSidebar hides it', () {
+      final stateManager = createStateManager();
+
+      stateManager.showSidebar();
+      expect(stateManager.isSidebarVisible, true);
+
+      stateManager.hideSidebar();
+      expect(stateManager.isSidebarVisible, false);
+    });
+
+    test('toggleSidebar flips visibility', () {
+      final stateManager = createStateManager();
+
+      stateManager.toggleSidebar();
+      expect(stateManager.isSidebarVisible, true);
+
+      stateManager.toggleSidebar();
+      expect(stateManager.isSidebarVisible, false);
+    });
+
+    test('setSidebarMode and setSidebarWidth update the state', () {
+      final stateManager = createStateManager();
+
+      stateManager.setSidebarMode(TrinaGridSidebarMode.floating);
+      expect(stateManager.sidebarMode, TrinaGridSidebarMode.floating);
+
+      stateManager.setSidebarWidth(450);
+      expect(stateManager.sidebarWidth, 450);
+    });
+
+    test('showSidebar is a no-op when the feature is disabled', () {
+      final stateManager = createStateManager(
+        configuration: const TrinaGridConfiguration(
+          sidebar: TrinaGridSidebarConfig(enabled: false),
+        ),
+      );
+
+      stateManager.showSidebar();
+      expect(stateManager.isSidebarVisible, false);
+
+      stateManager.toggleSidebar();
+      expect(stateManager.isSidebarVisible, false);
+    });
+
+    test('notifies listeners when visibility changes', () {
+      final stateManager = createStateManager();
+
+      int notifyCount = 0;
+      stateManager.addListener(() => notifyCount++);
+
+      stateManager.showSidebar();
+      expect(notifyCount, greaterThan(0));
+    });
+  });
+
+  group('Record sidebar widget', () {
+    testWidgets('docked panel appears and disappears on toggle', (
+      tester,
+    ) async {
+      final columns = ColumnHelper.textColumn('col', count: 3, width: 150);
+      final rows = RowHelper.count(5, columns);
+
+      late TrinaGridStateManager stateManager;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TrinaGrid(
+              columns: columns,
+              rows: rows,
+              onLoaded: (event) => stateManager = event.stateManager,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Hidden by default.
+      expect(find.text('Search for field...'), findsNothing);
+
+      stateManager.showSidebar();
+      await tester.pumpAndSettle();
+
+      // The built-in record view (with its search box) is now shown.
+      expect(find.text('Search for field...'), findsOneWidget);
+
+      stateManager.hideSidebar();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Search for field...'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a built-in **record sidebar** to TrinaGrid: a panel that shows every field of the currently selected row with a search box and inline editing. It is controlled entirely through the state manager and rendered by the grid (previously it was a demo-only widget the screen placed manually).

## What's included

- **Config**: `TrinaGridSidebarConfig` (`enabled`, `mode`, `width`, `animationDuration`, `contentBuilder`) on `TrinaGridConfiguration`, and the `TrinaGridSidebarMode { docked, floating }` enum.
- **State API**: `showSidebar({mode})`, `hideSidebar()`, `toggleSidebar({mode})`, `setSidebarVisible`, `setSidebarMode`, `setSidebarWidth`, plus `isSidebarVisible` / `sidebarMode` / `sidebarWidth` getters (new `SidebarState` mixin, added to `defaultGridFilter` so the grid rebuilds on toggle).
- **Rendering**: docked mode pushes/shrinks the grid; floating mode slides a panel over the grid (via `AnimatedPositioned`, clipped by the `Stack`) with a close button placed inline next to the search field. Grids that never use the sidebar keep their original widget tree.
- **Content**: built-in field view with search and write-back (`changeCellValue`), overridable through `contentBuilder`.
- **Demo**: `Record Sidebar` screen with toggle / docked-vs-floating / width controls.
- **Docs**: `doc/features/sidebar.md`, linked from `doc/index.md`.

## Testing

- `dart format` and `dart analyze` clean (package and demo).
- New `test/scenario/sidebar/sidebar_state_test.dart` (9 tests): state defaults/actions and a widget test verifying the docked panel appears/disappears on toggle.
- Full suite shows no new failures versus `main` (pre-existing failures on the base are unchanged).