### PR TITLE
fix: update demo for font_awesome_flutter v11

### DIFF
--- a/demo/lib/screen/feature/grid_export_screen.dart
+++ b/demo/lib/screen/feature/grid_export_screen.dart
@@ -769,7 +769,7 @@ class _GridExportScreenState extends State<GridExportScreen> {
 
   Widget _buildExportButton(
     String label,
-    IconData icon,
+    FaIconData icon,
     Color color,
     VoidCallback onPressed,
   ) {

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
         path: ../
     faker: ^2.1.0
     url_launcher: ^6.2.1
-    font_awesome_flutter: ^10.6.0
+    font_awesome_flutter: ^11.0.0
     rainbow_color: ^2.0.1
     file_saver: ^0.2.14
     # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary

Upgrades `font_awesome_flutter` to `^11.0.0` in the demo app and fixes the resulting type change.

In font_awesome_flutter v11, `FontAwesomeIcons.*` values are `FaIconData` instead of `IconData`. The `_buildExportButton` helper in the grid export screen typed its `icon` parameter as `IconData`, which no longer compiles against v11. Updated the parameter to `FaIconData`.

## Changes

- `demo/pubspec.yaml`: `font_awesome_flutter: ^10.6.0` -> `^11.0.0`
- `demo/lib/screen/feature/grid_export_screen.dart`: `_buildExportButton` icon parameter `IconData` -> `FaIconData`

## Notes

- Demo-only change; no impact on the published `trina_grid` package.
- `flutter analyze` on the edited file passes with no issues.