### PR TITLE
feat: add per axis scroll physics to TrinaGrid (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Feature: Added `horizontalScrollPhysics` and `verticalScrollPhysics` to `TrinaGrid`, so each scroll axis can have its own `ScrollPhysics`. Pair `verticalScrollPhysics: NeverScrollableScrollPhysics()` with `fitContent: true` to place a grid inside a scrolling page while keeping its horizontal scrolling (#270). @doonfrs
+* Fix: `scrollPhysics` now takes effect when it changes after the grid is built. `TrinaScrollBehavior` did not override `ScrollBehavior.shouldNotify`, so scrollables kept the physics they resolved on their first build. @doonfrs
+* Fix: `fitContent` now accounts for the horizontal scrollbar strip, which is a sibling of the rows viewport rather than an overlay. The grid used to come up short by that strip, leaving the rows scrollable by a few pixels. @doonfrs
+* Fix: Guard the body rows scroll listeners against positions that have clients but have not been laid out yet, which threw a null check error. @doonfrs
 * Fix: Keyboard navigation now scrolls all the way to the end of the grid, so the last row and last column are no longer left partially hidden under the scrollbars (#389). @doonfrs
 * Fix: Frozen column rows now share the same scroll extent as the body, so Ctrl+End and vertical keyboard navigation reach the last row when frozen columns are visible. @doonfrs
 

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -61,6 +61,7 @@ import 'screen/feature/value_formatter_screen.dart';
 import 'screen/home_screen.dart';
 import 'screen/feature/pages_list_screen.dart';
 import 'screen/feature/frozen_rows_screen.dart';
+import 'screen/feature/scroll_physics_screen.dart';
 import 'screen/feature/scrollbars.dart';
 import 'screen/feature/row_wrapper_screen.dart';
 import 'screen/feature/row_wrapper_frozen_screen.dart';
@@ -169,6 +170,7 @@ class MyApp extends StatelessWidget {
         EmptyScreen.routeName: (context) => const EmptyScreen(),
         PagesListScreen.routeName: (context) => const PagesListScreen(),
         FrozenRowsScreen.routeName: (context) => const FrozenRowsScreen(),
+        ScrollPhysicsScreen.routeName: (context) => const ScrollPhysicsScreen(),
         ScrollbarsScreen.routeName: (context) => const ScrollbarsScreen(),
         LoadingOptionsScreen.routeName: (context) =>
             const LoadingOptionsScreen(),

--- a/demo/lib/screen/feature/scroll_physics_screen.dart
+++ b/demo/lib/screen/feature/scroll_physics_screen.dart
@@ -1,0 +1,265 @@
+import 'package:demo/dummy_data/development.dart';
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../widget/trina_example_button.dart';
+import '../../widget/trina_example_screen.dart';
+
+/// Options offered for each axis in the controls below.
+enum _PhysicsOption {
+  platformDefault('Platform default', null),
+  never('Never scrollable', NeverScrollableScrollPhysics()),
+  bouncing('Bouncing', BouncingScrollPhysics()),
+  clamping('Clamping', ClampingScrollPhysics());
+
+  const _PhysicsOption(this.label, this.physics);
+
+  final String label;
+  final ScrollPhysics? physics;
+}
+
+class ScrollPhysicsScreen extends StatefulWidget {
+  static const routeName = 'feature/scroll-physics';
+
+  const ScrollPhysicsScreen({super.key});
+
+  @override
+  State<ScrollPhysicsScreen> createState() => _ScrollPhysicsScreenState();
+}
+
+/// Height used for the grid when it is not sizing itself to its content.
+const double _fixedGridHeight = 400;
+
+class _ScrollPhysicsScreenState extends State<ScrollPhysicsScreen> {
+  final List<TrinaColumn> columns = [];
+  final List<TrinaRow> rows = [];
+
+  final ScrollController _pageScroll = ScrollController();
+
+  _PhysicsOption _vertical = _PhysicsOption.never;
+  _PhysicsOption _horizontal = _PhysicsOption.platformDefault;
+  bool _fitContent = true;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Enough columns to overflow the width, few enough rows that the grid
+    // stays a readable section of the page when `fitContent` is on.
+    final dummyData = DummyData(15, 20);
+    columns.addAll(dummyData.columns);
+    rows.addAll(dummyData.rows);
+  }
+
+  @override
+  void dispose() {
+    _pageScroll.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaExampleScreen(
+      title: 'Scroll Physics',
+      topTitle: 'Scroll Physics',
+      topContents: const [
+        Text(
+          'scrollPhysics applies to both axes at once, so blocking vertical scrolling used to block horizontal scrolling with it. '
+          'horizontalScrollPhysics and verticalScrollPhysics control each axis on its own.',
+        ),
+        SizedBox(height: 8),
+        Text(
+          'The grid below sits inside a scrolling page. With Vertical set to "Never scrollable" and Fit content on, '
+          'dragging up and down over the grid scrolls the page, while dragging left and right still scrolls the grid. '
+          'Switch Vertical back to "Platform default" to feel the scroll conflict that the per axis physics avoids.',
+        ),
+        SizedBox(height: 8),
+        Text(
+          'Turning Fit content off gives the grid a fixed height instead, so it keeps its own vertical scrolling. '
+          'A grid inside a page needs one of the two: without a bounded height and without fitContent, it has no '
+          'height to lay out with.',
+        ),
+      ],
+      topButtons: [
+        TrinaExampleButton(
+          url:
+              'https://github.com/doonfrs/trina_grid/blob/master/demo/lib/screen/feature/scroll_physics_screen.dart',
+        ),
+      ],
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildControls(),
+          const SizedBox(height: 10),
+          Expanded(child: _buildScrollingPage()),
+        ],
+      ),
+    );
+  }
+
+  /// The "page" the grid is embedded in. Everything inside scrolls together.
+  Widget _buildScrollingPage() {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.blueGrey.shade200),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: SingleChildScrollView(
+        controller: _pageScroll,
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildPageSection(
+              'Page content above the grid',
+              'This block and the one below the grid belong to the page, not to the grid. '
+                  'They are here so the page is taller than the viewport and has something to scroll.',
+              Colors.indigo,
+            ),
+            const SizedBox(height: 16),
+            _buildGrid(),
+            const SizedBox(height: 16),
+            _buildPageSection(
+              'Page content below the grid',
+              'Scroll down to here by dragging over the grid itself. That only works while the '
+                  'grid hands vertical drags back to the page.',
+              Colors.teal,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrid() {
+    final grid = TrinaGrid(
+      // The grid is rebuilt when the sizing mode changes so it takes effect.
+      key: ValueKey('grid_$_fitContent'),
+      columns: columns,
+      rows: rows,
+      fitContent: _fitContent,
+      horizontalScrollPhysics: _horizontal.physics,
+      verticalScrollPhysics: _vertical.physics,
+      configuration: const TrinaGridConfiguration(
+        columnSize: TrinaGridColumnSizeConfig(
+          autoSizeMode: TrinaAutoSizeMode.none,
+        ),
+      ),
+    );
+
+    // The page gives its children unbounded height, so a grid that does not
+    // size itself to its content needs an explicit height.
+    return _fitContent ? grid : SizedBox(height: _fixedGridHeight, child: grid);
+  }
+
+  Widget _buildPageSection(String title, String body, MaterialColor color) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: color.shade700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(body),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildControls() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.blueGrey.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Wrap(
+        spacing: 24,
+        runSpacing: 12,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _buildPhysicsDropdown(
+            label: 'Vertical',
+            value: _vertical,
+            onChanged: (value) => setState(() => _vertical = value),
+          ),
+          _buildPhysicsDropdown(
+            label: 'Horizontal',
+            value: _horizontal,
+            onChanged: (value) => setState(() => _horizontal = value),
+          ),
+          Tooltip(
+            message: _fitContent
+                ? 'The grid sizes itself to all of its rows, so the page scrolls through them.'
+                : 'The grid is ${_fixedGridHeight.toInt()}px tall, so rows past that need the grid to scroll vertically.',
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _fitContent
+                      ? 'Fit content'
+                      : 'Fixed height (${_fixedGridHeight.toInt()}px)',
+                ),
+                const SizedBox(width: 8),
+                Switch(
+                  value: _fitContent,
+                  onChanged: (value) => setState(() => _fitContent = value),
+                ),
+              ],
+            ),
+          ),
+          TextButton.icon(
+            icon: const Icon(Icons.vertical_align_top),
+            label: const Text('Scroll page to top'),
+            onPressed: _pageScroll.hasClients
+                ? () => _pageScroll.animateTo(
+                    0,
+                    duration: const Duration(milliseconds: 300),
+                    curve: Curves.easeOut,
+                  )
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPhysicsDropdown({
+    required String label,
+    required _PhysicsOption value,
+    required ValueChanged<_PhysicsOption> onChanged,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('$label: '),
+        const SizedBox(width: 4),
+        DropdownButton<_PhysicsOption>(
+          value: value,
+          onChanged: (selected) {
+            if (selected != null) onChanged(selected);
+          },
+          items: _PhysicsOption.values
+              .map(
+                (option) => DropdownMenuItem<_PhysicsOption>(
+                  value: option,
+                  child: Text(option.label),
+                ),
+              )
+              .toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -67,6 +67,7 @@ import 'feature/theme_switching_screen.dart';
 import 'feature/time_type_column_screen.dart';
 import 'feature/value_formatter_screen.dart';
 import 'feature/pages_list_screen.dart';
+import 'feature/scroll_physics_screen.dart';
 import 'feature/scrollbars.dart';
 import 'feature/date_time_column_screen.dart';
 import 'feature/row_wrapper_screen.dart';
@@ -517,6 +518,15 @@ class _TrinaFeaturesState extends State<TrinaFeatures> {
         description: 'Customize scrollbar appearance, behavior, and visibility',
         onTapLiveDemo: () {
           Navigator.pushNamed(context, ScrollbarsScreen.routeName);
+        },
+        trailing: newIcon,
+      ),
+      TrinaListTile(
+        title: 'Scroll Physics',
+        description:
+            'Set scroll physics per axis to embed a grid in a scrolling page',
+        onTapLiveDemo: () {
+          Navigator.pushNamed(context, ScrollPhysicsScreen.routeName);
         },
         trailing: newIcon,
       ),

--- a/doc/features/scrollbars.md
+++ b/doc/features/scrollbars.md
@@ -345,6 +345,59 @@ TrinaGrid(
 )
 ```
 
+### Per-Axis Scroll Physics
+
+`scrollPhysics` applies to both axes at once, so blocking vertical scrolling with it blocks horizontal scrolling too. Use `horizontalScrollPhysics` and `verticalScrollPhysics` to control each axis on its own.
+
+The common case is a width-constrained grid inside a scrolling page: the page should own vertical scrolling while the grid keeps scrolling horizontally. Pair it with `fitContent: true` so the grid sizes itself to its content instead of needing a bounded height.
+
+```dart
+SingleChildScrollView(
+  child: TrinaGrid(
+    columns: columns,
+    rows: rows,
+    fitContent: true,
+    verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+  ),
+)
+```
+
+The reverse works the same way, for a grid inside a horizontally scrolling parent:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  horizontalScrollPhysics: const NeverScrollableScrollPhysics(),
+)
+```
+
+#### Precedence
+
+For each axis, the physics is resolved in this order:
+
+1. `verticalScrollPhysics` / `horizontalScrollPhysics`, if set for that axis
+2. `scrollPhysics`, if set
+3. The platform default from `MaterialScrollBehavior`
+
+A per-axis value replaces the fallback for its axis rather than layering on top of it, so it can re-enable an axis that `scrollPhysics` disabled:
+
+```dart
+// Nothing scrolls except horizontally.
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  scrollPhysics: const NeverScrollableScrollPhysics(),
+  horizontalScrollPhysics: const ClampingScrollPhysics(),
+)
+```
+
+#### Limitation
+
+Only the parts of `ScrollPhysics` that receive scroll metrics can be resolved per axis, because that is where the axis is known. The axis-agnostic ones (fling velocity thresholds, the spring description, the drag start threshold) come from `scrollPhysics` or the platform default instead. None of Flutter's built-in physics differ through those values, so this only matters for custom `ScrollPhysics` subclasses that override them.
+
+Internally this is implemented by `TrinaAxisScrollPhysics`, which is exported and can be used directly anywhere a `ScrollPhysics` is accepted.
+
 ### Combining Scroll Physics
 
 You can combine multiple scroll physics using the `applyTo` method for more complex behaviors:
@@ -410,6 +463,7 @@ TrinaGrid(
 
 7. **Scroll Physics**: Choose appropriate scroll physics based on your use case:
    - Use `NeverScrollableScrollPhysics()` when the grid is inside a scrollable parent to prevent scroll conflicts
+   - Reach for `verticalScrollPhysics` / `horizontalScrollPhysics` instead of `scrollPhysics` when only one axis should be affected, so the other axis keeps working
    - Use platform-specific physics (default) for the most native feel on each platform
    - Consider `AlwaysScrollableScrollPhysics()` if you need scrolling gestures to work even when content fits the viewport
 

--- a/lib/src/trina_axis_scroll_physics.dart
+++ b/lib/src/trina_axis_scroll_physics.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// A [ScrollPhysics] that applies different physics to each scroll axis.
+///
+/// [ScrollBehavior.getScrollPhysics] resolves a single [ScrollPhysics] for
+/// every [Scrollable] beneath a [ScrollConfiguration], with no way to tell the
+/// axes apart. Every [ScrollPhysics] method that makes a decision does receive
+/// [ScrollMetrics] though, and those metrics know their own
+/// [ScrollMetrics.axis], so one physics object can dispatch per axis.
+///
+/// TrinaGrid uses this internally when `TrinaGrid.horizontalScrollPhysics` or
+/// `TrinaGrid.verticalScrollPhysics` is set. The common case is a grid placed
+/// inside a scrolling page, where the page should own vertical scrolling while
+/// the grid keeps its horizontal scrolling:
+///
+/// ```dart
+/// TrinaGrid(
+///   columns: columns,
+///   rows: rows,
+///   fitContent: true,
+///   verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+/// )
+/// ```
+///
+/// It can also be used directly wherever a [ScrollPhysics] is accepted:
+///
+/// ```dart
+/// TrinaAxisScrollPhysics(
+///   horizontal: const BouncingScrollPhysics(),
+///   vertical: const NeverScrollableScrollPhysics(),
+/// )
+/// ```
+///
+/// Only the members that receive [ScrollMetrics] can be dispatched per axis.
+/// The axis-agnostic ones ([spring], [minFlingDistance], [minFlingVelocity],
+/// [maxFlingVelocity], [carriedMomentum], [dragStartDistanceMotionThreshold])
+/// keep the inherited behavior and defer to [parent], so fling and spring
+/// tuning follows the ambient physics rather than [horizontal] or [vertical].
+/// In practice none of Flutter's built-in physics differ through those members.
+class TrinaAxisScrollPhysics extends ScrollPhysics {
+  const TrinaAxisScrollPhysics({
+    required this.horizontal,
+    required this.vertical,
+    super.parent,
+  });
+
+  /// Physics applied to scroll positions on [Axis.horizontal].
+  final ScrollPhysics horizontal;
+
+  /// Physics applied to scroll positions on [Axis.vertical].
+  final ScrollPhysics vertical;
+
+  ScrollPhysics _forAxis(Axis axis) =>
+      axis == Axis.horizontal ? horizontal : vertical;
+
+  @override
+  TrinaAxisScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return TrinaAxisScrollPhysics(
+      horizontal: horizontal.applyTo(ancestor),
+      vertical: vertical.applyTo(ancestor),
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  bool shouldAcceptUserOffset(ScrollMetrics position) {
+    return _forAxis(position.axis).shouldAcceptUserOffset(position);
+  }
+
+  @override
+  double applyPhysicsToUserOffset(ScrollMetrics position, double offset) {
+    return _forAxis(position.axis).applyPhysicsToUserOffset(position, offset);
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    return _forAxis(position.axis).applyBoundaryConditions(position, value);
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    return _forAxis(
+      position.axis,
+    ).createBallisticSimulation(position, velocity);
+  }
+
+  @override
+  double adjustPositionForNewDimensions({
+    required ScrollMetrics oldPosition,
+    required ScrollMetrics newPosition,
+    required bool isScrolling,
+    required double velocity,
+  }) {
+    return _forAxis(newPosition.axis).adjustPositionForNewDimensions(
+      oldPosition: oldPosition,
+      newPosition: newPosition,
+      isScrolling: isScrolling,
+      velocity: velocity,
+    );
+  }
+
+  @override
+  bool recommendDeferredLoading(
+    double velocity,
+    ScrollMetrics metrics,
+    BuildContext context,
+  ) {
+    return _forAxis(
+      metrics.axis,
+    ).recommendDeferredLoading(velocity, metrics, context);
+  }
+
+  @override
+  Tolerance toleranceFor(ScrollMetrics metrics) {
+    return _forAxis(metrics.axis).toleranceFor(metrics);
+  }
+
+  /// The base implementation returns a bare `true` without deferring to
+  /// [parent], so it has to be combined here. Otherwise a grid whose axes are
+  /// both blocked would still advertise implicit scrolling to accessibility.
+  @override
+  bool get allowImplicitScrolling =>
+      horizontal.allowImplicitScrolling || vertical.allowImplicitScrolling;
+
+  @override
+  String toString() {
+    return '${objectRuntimeType(this, 'TrinaAxisScrollPhysics')}'
+        '(horizontal: $horizontal, vertical: $vertical)';
+  }
+}

--- a/lib/src/trina_grid.dart
+++ b/lib/src/trina_grid.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -132,6 +133,8 @@ class TrinaGrid extends TrinaStatefulWidget {
     this.onValidationFailed,
     this.onLazyFetchCompleted,
     this.scrollPhysics,
+    this.horizontalScrollPhysics,
+    this.verticalScrollPhysics,
     this.fitContent = false,
   });
 
@@ -511,6 +514,10 @@ class TrinaGrid extends TrinaStatefulWidget {
 
   /// Custom scroll physics to control scrolling behavior.
   ///
+  /// Applies to both axes. To control the axes separately, use
+  /// [horizontalScrollPhysics] and [verticalScrollPhysics], which take
+  /// precedence over this value on the axis they cover.
+  ///
   /// If null, uses platform-specific default scroll physics from [MaterialScrollBehavior].
   ///
   /// Example:
@@ -521,6 +528,40 @@ class TrinaGrid extends TrinaStatefulWidget {
   /// )
   /// ```
   final ScrollPhysics? scrollPhysics;
+
+  /// Scroll physics applied only to horizontal scrolling.
+  ///
+  /// Takes precedence over [scrollPhysics] on this axis. When null, the axis
+  /// falls back to [scrollPhysics], then to the platform default.
+  ///
+  /// See [verticalScrollPhysics] for the typical use case.
+  final ScrollPhysics? horizontalScrollPhysics;
+
+  /// Scroll physics applied only to vertical scrolling.
+  ///
+  /// Takes precedence over [scrollPhysics] on this axis. When null, the axis
+  /// falls back to [scrollPhysics], then to the platform default.
+  ///
+  /// Use this to place the grid inside a scrolling page: the page owns vertical
+  /// scrolling while the grid keeps scrolling horizontally. Pair it with
+  /// [fitContent] so the grid sizes itself to its content instead of needing a
+  /// bounded height.
+  ///
+  /// ```dart
+  /// SingleChildScrollView(
+  ///   child: TrinaGrid(
+  ///     columns: columns,
+  ///     rows: rows,
+  ///     fitContent: true,
+  ///     verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// Note that fling and spring tuning still comes from [scrollPhysics] or the
+  /// platform default, since those values are not axis-specific. See
+  /// [TrinaAxisScrollPhysics].
+  final ScrollPhysics? verticalScrollPhysics;
 
   /// When `true`, the grid sizes its overall height to fit its content
   /// (header + columns + rows + footer + borders) instead of expanding to
@@ -929,6 +970,14 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
       height += (row.height ?? defaultRowHeight) + cellHorizontalBorder;
     }
 
+    // The horizontal scrollbar is a sibling of the rows viewport rather than an
+    // overlay, so it takes height away from the rows. Without this the grid is
+    // left short by exactly that strip and the rows scroll by it.
+    final scrollbar = widget.configuration.scrollbar;
+    if (scrollbar.showHorizontal) {
+      height += scrollbar.effectiveThickness;
+    }
+
     if (_stateManager.showColumnFooter) {
       final double columnFooterHeight = _stateManager.columnFooterHeight > 0
           ? _stateManager.columnFooterHeight
@@ -1131,6 +1180,8 @@ class TrinaGridState extends TrinaStateWithChange<TrinaGrid> {
     final Widget grid = _GridContainer(
       stateManager: _stateManager,
       scrollPhysics: widget.scrollPhysics,
+      horizontalScrollPhysics: widget.horizontalScrollPhysics,
+      verticalScrollPhysics: widget.verticalScrollPhysics,
       child: body,
     );
 
@@ -1598,11 +1649,15 @@ class _GridContainer extends StatelessWidget {
 
   final Widget child;
   final ScrollPhysics? scrollPhysics;
+  final ScrollPhysics? horizontalScrollPhysics;
+  final ScrollPhysics? verticalScrollPhysics;
 
   const _GridContainer({
     required this.stateManager,
     required this.child,
     required this.scrollPhysics,
+    required this.horizontalScrollPhysics,
+    required this.verticalScrollPhysics,
   });
 
   @override
@@ -1618,6 +1673,8 @@ class _GridContainer extends StatelessWidget {
           isMobile: PlatformHelper.isMobile,
           userDragDevices: stateManager.configuration.scrollbar.dragDevices,
           scrollPhysics: scrollPhysics,
+          horizontalScrollPhysics: horizontalScrollPhysics,
+          verticalScrollPhysics: verticalScrollPhysics,
         ),
         child: DecoratedBox(
           decoration: BoxDecoration(
@@ -1684,13 +1741,23 @@ class TrinaScrollBehavior extends MaterialScrollBehavior {
     required this.isMobile,
     Set<PointerDeviceKind>? userDragDevices,
     this.scrollPhysics,
+    this.horizontalScrollPhysics,
+    this.verticalScrollPhysics,
   }) : _dragDevices =
            userDragDevices ??
            (isMobile ? _mobileDragDevices : _desktopDragDevices),
        super();
 
   final bool isMobile;
+
+  /// Physics applied to both axes, unless overridden per axis.
   final ScrollPhysics? scrollPhysics;
+
+  /// Physics applied to horizontal scrolling only.
+  final ScrollPhysics? horizontalScrollPhysics;
+
+  /// Physics applied to vertical scrolling only.
+  final ScrollPhysics? verticalScrollPhysics;
 
   @override
   Set<PointerDeviceKind> get dragDevices => _dragDevices;
@@ -1719,9 +1786,41 @@ class TrinaScrollBehavior extends MaterialScrollBehavior {
     return child;
   }
 
+  /// [ScrollBehavior.shouldNotify] returns false by default, which would leave
+  /// every [Scrollable] below the [ScrollConfiguration] holding the physics it
+  /// resolved on its first build. Without this, changing any of the physics
+  /// after the grid is built has no effect.
+  @override
+  bool shouldNotify(TrinaScrollBehavior oldDelegate) {
+    return oldDelegate.isMobile != isMobile ||
+        oldDelegate.scrollPhysics != scrollPhysics ||
+        oldDelegate.horizontalScrollPhysics != horizontalScrollPhysics ||
+        oldDelegate.verticalScrollPhysics != verticalScrollPhysics ||
+        !setEquals(oldDelegate._dragDevices, _dragDevices);
+  }
+
   @override
   ScrollPhysics getScrollPhysics(BuildContext context) {
-    return scrollPhysics ?? super.getScrollPhysics(context);
+    final base = scrollPhysics ?? super.getScrollPhysics(context);
+
+    if (horizontalScrollPhysics == null && verticalScrollPhysics == null) {
+      return base;
+    }
+
+    // A ScrollBehavior resolves one physics for every Scrollable below it and
+    // is never told which axis it is resolving for. TrinaAxisScrollPhysics
+    // defers that decision to call time, where ScrollMetrics.axis is known.
+    //
+    // Each axis replaces [base] rather than layering onto it, the same way
+    // [scrollPhysics] replaces the platform default. Layering would let a
+    // blocking [scrollPhysics] override a per axis physics meant to re-enable
+    // that axis, since the behaviors a physics does not define defer to its
+    // parent.
+    return TrinaAxisScrollPhysics(
+      horizontal: horizontalScrollPhysics ?? base,
+      vertical: verticalScrollPhysics ?? base,
+      parent: base,
+    );
   }
 }
 

--- a/lib/src/ui/trina_body_rows.dart
+++ b/lib/src/ui/trina_body_rows.dart
@@ -78,8 +78,19 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
     updateState(TrinaNotifierEventForceUpdate.instance);
   }
 
+  /// Having clients does not mean the position has been laid out yet, and
+  /// [ScrollPosition.maxScrollExtent] and [ScrollPosition.viewportDimension]
+  /// both throw before that happens.
+  bool _isLaidOut(ScrollController controller) {
+    if (!controller.hasClients) return false;
+
+    final position = controller.position;
+
+    return position.hasContentDimensions && position.hasViewportDimension;
+  }
+
   void _updateVerticalScrollInfo() {
-    if (!_verticalScroll.hasClients) return;
+    if (!_isLaidOut(_verticalScroll)) return;
 
     // Update value notifiers without triggering setState
     _verticalScrollOffsetNotifier.value = _verticalScroll.offset;
@@ -90,7 +101,7 @@ class TrinaBodyRowsState extends TrinaStateWithChange<TrinaBodyRows> {
   }
 
   void _updateHorizontalScrollInfo() {
-    if (!_horizontalScroll.hasClients) return;
+    if (!_isLaidOut(_horizontalScroll)) return;
 
     // Update value notifiers without triggering setState
     _horizontalScrollOffsetNotifier.value = _horizontalScroll.offset;

--- a/lib/trina_grid.dart
+++ b/lib/trina_grid.dart
@@ -41,6 +41,7 @@ export './src/plugin/trina_aggregate_column_footer.dart';
 export './src/plugin/trina_infinity_scroll_rows.dart';
 export './src/plugin/trina_lazy_pagination.dart';
 export './src/plugin/trina_pagination.dart';
+export './src/trina_axis_scroll_physics.dart';
 export './src/trina_dual_grid.dart';
 export './src/trina_dual_grid_popup.dart';
 export './src/trina_grid.dart';

--- a/test/scenario/layout/fit_content_test.dart
+++ b/test/scenario/layout/fit_content_test.dart
@@ -24,12 +24,17 @@ void main() {
     //   columnHeight                        (column titles)
     // + gridBorderWidth                     (column-row divider)
     // + rows * (rowHeight + cellHorizontalBorderWidth)
+    // + effectiveThickness                  (horizontal scrollbar strip, which
+    //                                        is a sibling of the rows viewport
+    //                                        rather than an overlay)
     double expectedHeightFor(int rowCount) {
       const style = TrinaGridStyleConfig();
+      const scrollbar = TrinaGridScrollbarConfig();
       final inner =
           style.columnHeight +
           style.gridBorderWidth +
-          rowCount * (style.rowHeight + style.cellHorizontalBorderWidth);
+          rowCount * (style.rowHeight + style.cellHorizontalBorderWidth) +
+          (scrollbar.showHorizontal ? scrollbar.effectiveThickness : 0);
       return inner + 2 * style.gridPadding;
     }
 
@@ -130,16 +135,55 @@ void main() {
       await tester.pumpAndSettle();
 
       const style = TrinaGridStyleConfig();
+      const scrollbar = TrinaGridScrollbarConfig();
       final inner =
           style.columnHeight +
           style.gridBorderWidth +
           // two default rows + one 100px row
           2 * (style.rowHeight + style.cellHorizontalBorderWidth) +
-          (100 + style.cellHorizontalBorderWidth);
+          (100 + style.cellHorizontalBorderWidth) +
+          (scrollbar.showHorizontal ? scrollbar.effectiveThickness : 0);
       final expected = inner + 2 * style.gridPadding;
 
       final gridSize = tester.getSize(find.byType(TrinaGrid));
       expect(gridSize.height, expected);
+    });
+
+    testWidgets('leaves the rows with nothing left to scroll vertically', (
+      tester,
+    ) async {
+      // The grid used to come up short by the horizontal scrollbar strip, which
+      // left the rows scrollable by exactly that much even though `fitContent`
+      // is meant to show all of them.
+      late TrinaGridStateManager stateManager;
+
+      await TestHelperUtil.changeWidth(tester: tester, width: 800, height: 900);
+
+      final manyColumns = ColumnHelper.textColumn(
+        'column',
+        count: 10,
+        width: 200,
+      );
+      final manyRows = RowHelper.count(12, manyColumns);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: SingleChildScrollView(
+              child: TrinaGrid(
+                columns: manyColumns,
+                rows: manyRows,
+                fitContent: true,
+                onLoaded: (event) => stateManager = event.stateManager,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(stateManager.scroll.bodyRowsVertical!.position.maxScrollExtent, 0);
     });
 
     testWidgets('fitContent: false (default) still expands to parent height', (

--- a/test/scenario/scrolling/axis_scroll_physics_test.dart
+++ b/test/scenario/scrolling/axis_scroll_physics_test.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../helper/test_helper_util.dart';
+
+/// Tests for https://github.com/doonfrs/trina_grid/issues/270
+///
+/// `scrollPhysics` applies to both axes at once, so blocking the grid's
+/// vertical scrolling used to block horizontal scrolling with it.
+/// `horizontalScrollPhysics` and `verticalScrollPhysics` let each axis be
+/// controlled on its own.
+void main() {
+  late TrinaGridStateManager stateManager;
+
+  Future<void> buildGrid(
+    WidgetTester tester, {
+    ScrollPhysics? scrollPhysics,
+    ScrollPhysics? horizontalScrollPhysics,
+    ScrollPhysics? verticalScrollPhysics,
+    int frozenStartColumns = 0,
+    bool smoothScrolling = true,
+  }) async {
+    await TestHelperUtil.changeWidth(tester: tester, width: 500, height: 400);
+
+    final columns = ColumnHelper.textColumn('column', count: 10, width: 200);
+
+    for (int i = 0; i < frozenStartColumns; i += 1) {
+      columns[i].frozen = TrinaColumnFrozen.start;
+    }
+
+    final rows = RowHelper.count(50, columns);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TrinaGrid(
+            columns: columns,
+            rows: rows,
+            scrollPhysics: scrollPhysics,
+            horizontalScrollPhysics: horizontalScrollPhysics,
+            verticalScrollPhysics: verticalScrollPhysics,
+            configuration: TrinaGridConfiguration(
+              scrollbar: TrinaGridScrollbarConfig(
+                smoothScrolling: smoothScrolling,
+              ),
+            ),
+            onLoaded: (TrinaGridOnLoadedEvent event) {
+              stateManager = event.stateManager;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<double> dragHorizontally(WidgetTester tester) async {
+    await tester.drag(find.byType(TrinaGrid), const Offset(-200, 0));
+    await tester.pumpAndSettle();
+    return stateManager.scroll.horizontal!.offset;
+  }
+
+  Future<double> dragVertically(WidgetTester tester) async {
+    await tester.drag(find.byType(TrinaGrid), const Offset(0, -200));
+    await tester.pumpAndSettle();
+    return stateManager.scroll.vertical!.offset;
+  }
+
+  testWidgets('With verticalScrollPhysics set to NeverScrollableScrollPhysics, '
+      'horizontal scrolling should work and vertical scrolling should not.', (
+    tester,
+  ) async {
+    await buildGrid(
+      tester,
+      verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+    );
+
+    expect(await dragHorizontally(tester), greaterThan(0));
+    expect(await dragVertically(tester), 0);
+  });
+
+  testWidgets(
+    'With horizontalScrollPhysics set to NeverScrollableScrollPhysics, '
+    'vertical scrolling should work and horizontal scrolling should not.',
+    (tester) async {
+      await buildGrid(
+        tester,
+        horizontalScrollPhysics: const NeverScrollableScrollPhysics(),
+      );
+
+      expect(await dragVertically(tester), greaterThan(0));
+      expect(await dragHorizontally(tester), 0);
+    },
+  );
+
+  testWidgets('With verticalScrollPhysics blocked and a frozen start column, '
+      'dragging over the frozen area should not scroll vertically.', (
+    tester,
+  ) async {
+    await buildGrid(
+      tester,
+      verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+      frozenStartColumns: 1,
+    );
+
+    // The frozen column occupies the leading 200px of the grid.
+    await tester.dragFrom(const Offset(60, 200), const Offset(0, -200));
+    await tester.pumpAndSettle();
+
+    expect(stateManager.scroll.vertical!.offset, 0);
+  });
+
+  testWidgets(
+    'With smooth scrolling disabled, per axis physics should still apply.',
+    (tester) async {
+      await buildGrid(
+        tester,
+        verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+        smoothScrolling: false,
+      );
+
+      expect(await dragHorizontally(tester), greaterThan(0));
+      expect(await dragVertically(tester), 0);
+    },
+  );
+
+  testWidgets(
+    'Without any physics passed, both axes should scroll as before.',
+    (tester) async {
+      await buildGrid(tester);
+
+      expect(await dragHorizontally(tester), greaterThan(0));
+      expect(await dragVertically(tester), greaterThan(0));
+    },
+  );
+
+  testWidgets('scrollPhysics on its own should still block both axes.', (
+    tester,
+  ) async {
+    await buildGrid(
+      tester,
+      scrollPhysics: const NeverScrollableScrollPhysics(),
+    );
+
+    expect(await dragHorizontally(tester), 0);
+    expect(await dragVertically(tester), 0);
+  });
+
+  testWidgets('Per axis physics should take precedence over scrollPhysics.', (
+    tester,
+  ) async {
+    await buildGrid(
+      tester,
+      scrollPhysics: const NeverScrollableScrollPhysics(),
+      horizontalScrollPhysics: const ClampingScrollPhysics(),
+    );
+
+    expect(await dragHorizontally(tester), greaterThan(0));
+    expect(await dragVertically(tester), 0);
+  });
+
+  testWidgets(
+    'Changing the physics after the grid is built should take effect.',
+    (tester) async {
+      await TestHelperUtil.changeWidth(tester: tester, width: 500, height: 400);
+
+      final columns = ColumnHelper.textColumn('column', count: 10, width: 200);
+      final rows = RowHelper.count(50, columns);
+
+      late StateSetter setOuterState;
+      ScrollPhysics? vertical;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                setOuterState = setState;
+                return TrinaGrid(
+                  columns: columns,
+                  rows: rows,
+                  verticalScrollPhysics: vertical,
+                  onLoaded: (TrinaGridOnLoadedEvent event) {
+                    stateManager = event.stateManager;
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Starts unrestricted.
+      expect(await dragVertically(tester), greaterThan(0));
+
+      // Block the vertical axis without rebuilding the grid from scratch.
+      setOuterState(() => vertical = const NeverScrollableScrollPhysics());
+      await tester.pumpAndSettle();
+
+      final blockedFrom = stateManager.scroll.vertical!.offset;
+      await tester.drag(find.byType(TrinaGrid), const Offset(0, -200));
+      await tester.pumpAndSettle();
+      expect(stateManager.scroll.vertical!.offset, blockedFrom);
+
+      // And release it again.
+      setOuterState(() => vertical = null);
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(TrinaGrid), const Offset(0, -200));
+      await tester.pumpAndSettle();
+      expect(stateManager.scroll.vertical!.offset, greaterThan(blockedFrom));
+    },
+  );
+
+  testWidgets(
+    'A grid inside a scrolling page should hand vertical drags to the page '
+    'while keeping its own horizontal scrolling.',
+    (tester) async {
+      await TestHelperUtil.changeWidth(tester: tester, width: 500, height: 400);
+
+      final columns = ColumnHelper.textColumn('column', count: 10, width: 200);
+      final rows = RowHelper.count(50, columns);
+      final outerScroll = ScrollController();
+      addTearDown(outerScroll.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ListView(
+              controller: outerScroll,
+              children: [
+                const SizedBox(height: 200),
+                TrinaGrid(
+                  columns: columns,
+                  rows: rows,
+                  fitContent: true,
+                  verticalScrollPhysics: const NeverScrollableScrollPhysics(),
+                  onLoaded: (TrinaGridOnLoadedEvent event) {
+                    stateManager = event.stateManager;
+                  },
+                ),
+                const SizedBox(height: 2000),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // `fitContent` makes the grid taller than the viewport, so its center is
+      // off-screen. Drag from a point that is inside the grid's rows area.
+      const insideGrid = Offset(250, 350);
+
+      // A vertical drag over the grid scrolls the page, not the grid.
+      await tester.dragFrom(insideGrid, const Offset(0, -150));
+      await tester.pumpAndSettle();
+
+      expect(outerScroll.offset, greaterThan(0));
+      expect(stateManager.scroll.vertical!.offset, 0);
+
+      // The grid keeps its own horizontal scrolling.
+      final outerOffsetBefore = outerScroll.offset;
+      await tester.dragFrom(insideGrid, const Offset(-200, 0));
+      await tester.pumpAndSettle();
+
+      expect(stateManager.scroll.horizontal!.offset, greaterThan(0));
+      expect(outerScroll.offset, outerOffsetBefore);
+    },
+  );
+}


### PR DESCRIPTION
Closes #270

## Problem

`TrinaGrid.scrollPhysics` applies to both axes at once. A width-constrained grid placed inside a vertical scroll view could not hand vertical scrolling to the page without also losing its horizontal scrolling, since `NeverScrollableScrollPhysics` blocked both.

This is not a duplicate of #96, which asked how to set physics at all and was resolved by #329.

## Changes

### Per axis physics

`horizontalScrollPhysics` and `verticalScrollPhysics` on `TrinaGrid`. Each takes precedence over `scrollPhysics` on its own axis, falling back to it and then to the platform default.

```dart
SingleChildScrollView(
  child: TrinaGrid(
    columns: columns,
    rows: rows,
    fitContent: true,
    verticalScrollPhysics: const NeverScrollableScrollPhysics(),
  ),
)
```

A `ScrollBehavior` resolves a single physics for every scrollable below it and is never told which axis it is resolving for. Every `ScrollPhysics` member that makes a decision does receive `ScrollMetrics` though, and those know their own `axis`, so the new `TrinaAxisScrollPhysics` defers the choice to call time. This reaches the header, column footer, and frozen row lists too, without touching their existing physics: `ClampingScrollPhysics` does not override `shouldAcceptUserOffset`, so that call delegates up the parent chain.

Each axis replaces the fallback rather than layering onto it, matching how `scrollPhysics` already replaces the platform default. Layering would stop a per axis physics from re-enabling an axis that `scrollPhysics` had disabled.

Only members that receive `ScrollMetrics` can be resolved per axis. The axis-agnostic ones (spring, fling thresholds, drag start threshold) defer to the ambient physics. No built-in Flutter physics differs through those.

### Fixes found along the way

- **`scrollPhysics` never applied on rebuild.** `TrinaScrollBehavior` did not override `ScrollBehavior.shouldNotify`, which returns `false` by default. `ScrollConfiguration.updateShouldNotify` calls it, so no scrollable was ever told to recompute, and every one kept the physics it resolved on its first build. This affected the pre-existing `scrollPhysics` param, not just the new ones.
- **`fitContent` came up short by the horizontal scrollbar strip.** That strip is a sibling of the rows viewport rather than an overlay, but `_computeContentHeight` did not count it, so the rows stayed scrollable by exactly its thickness (measured: `maxScrollExtent` of 12.0 against an `effectiveThickness` of 12.0). Two existing `fitContent` tests needed their expected heights adjusted accordingly.
- **Null check error in the body rows scroll listeners.** They guarded on `hasClients`, which only means a controller is attached, not that the position has been laid out. Both `maxScrollExtent` and `viewportDimension` throw before that.

### Docs and demo

New "Per-Axis Scroll Physics" section in `doc/features/scrollbars.md` covering the use case, precedence, and the limitation. New Scroll Physics demo screen with a grid embedded in a scrolling page and per axis dropdowns, so the behavior can be checked by hand.

## Testing

`test/scenario/scrolling/axis_scroll_physics_test.dart`, 9 cases: each axis blocked on its own, a frozen start column, smooth scrolling off, an unchanged baseline, `scrollPhysics` alone still blocking both, per axis precedence, physics changed at runtime, and the reported scenario end to end inside an outer `ListView`.

The runtime-change case was verified to fail without the `shouldNotify` fix. `test/scenario/layout/fit_content_test.dart` gains a case pinning that `fitContent` leaves no vertical scroll extent.

Full suite: 1630 passing. `dart analyze` clean on both packages.
