### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
 # Changelog
 
-## [2.3.0] - 2026. 05. 15
+## [2.3.0] - 2026. 07. 23
 
+* Feature: Added built-in record sidebar with docked and floating modes (#396). @doonfrs
+* Feature: Sidebar fields are editable using grid cell editors with shadcn styling (#399). @doonfrs
 * Feature: Added `unfocusedSelectionColor` to `TrinaGridStyleConfig` for visually distinguishing focused vs. unfocused grids in multi-grid layouts (#372). @vasco-feltrin
 * Enhancement: `unfocusedSelectionColor` now also applies to multi-cell selections (not just the current cell), and falls back to `gridBackgroundColor` when unset so existing apps see no behavior change. Dark theme ships with a sensible default. @doonfrs
+* Feature: Made columnAscendingIcon and columnDescendingIcon clickable to trigger sorting (#379) (#380). @itsnotmeman
+* Feature: Made scrollbar track-click animation configurable (#277) (#388). @doonfrs
+* Feature: Added Hungarian locale (#382). @nagylzs
+* Feature: Added column filtering demo screen with lazy pagination and dynamic configuration controls (#387). @doonfrs
+* Fix: Arrow keys not working on Linux with NumLock on; all keyboard shortcuts are now NumLock-safe (#381) (#380) (#385). @itsnotmeman @doonfrs
+* Fix: Prevent crash when toggling docked sidebar visibility (#398). @doonfrs
+* Fix: Make selectWithSearch popup usable with a11y semantics on web (#394) (#395). @doonfrs
+* Fix: Decoupled checkbox colors from cell selection colors (#390) (#392). @doonfrs
+* Fix: Guard select cell initialValue against type mismatch (#391). @doonfrs
+* Fix: Scope column filter rebuilds to filter events (#367) (#386). @doonfrs
+* Fix: Include pagination and time picker fields in TrinaGridLocaleText equality (#384). @doonfrs
+* Fix: Column header alignment (#301) and scrollbar thumb overflow (#375). @doonfrs
+* Fix: Provide default ShadTheme so select popups work without ShadApp (#374). @doonfrs
+* Fix: Updated demo for font_awesome_flutter v11 (#397). @doonfrs
+* Chore: Updated shadcn_ui dependency to ^0.55.0. @doonfrs
+* Test: Cover filter popup ShadTheme path (#376) (#378). @doonfrs
+* Test: Updated select cell search tests for the Material TextField search field introduced in #395. @doonfrs
 
 ## [2.2.2] - 2026. 05. 15
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   collection: ^1.19.1
   path: ^1.9.1
   pdf: ^3.11.3
-  shadcn_ui: ^0.43.0
+  shadcn_ui: ^0.55.0
 
 dev_dependencies:
   flutter_test:

--- a/test/src/ui/cells/trina_select_cell_test.dart
+++ b/test/src/ui/cells/trina_select_cell_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:trina_grid/src/ui/cells/trina_select_cell.dart';
 import 'package:trina_grid/src/ui/widgets/trina_dropdown_menu.dart';
 import 'package:trina_grid/trina_grid.dart';
@@ -63,7 +62,13 @@ void main() {
   }
 
   group('Search Functionality', () {
-    final searchFieldFinder = find.byType(ShadInput);
+    // The search field is a plain Material TextField since #395 (ShadInput
+    // dropped for web a11y). Match it by its hint text to avoid picking up
+    // other TextFields in the tree.
+    final searchFieldFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField && widget.decoration?.hintText == 'Search...',
+    );
 
     // The search field has a 250ms debounce; pumpAndSettle without a
     // duration can return before that timer fires, so callers must wait


### PR DESCRIPTION
## Summary

Releases v2.3.0 to pub.dev. The previous 2.3.0 entry (May) was never published (pub.dev is still at 2.2.2), so this folds everything since v2.2.2 into a single 2.3.0 changelog entry dated today.

- Merged changelog entry covering the record sidebar, sidebar cell editors, unfocusedSelectionColor, clickable sort icons, NumLock-safe shortcuts, Hungarian locale, and all fixes since v2.2.2
- Bumped shadcn_ui from ^0.43.0 to ^0.55.0 (pre-1.0 caret meant ^0.43.0 blocked apps using newer shadcn_ui; resolves to 0.55.0, analyze and full test suite pass)
- Fixed 4 select cell search tests that were broken on main since #395 replaced the popup search ShadInput with a Material TextField (the tests still targeted find.byType(ShadInput))

## Notes

- Version stays 2.3.0; publish to pub.dev with dart pub publish after merge.
- CI tests.yaml triggers on PRs to master but the default branch is main, which is likely why the broken tests went unnoticed; worth fixing separately.