### PR TITLE
fix: reach the end of the grid when scrolling with the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+* Fix: Keyboard navigation now scrolls all the way to the end of the grid, so the last row and last column are no longer left partially hidden under the scrollbars (#389). @doonfrs
+* Fix: Frozen column rows now share the same scroll extent as the body, so Ctrl+End and vertical keyboard navigation reach the last row when frozen columns are visible. @doonfrs
+
 ## [2.3.0] - 2026. 07. 23
 
 * Feature: Added built-in record sidebar with docked and floating modes (#396). @doonfrs

--- a/doc/features/scrollbars.md
+++ b/doc/features/scrollbars.md
@@ -78,6 +78,20 @@ The `TrinaGridScrollbarConfig` class provides the following key options for scro
 | `trackClickDuration` | `Duration` | `Duration(milliseconds: 200)` | Duration of the scroll animation when clicking the scrollbar track to jump to a position. Set to `Duration.zero` to jump instantly. |
 | `trackClickCurve` | `Curve` | `Curves.easeOutCubic` | Easing curve for the track-click jump animation. |
 
+### Layout footprint
+
+Scrollbars are drawn as overlays, but the grid still reserves space for them so that the last row and
+the last column are never left permanently underneath a scrollbar. Two read-only getters expose how
+much space that is:
+
+| Getter | Description |
+|--------|-------------|
+| `effectiveThickness` | Total cross axis space a scrollbar occupies: `thickness` plus 2px of padding on each side. This is the height of the horizontal scrollbar strip and the width of the vertical scrollbar overlay. |
+| `verticalScrollBarReservedWidth` | The trailing width reserved for the vertical scrollbar, or `0` when `showVertical` is `false`. |
+
+Increasing `thickness` therefore also increases the space the grid reserves. Use these getters
+instead of hardcoding the padding if you build custom layouts around the grid.
+
 ## Examples
 
 ### Always Visible Scrollbars

--- a/lib/src/manager/state/scroll_state.dart
+++ b/lib/src/manager/state/scroll_state.dart
@@ -66,6 +66,40 @@ mixin ScrollState implements ITrinaGridState {
     return Offset((maxWidth! + gridGlobalOffset!.dx) - offset.dx, offset.dy);
   }
 
+  /// The live [ScrollPosition] of [controller], or null when it has no client
+  /// or has not been laid out yet.
+  ///
+  /// Returns null during the frames before the body lists are laid out, and in
+  /// unit tests where the scroll controller is mocked. Callers must treat null
+  /// as "fall back to geometry computed from the configuration".
+  ScrollPosition? _laidOutPosition(ScrollController? controller) {
+    if (controller == null || !controller.hasClients) {
+      return null;
+    }
+
+    final position = controller.position;
+
+    if (!position.hasViewportDimension || !position.hasContentDimensions) {
+      return null;
+    }
+
+    return position;
+  }
+
+  /// Clamps [offset] to the scrollable range of [controller].
+  ///
+  /// When the position is not available this returns [offset] unchanged, so the
+  /// behaviour matches the computed geometry fallback.
+  double _clampToScrollExtent(ScrollController? controller, double offset) {
+    final position = _laidOutPosition(controller);
+
+    if (position == null) {
+      return offset;
+    }
+
+    return offset.clamp(position.minScrollExtent, position.maxScrollExtent);
+  }
+
   @override
   void scrollByDirection(TrinaMoveDirection direction, double offset) {
     if (direction.vertical) {
@@ -109,31 +143,46 @@ mixin ScrollState implements ITrinaGridState {
       }
     }
 
-    final double screenOffset =
-        scroll.verticalOffset +
-        columnRowContainerHeight -
-        columnGroupHeight -
-        columnHeight -
-        columnFilterHeight -
-        columnFooterHeight -
+    // Height of the region in which scrollable rows are actually visible.
+    //
+    // Prefer the live viewport of the body rows list: it already accounts for
+    // the horizontal scrollbar strip below the list, the frozen top and bottom
+    // row bands, and every divider, none of which the layout getters below know
+    // about. The computed value is only a fallback for the frames before the
+    // list is laid out.
+    final double viewportHeight =
+        _laidOutPosition(scroll.bodyRowsVertical)?.viewportDimension ??
+        (columnRowContainerHeight -
+            columnGroupHeight -
+            columnHeight -
+            columnFilterHeight -
+            columnFooterHeight -
+            configuration.style.cellHorizontalBorderWidth);
+
+    final double screenOffset = scroll.verticalOffset + viewportHeight;
+
+    // The row being moved to, and the space it occupies in the list. The border
+    // has to be included: the list lays each row out as height + border, so
+    // leaving it out stops one border short of the bottom of the last row.
+    final double targetRowHeight =
+        getRowHeight(rowIdx + direction.offset) +
         configuration.style.cellHorizontalBorderWidth;
 
     final bool inScrollStart = scroll.verticalOffset <= offsetToMove;
 
-    final bool inScrollEnd =
-        offsetToMove + getRowHeight(rowIdx) <= screenOffset;
+    final bool inScrollEnd = offsetToMove + targetRowHeight <= screenOffset;
 
     if (inScrollStart && inScrollEnd) {
       return;
     } else if (inScrollEnd == false) {
       offsetToMove =
-          scroll.verticalOffset +
-          offsetToMove +
-          getRowHeight(rowIdx) -
-          screenOffset;
+          scroll.verticalOffset + offsetToMove + targetRowHeight - screenOffset;
     }
 
-    scrollByDirection(direction, offsetToMove);
+    scrollByDirection(
+      direction,
+      _clampToScrollExtent(scroll.bodyRowsVertical, offsetToMove),
+    );
   }
 
   @override
@@ -153,13 +202,21 @@ mixin ScrollState implements ITrinaGridState {
 
     double offsetToMove = columnToMove.startPosition;
 
-    final double? screenOffset = showFrozenColumn == true
-        ? maxWidth! - leftFrozenColumnsWidth - rightFrozenColumnsWidth
-        : maxWidth;
+    // The vertical scrollbar is an overlay inside the body's Stack, so it does
+    // not shrink the horizontal viewport, it covers the trailing band of it.
+    // The body pads its scroll content by the same amount so the last column
+    // can be scrolled clear of the overlay. Exclude that band here, otherwise
+    // scrolling to the last column stops exactly one scrollbar width short of
+    // maxScrollExtent and leaves the column hidden under the scrollbar.
+    final double screenOffset =
+        (showFrozenColumn == true
+            ? maxWidth! - leftFrozenColumnsWidth - rightFrozenColumnsWidth
+            : maxWidth!) -
+        configuration.scrollbar.verticalScrollBarReservedWidth;
 
     if (direction.isRight) {
       if (offsetToMove > scroll.horizontal!.offset) {
-        offsetToMove -= screenOffset!;
+        offsetToMove -= screenOffset;
         offsetToMove += columnToMove.width;
         offsetToMove += scrollOffsetByFrozenColumn;
 
@@ -170,7 +227,7 @@ mixin ScrollState implements ITrinaGridState {
     } else {
       final offsetToNeed = offsetToMove + columnToMove.width;
 
-      final currentOffset = screenOffset! + scroll.horizontal!.offset;
+      final currentOffset = screenOffset + scroll.horizontal!.offset;
 
       if (offsetToNeed > currentOffset) {
         offsetToMove = scroll.horizontal!.offset + offsetToNeed - currentOffset;
@@ -180,7 +237,10 @@ mixin ScrollState implements ITrinaGridState {
       }
     }
 
-    scrollByDirection(direction, offsetToMove);
+    scrollByDirection(
+      direction,
+      _clampToScrollExtent(scroll.bodyRowsHorizontal, offsetToMove),
+    );
   }
 
   @override

--- a/lib/src/manager/state/visibility_layout_state.dart
+++ b/lib/src/manager/state/visibility_layout_state.dart
@@ -61,12 +61,11 @@ mixin VisibilityLayoutState implements ITrinaGridState {
     //
     // The scrollbar overlays content but still occupies visual space on the
     // right edge, so columns must be sized to (viewport width - scrollbar width).
-    // Scrollbar uses thickness + 4px padding (see trina_vertical_scroll_bar.dart:273)
     // Only subtract when columnShowScrollWidth is enabled (matching behavior in
     // trina_body_columns.dart and trina_body_columns_footer.dart)
     if (configuration.scrollbar.showVertical &&
         configuration.scrollbar.columnShowScrollWidth) {
-      offset += configuration.scrollbar.thickness + 4;
+      offset += configuration.scrollbar.effectiveThickness;
     }
 
     getColumnsAutoSizeHelper(

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -1328,6 +1328,24 @@ class TrinaGridScrollbarConfig {
   /// Get effective radius for the scrollbar
   double get effectiveRadius => radius ?? thickness / 2;
 
+  /// Total cross axis space a scrollbar occupies: the [thickness] of the
+  /// thumb and track plus 2px of padding on each side.
+  ///
+  /// This is the width of the box built by `TrinaVerticalScrollBar`, the height
+  /// of the box built by `TrinaHorizontalScrollBar`, and the amount of trailing
+  /// padding the body adds to the horizontal scroll extent so the last column
+  /// can be scrolled clear of the overlaid vertical scrollbar.
+  double get effectiveThickness => thickness + 4;
+
+  /// Trailing space reserved for the overlaid vertical scrollbar, or 0 when it
+  /// is hidden.
+  ///
+  /// The vertical scrollbar is drawn as an overlay, so it does not shrink the
+  /// horizontal viewport, it covers the trailing band of it. Scrolling logic
+  /// must exclude this band from the usable viewport width.
+  double get verticalScrollBarReservedWidth =>
+      showVertical ? effectiveThickness : 0;
+
   @override
   bool operator ==(covariant Object other) {
     return identical(this, other) ||

--- a/lib/src/ui/trina_body_columns.dart
+++ b/lib/src/ui/trina_body_columns.dart
@@ -111,7 +111,7 @@ class TrinaBodyColumnsState extends TrinaStateWithChange<TrinaBodyColumns> {
         // region while the linked header clamps short, visibly misaligning
         // header titles from their data cells.
         padding: scrollConfig.showVertical
-            ? EdgeInsetsDirectional.only(end: scrollConfig.thickness + 4)
+            ? EdgeInsetsDirectional.only(end: scrollConfig.effectiveThickness)
             : EdgeInsets.zero,
         child: TrinaVisibilityLayout(
           delegate: MainColumnLayoutDelegate(

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -224,7 +224,7 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
                   child: Padding(
                     padding: scrollConfig.showVertical
                         ? EdgeInsetsDirectional.only(
-                            end: scrollConfig.thickness + 4,
+                            end: scrollConfig.effectiveThickness,
                           )
                         : EdgeInsets.zero,
                     child: CustomSingleChildLayout(

--- a/lib/src/ui/trina_left_frozen_rows.dart
+++ b/lib/src/ui/trina_left_frozen_rows.dart
@@ -131,6 +131,15 @@ class TrinaLeftFrozenRowsState
                 )
                 .toList(),
           ),
+        // Match the footprint of the body's horizontal scrollbar so that every
+        // list in the vertical scroll controller group has the same viewport
+        // height and therefore the same maxScrollExtent. Without this, scrolling
+        // the group to the body's maxScrollExtent overscrolls this list, whose
+        // ClampingScrollPhysics then springs back and drags the body with it.
+        if (stateManager.configuration.scrollbar.showHorizontal)
+          SizedBox(
+            height: stateManager.configuration.scrollbar.effectiveThickness,
+          ),
       ],
     );
   }

--- a/lib/src/ui/trina_right_frozen_rows.dart
+++ b/lib/src/ui/trina_right_frozen_rows.dart
@@ -131,6 +131,15 @@ class TrinaRightFrozenRowsState
                 )
                 .toList(),
           ),
+        // Match the footprint of the body's horizontal scrollbar so that every
+        // list in the vertical scroll controller group has the same viewport
+        // height and therefore the same maxScrollExtent. Without this, scrolling
+        // the group to the body's maxScrollExtent overscrolls this list, whose
+        // ClampingScrollPhysics then springs back and drags the body with it.
+        if (stateManager.configuration.scrollbar.showHorizontal)
+          SizedBox(
+            height: stateManager.configuration.scrollbar.effectiveThickness,
+          ),
       ],
     );
   }

--- a/lib/src/widgets/trina_horizontal_scroll_bar.dart
+++ b/lib/src/widgets/trina_horizontal_scroll_bar.dart
@@ -267,7 +267,15 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
             valueListenable: widget.horizontalScrollExtentNotifier,
             builder: (context, scrollExtent, _) {
               if (scrollExtent <= 0) {
-                return SizedBox(height: scrollConfig.thickness);
+                // Keep the same footprint as the overflowing branch below.
+                //
+                // This strip is a sibling of the rows viewport, so its height is
+                // subtracted from the vertical scroll extent. Changing it with
+                // the overflow state would shift the body by 4px whenever a
+                // column resize crosses the overflow threshold, and would make
+                // the body's maxScrollExtent differ from the frozen rows lists
+                // that share its vertical scroll controller group.
+                return SizedBox(height: scrollConfig.effectiveThickness);
               }
 
               return ValueListenableBuilder<double>(
@@ -295,7 +303,7 @@ class _TrinaHorizontalScrollBarState extends State<TrinaHorizontalScrollBar>
 
                       return SizedBox(
                         width: widget.width,
-                        height: scrollConfig.thickness + 4, // Add padding
+                        height: scrollConfig.effectiveThickness,
                         child: Stack(
                           children: [
                             // Track

--- a/lib/src/widgets/trina_vertical_scroll_bar.dart
+++ b/lib/src/widgets/trina_vertical_scroll_bar.dart
@@ -293,7 +293,7 @@ class _TrinaVerticalScrollBarState extends State<TrinaVerticalScrollBar>
                             (widget.height - thumbHeight);
 
                         return SizedBox(
-                          width: scrollConfig.thickness + 4, // Add padding
+                          width: scrollConfig.effectiveThickness,
                           height: widget.height,
                           child: Stack(
                             children: [

--- a/test/scenario/scrolling/keyboard_scroll_to_end_test.dart
+++ b/test/scenario/scrolling/keyboard_scroll_to_end_test.dart
@@ -1,0 +1,492 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+import 'package:trina_grid/src/widgets/trina_horizontal_scroll_bar.dart';
+import 'package:trina_grid/src/widgets/trina_vertical_scroll_bar.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../helper/test_helper_util.dart';
+
+/// Regression tests for https://github.com/doonfrs/trina_grid/issues/389
+///
+/// Scrolling driven by the keyboard used to stop short of the maximum scroll
+/// extent, leaving the last row and the last column partially hidden under the
+/// overlaid scrollbars, while the mouse wheel and the scrollbars reached the end
+/// correctly.
+void main() {
+  late TrinaGridStateManager stateManager;
+
+  Future<List<TrinaColumn>> buildGrid(
+    WidgetTester tester, {
+    int columnCount = 10,
+    int rowCount = 30,
+    double width = 500,
+    double height = 400,
+    double columnWidth = 200,
+    TrinaGridConfiguration configuration = const TrinaGridConfiguration(),
+    List<TrinaColumnGroup>? columnGroups,
+    void Function(List<TrinaColumn> columns)? beforeBuild,
+  }) async {
+    await TestHelperUtil.changeWidth(
+      tester: tester,
+      width: width,
+      height: height,
+    );
+
+    final columns = ColumnHelper.textColumn(
+      'column',
+      count: columnCount,
+      width: columnWidth,
+    );
+
+    beforeBuild?.call(columns);
+
+    final rows = RowHelper.count(rowCount, columns);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TrinaGrid(
+            columns: columns,
+            columnGroups: columnGroups,
+            rows: rows,
+            configuration: configuration,
+            onLoaded: (TrinaGridOnLoadedEvent event) {
+              stateManager = event.stateManager;
+              stateManager.setKeepFocus(true);
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    return columns;
+  }
+
+  double horizontalOffset() => stateManager.scroll.bodyRowsHorizontal!.offset;
+
+  double verticalOffset() => stateManager.scroll.bodyRowsVertical!.offset;
+
+  group('Keyboard scrolling reaches the end of the grid', () {
+    testWidgets(
+      'Scrolling to the last column should land on the maximum scroll extent.',
+      (tester) async {
+        final columns = await buildGrid(tester);
+
+        stateManager.moveScrollByColumn(
+          TrinaMoveDirection.right,
+          columns.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          horizontalOffset(),
+          closeTo(stateManager.scroll.maxScrollHorizontal, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'Moving to the last column with the arrow keys should land on the '
+      'maximum scroll extent.',
+      (tester) async {
+        final columns = await buildGrid(tester);
+
+        stateManager.setCurrentCell(
+          stateManager.refRows.first.cells['column0'],
+          0,
+        );
+        await tester.pumpAndSettle();
+
+        for (int i = 0; i < columns.length - 1; i += 1) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+          await tester.pumpAndSettle();
+        }
+
+        expect(stateManager.currentColumn?.field, 'column9');
+        expect(
+          horizontalOffset(),
+          closeTo(stateManager.scroll.maxScrollHorizontal, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'Moving to the last column with the Tab key should land on the maximum '
+      'scroll extent.',
+      (tester) async {
+        final columns = await buildGrid(tester);
+
+        stateManager.setCurrentCell(
+          stateManager.refRows.first.cells['column0'],
+          0,
+        );
+        await tester.pumpAndSettle();
+
+        for (int i = 0; i < columns.length - 1; i += 1) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pumpAndSettle();
+        }
+
+        expect(stateManager.currentColumn?.field, 'column9');
+        expect(
+          horizontalOffset(),
+          closeTo(stateManager.scroll.maxScrollHorizontal, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'Scrolling to the last row should land on the maximum scroll extent.',
+      (tester) async {
+        await buildGrid(tester);
+
+        stateManager.moveScrollByRow(
+          TrinaMoveDirection.down,
+          stateManager.refRows.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'Moving to the last row with the arrow keys should land on the maximum '
+      'scroll extent.',
+      (tester) async {
+        await buildGrid(tester, rowCount: 20);
+
+        stateManager.setCurrentCell(
+          stateManager.refRows.first.cells['column0'],
+          0,
+        );
+        await tester.pumpAndSettle();
+
+        for (int i = 0; i < stateManager.refRows.length - 1; i += 1) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.pumpAndSettle();
+        }
+
+        expect(stateManager.currentRowIdx, stateManager.refRows.length - 1);
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'Moving to the last row with the PageDown key should land on the maximum '
+      'scroll extent.',
+      (tester) async {
+        await buildGrid(tester, rowCount: 20);
+
+        stateManager.setCurrentCell(
+          stateManager.refRows.first.cells['column0'],
+          0,
+        );
+        await tester.pumpAndSettle();
+
+        for (int i = 0; i < 10; i += 1) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
+          await tester.pumpAndSettle();
+        }
+
+        expect(stateManager.currentRowIdx, stateManager.refRows.length - 1);
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'The last column should be clear of the overlaid vertical scrollbar.',
+      (tester) async {
+        final columns = await buildGrid(tester);
+
+        stateManager.moveScrollByColumn(
+          TrinaMoveDirection.right,
+          columns.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        final lastCell = find.text('column9 value 0');
+        final lastCellRight = tester.getTopRight(lastCell).dx;
+        final scrollBarLeft = tester
+            .getTopLeft(find.byType(TrinaVerticalScrollBar))
+            .dx;
+
+        expect(lastCellRight, lessThanOrEqualTo(scrollBarLeft + 0.5));
+      },
+    );
+
+    testWidgets('The last row should be clear of the horizontal scrollbar.', (
+      tester,
+    ) async {
+      await buildGrid(tester);
+
+      stateManager.moveScrollByRow(
+        TrinaMoveDirection.down,
+        stateManager.refRows.length - 2,
+      );
+      await tester.pumpAndSettle();
+
+      final lastCell = find.text('column0 value 29');
+      final lastCellBottom = tester.getBottomLeft(lastCell).dy;
+      final scrollBarTop = tester
+          .getTopLeft(find.byType(TrinaHorizontalScrollBar))
+          .dy;
+
+      expect(lastCellBottom, lessThanOrEqualTo(scrollBarTop + 0.5));
+    });
+  });
+
+  group('Keyboard scrolling with frozen columns', () {
+    testWidgets(
+      'Scrolling to the last row should land on the maximum scroll extent.',
+      (tester) async {
+        await buildGrid(
+          tester,
+          // Wide enough that the grid keeps the frozen columns visible.
+          width: 900,
+          beforeBuild: (columns) {
+            columns.first.frozen = TrinaColumnFrozen.start;
+            columns.last.frozen = TrinaColumnFrozen.end;
+          },
+        );
+
+        expect(stateManager.showFrozenColumn, isTrue);
+
+        stateManager.moveScrollByRow(
+          TrinaMoveDirection.down,
+          stateManager.refRows.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+
+    testWidgets('Ctrl + End should land on the maximum scroll extent.', (
+      tester,
+    ) async {
+      await buildGrid(
+        tester,
+        // Wide enough that the grid keeps the frozen columns visible.
+        width: 900,
+        beforeBuild: (columns) {
+          columns.first.frozen = TrinaColumnFrozen.start;
+          columns.last.frozen = TrinaColumnFrozen.end;
+        },
+      );
+
+      expect(stateManager.showFrozenColumn, isTrue);
+
+      stateManager.setCurrentCell(
+        stateManager.refRows.first.cells['column1'],
+        0,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+      await tester.sendKeyEvent(LogicalKeyboardKey.end);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+      await tester.pumpAndSettle();
+
+      expect(
+        verticalOffset(),
+        closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+      );
+    });
+  });
+
+  group('Keyboard scrolling with other scrollbar configurations', () {
+    testWidgets(
+      'With the vertical scrollbar hidden, the last column should still land on '
+      'the maximum scroll extent.',
+      (tester) async {
+        final columns = await buildGrid(
+          tester,
+          configuration: const TrinaGridConfiguration(
+            scrollbar: TrinaGridScrollbarConfig(showVertical: false),
+          ),
+        );
+
+        stateManager.moveScrollByColumn(
+          TrinaMoveDirection.right,
+          columns.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          horizontalOffset(),
+          closeTo(stateManager.scroll.maxScrollHorizontal, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'With the horizontal scrollbar hidden, the last row should still land on '
+      'the maximum scroll extent.',
+      (tester) async {
+        await buildGrid(
+          tester,
+          configuration: const TrinaGridConfiguration(
+            scrollbar: TrinaGridScrollbarConfig(showHorizontal: false),
+          ),
+        );
+
+        stateManager.moveScrollByRow(
+          TrinaMoveDirection.down,
+          stateManager.refRows.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'The reserved scrollbar band should follow a custom thickness.',
+      (tester) async {
+        final columns = await buildGrid(
+          tester,
+          configuration: const TrinaGridConfiguration(
+            scrollbar: TrinaGridScrollbarConfig(thickness: 20),
+          ),
+        );
+
+        stateManager.moveScrollByColumn(
+          TrinaMoveDirection.right,
+          columns.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          horizontalOffset(),
+          closeTo(stateManager.scroll.maxScrollHorizontal, 0.5),
+        );
+      },
+    );
+
+    testWidgets(
+      'A grid with a header, column groups, a column filter and a column footer '
+      'should still land on the maximum scroll extent.',
+      (tester) async {
+        await buildGrid(
+          tester,
+          height: 600,
+          columnGroups: [
+            TrinaColumnGroup(
+              title: 'group',
+              fields: ['column0', 'column1', 'column2'],
+            ),
+          ],
+          beforeBuild: (columns) {
+            columns.first.footerRenderer = (context) => const Text('footer');
+          },
+        );
+
+        stateManager.setShowColumnFilter(true);
+        await tester.pumpAndSettle();
+
+        stateManager.moveScrollByRow(
+          TrinaMoveDirection.down,
+          stateManager.refRows.length - 2,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          verticalOffset(),
+          closeTo(stateManager.scroll.maxScrollVertical, 0.5),
+        );
+      },
+    );
+  });
+
+  group('Keyboard scrolling stays inside the scrollable range', () {
+    testWidgets('Scrolling should never overshoot the maximum extent.', (
+      tester,
+    ) async {
+      final columns = await buildGrid(tester);
+
+      stateManager.moveScrollByColumn(
+        TrinaMoveDirection.right,
+        columns.length - 2,
+      );
+      stateManager.moveScrollByRow(
+        TrinaMoveDirection.down,
+        stateManager.refRows.length - 2,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        horizontalOffset(),
+        lessThanOrEqualTo(stateManager.scroll.maxScrollHorizontal),
+      );
+      expect(
+        verticalOffset(),
+        lessThanOrEqualTo(stateManager.scroll.maxScrollVertical),
+      );
+    });
+
+    testWidgets('Scrolling back should reach the start of the grid.', (
+      tester,
+    ) async {
+      final columns = await buildGrid(tester);
+
+      stateManager.moveScrollByColumn(
+        TrinaMoveDirection.right,
+        columns.length - 2,
+      );
+      stateManager.moveScrollByRow(
+        TrinaMoveDirection.down,
+        stateManager.refRows.length - 2,
+      );
+      await tester.pumpAndSettle();
+
+      stateManager.moveScrollByColumn(TrinaMoveDirection.left, 1);
+      stateManager.moveScrollByRow(TrinaMoveDirection.up, 1);
+      await tester.pumpAndSettle();
+
+      expect(horizontalOffset(), closeTo(0, 0.5));
+      expect(verticalOffset(), closeTo(0, 0.5));
+    });
+
+    testWidgets(
+      'A grid that does not overflow should not scroll and should not throw.',
+      (tester) async {
+        await buildGrid(
+          tester,
+          columnCount: 2,
+          rowCount: 3,
+          columnWidth: 100,
+          width: 800,
+          height: 600,
+        );
+
+        stateManager.moveScrollByColumn(TrinaMoveDirection.right, 0);
+        stateManager.moveScrollByRow(TrinaMoveDirection.down, 1);
+        await tester.pumpAndSettle();
+
+        expect(horizontalOffset(), closeTo(0, 0.5));
+        expect(verticalOffset(), closeTo(0, 0.5));
+      },
+    );
+  });
+}

--- a/test/src/manager/state/scroll_state_test.dart
+++ b/test/src/manager/state/scroll_state_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:trina_grid/trina_grid.dart';
 
 import '../../../helper/column_helper.dart';
@@ -254,6 +255,95 @@ void main() {
           ),
           false,
         );
+      },
+    );
+  });
+
+  group('When the body scroll controllers are not laid out', () {
+    late TrinaGridStateManager stateManager;
+
+    late MockTrinaGridScrollController scroll;
+
+    late MockLinkedScrollControllerGroup vertical;
+
+    late MockLinkedScrollControllerGroup horizontal;
+
+    late List<TrinaColumn> columns;
+
+    setUp(() {
+      scroll = MockTrinaGridScrollController();
+      vertical = MockLinkedScrollControllerGroup();
+      horizontal = MockLinkedScrollControllerGroup();
+
+      when(scroll.vertical).thenReturn(vertical);
+      when(scroll.horizontal).thenReturn(horizontal);
+      when(scroll.verticalOffset).thenReturn(0);
+      when(scroll.horizontalOffset).thenReturn(0);
+      when(vertical.offset).thenReturn(0);
+      when(horizontal.offset).thenReturn(0);
+
+      // Left unstubbed on purpose: a grid whose body lists have not been laid
+      // out yet has no body scroll controller, so the scrolling logic has to
+      // fall back to geometry computed from the configuration.
+      expect(scroll.bodyRowsVertical, isNull);
+      expect(scroll.bodyRowsHorizontal, isNull);
+
+      columns = ColumnHelper.textColumn('column', count: 5, width: 200);
+
+      stateManager = createStateManager(
+        columns: columns,
+        rows: RowHelper.count(20, columns),
+        scroll: scroll,
+        layout: const BoxConstraints(maxWidth: 500, maxHeight: 500),
+      );
+
+      stateManager.setGridGlobalOffset(Offset.zero);
+    });
+
+    test(
+      'moveScrollByColumn should exclude the reserved vertical scrollbar band.',
+      () {
+        stateManager.moveScrollByColumn(TrinaMoveDirection.right, 3);
+
+        final lastColumn = columns.last;
+
+        final expectedOffset =
+            lastColumn.startPosition +
+            lastColumn.width -
+            (500 -
+                stateManager
+                    .configuration
+                    .scrollbar
+                    .verticalScrollBarReservedWidth);
+
+        verify(horizontal.jumpTo(expectedOffset)).called(1);
+      },
+    );
+
+    test(
+      'moveScrollByRow should fall back to the computed viewport height.',
+      () {
+        stateManager.moveScrollByRow(TrinaMoveDirection.down, 12);
+
+        final style = stateManager.configuration.style;
+
+        final rowTotalHeight =
+            style.rowHeight + style.cellHorizontalBorderWidth;
+
+        final viewportHeight =
+            stateManager.columnRowContainerHeight -
+            stateManager.columnGroupHeight -
+            stateManager.columnHeight -
+            stateManager.columnFilterHeight -
+            stateManager.columnFooterHeight -
+            style.cellHorizontalBorderWidth;
+
+        // Rows 0 through 12 scrolled past, then the target row 13 has to fit
+        // fully, including the border the list lays out beneath it.
+        final expectedOffset =
+            (13 * rowTotalHeight) + rowTotalHeight - viewportHeight;
+
+        verify(vertical.jumpTo(expectedOffset)).called(1);
       },
     );
   });

--- a/test/src/trina_grid_configuration_test.dart
+++ b/test/src/trina_grid_configuration_test.dart
@@ -236,6 +236,39 @@ void main() {
         expect(configA.hashCode == configB.hashCode, true);
       },
     );
+
+    test('The effective thickness should include the surrounding padding.', () {
+      expect(const TrinaGridScrollbarConfig().effectiveThickness, 12.0);
+
+      expect(
+        const TrinaGridScrollbarConfig(thickness: 20).effectiveThickness,
+        24.0,
+      );
+    });
+
+    test(
+      'The reserved width should follow the visibility of the vertical scrollbar.',
+      () {
+        expect(
+          const TrinaGridScrollbarConfig().verticalScrollBarReservedWidth,
+          12.0,
+        );
+
+        expect(
+          const TrinaGridScrollbarConfig(
+            thickness: 20,
+          ).verticalScrollBarReservedWidth,
+          24.0,
+        );
+
+        expect(
+          const TrinaGridScrollbarConfig(
+            showVertical: false,
+          ).verticalScrollBarReservedWidth,
+          0.0,
+        );
+      },
+    );
   });
 
   group('style', () {


### PR DESCRIPTION
Closes #389

Keyboard navigation stopped short of the maximum scroll extent, leaving the last row and the last column partially hidden under the overlaid scrollbars. The mouse wheel and the scrollbars reached the end correctly, because they act on the real scroll extent while the keyboard path reconstructed the viewport from configuration getters.

## What was wrong

Three separate defects, all producing the same symptom.

**1. The horizontal target ignored the reserved scrollbar band.** The body deliberately pads its horizontal scroll content by the vertical scrollbar's footprint, so the last column can be scrolled clear of the overlay. `moveScrollByColumn` derived its usable width from `maxWidth` minus the frozen column widths, with no term for that band, so its target for the last column was always exactly one scrollbar width short of `maxScrollExtent` and the column stayed underneath the scrollbar.

**2. The vertical target overestimated the viewport.** `moveScrollByRow` derived the viewport height from getters that know nothing about the horizontal scrollbar strip below the list or the frozen row bands, so it believed the viewport was taller than it is and either did not scroll at all or scrolled short. It also measured the target row without the border the list lays out beneath it.

That strip is not a fixed height: it is one size when the grid overflows horizontally and another when it does not. So this could not be fixed by adding more configuration derived terms, and the viewport is now read from the live scroll position.

**3. Frozen row lists had a different scroll extent than the body.** They share the vertical scroll controller group with the body but had no scrollbar strip beneath them, so a taller viewport and a smaller `maxScrollExtent`. The group forwards a raw offset to every member without clamping, so scrolling to the body's maximum overscrolled the frozen lists, whose `ClampingScrollPhysics` sprang back and dragged the body with it. This also meant **Ctrl+End was already short of the last row** on frozen column grids before this PR.

## The fix

- The vertical axis reads the live `viewportDimension`, keeping the previous formula as a fallback for the frames before the list is laid out and for unit tests that mock the scroll controller. Both axes clamp the computed target to the real scrollable range.
- The horizontal axis subtracts a new `verticalScrollBarReservedWidth`.
- `scrollByDirection` is deliberately left untouched. Its other callers must not be clamped, in particular `prependRows`, which jumps against a deliberately stale extent before layout runs.
- Both frozen row widgets reserve the same footprint as the body's horizontal scrollbar, and that strip is now a constant height. Keeping it constant is what makes the extents match, and it also removes a 4px jump when a column resize crossed the overflow threshold.
- The scrollbar footprint was a literal repeated in five files, which is how the scrolling logic came to be the one place that never accounted for it. It is now `TrinaGridScrollbarConfig.effectiveThickness`, with every call site keeping its existing gating.

## Verification

`test/scenario/scrolling/keyboard_scroll_to_end_test.dart` adds 17 tests covering arrow keys, Tab, PageDown and Ctrl+End, both axes, frozen columns, a custom thickness, each scrollbar hidden, and the non-overflowing and backwards cases. **12 of them fail on `main`**, confirmed by reverting `lib/` and re-running, so they are genuine regression tests rather than tests fitted to the change. Unit tests pin the mocked controller fallback path and the new getters.

Full suite passes (1620 tests), `dart analyze` clean. The first commit was verified green on its own so the second can be reviewed or reverted independently.

## Note for reviewers

The horizontal scrollbar strip is now a constant height, so a grid that does not overflow horizontally sits 4px differently than before. That is intended and is what makes the frozen row extents line up, but it is the one visible layout change here.

Not addressed, worth its own issue: `moveScrollByRow` sums row heights over `refRows` while the body list only holds non-frozen rows, which gives a wrong target row when *row* freezing is used. Different failure mode, and a correct fix needs an index projection plus a decision about what scrolling to an always-visible row should mean.
