### PR TITLE
fix: prevent crash when toggling docked sidebar visibility

### DIFF
--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -1180,16 +1180,15 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       );
     }
 
-    // Docked mode: take space and push the grid. When hidden, leave the grid
-    // untouched so grids that never use the sidebar keep their original tree.
-    if (!_stateManager.isSidebarVisible) {
-      return grid;
-    }
-
+    // Docked mode: keep the grid pinned in the same Expanded slot so toggling
+    // only adds or removes the trailing panel. Swapping the grid between a bare
+    // widget and a Row would reparent its gridKey subtree during the body
+    // LayoutBuilder's layout pass and crash (overlay re-attach mid-layout).
     return Row(
       children: [
         Expanded(child: grid),
-        SizedBox(width: _stateManager.sidebarWidth, child: panel(false)),
+        if (_stateManager.isSidebarVisible)
+          SizedBox(width: _stateManager.sidebarWidth, child: panel(false)),
       ],
     );
   }


### PR DESCRIPTION
## Summary

Fixes a crash that occurred when toggling the record sidebar's visibility in **docked** mode.

Previously, the docked branch of `_wrapWithSidebar` returned a bare `grid` widget when the sidebar was hidden, and swapped to a `Row` containing the grid when the sidebar became visible. Toggling visibility therefore reparented the `gridKey` subtree between two different tree shapes during the body `LayoutBuilder`'s layout pass, which crashed on overlay re-attach mid-layout.

## Fix

Keep the grid pinned in the same `Expanded` slot at all times. The `Row` is always returned in docked mode, and only the trailing `SizedBox` panel is conditionally added/removed via a collection `if`. This means toggling the sidebar only adds or removes the trailing panel without ever reparenting the grid subtree.

```dart
return Row(
  children: [
    Expanded(child: grid),
    if (_stateManager.isSidebarVisible)
      SizedBox(width: _stateManager.sidebarWidth, child: panel(false)),
  ],
);
```

## Notes

- Floating mode is unaffected.
- `dart format` and `dart analyze` pass with no issues.