### PR TITLE
docs: clarify titleRenderer is the column header renderer

### DIFF
--- a/doc/features/column-title-renderer.md
+++ b/doc/features/column-title-renderer.md
@@ -1,6 +1,8 @@
 # Column Title Renderer
 
-The column title renderer feature allows you to fully customize the appearance and behavior of column titles in TrinaGrid. This is useful when you want to:
+> Looking for a `headerRenderer` or `headerBuilder`? This is it. TrinaGrid calls the column header the column *title*, so `TrinaColumn.titleRenderer` is the header customization API, and it is the direct counterpart of `footerRenderer`.
+
+The column title renderer feature allows you to fully customize the appearance and behavior of column titles (also known as column headers) in TrinaGrid. This is useful when you want to:
 
 - Create visually distinctive column headers
 - Add custom icons or badges to column titles

--- a/doc/index.md
+++ b/doc/index.md
@@ -28,7 +28,7 @@ Welcome to the official documentation for TrinaGrid, a powerful data grid for Fl
   - [Multi-Items Filter](features/column-filtering.md#multi-items-filter-multi-linecomma-separated)
 - [Column Groups](features/column-groups.md)
 - [Column Renderers](features/column-renderer.md)
-- [Column Title Renderer](features/column-title-renderer.md)
+- [Column Title Renderer](features/column-title-renderer.md) (custom column headers)
 - [Column Footer](features/column-footer.md)
 - [Column Viewport Visibility](features/column-visibility.md)
 

--- a/lib/src/model/trina_column.dart
+++ b/lib/src/model/trina_column.dart
@@ -220,8 +220,9 @@ class TrinaColumn {
   )?
   editCellRenderer;
 
-  /// Custom renderer for the column title.
-  /// This allows complete customization of the column title UI.
+  /// Custom renderer for the column title (also known as the column header).
+  /// This allows complete customization of the column title UI, and is the
+  /// header counterpart of [footerRenderer].
   /// If provided, this takes precedence over the title, titleSpan, and other title-related properties.
   ///
   /// ```dart


### PR DESCRIPTION
## Summary

Issue #407 asked for a `headerRenderer` on `TrinaColumn`. That capability already exists as `TrinaColumn.titleRenderer`, the direct counterpart of `footerRenderer`. The real problem is naming: TrinaGrid calls the column header the column *title*, and the word "header" appeared nowhere in the relevant documentation, so nobody searching for it could find the feature.

No new API is added here. Adding a `headerRenderer` alias would mean two public names for one thing plus a precedence rule to maintain, so this fixes the discoverability gap instead.

## Changes

- `doc/features/column-title-renderer.md`: callout at the top of the page for anyone searching for `headerRenderer` or `headerBuilder`, and "also known as column headers" in the intro sentence.
- `doc/index.md`: the index entry now reads "Column Title Renderer (custom column headers)".
- `lib/src/model/trina_column.dart`: `titleRenderer` dartdoc now says "also known as the column header" and names it the header counterpart of `footerRenderer`. This is what renders on the pub.dev API docs, which is where a lot of people search.

Docs and comments only. No behavior change. `dart format` and `dart analyze` are clean.

Closes #407
