### PR TITLE
feat: derive grid colors from the Material theme (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Feature: Added `TrinaGridConfiguration.fromTheme(context)` and `TrinaGridStyleConfig.fromTheme`/`fromColorScheme`, deriving the grid colors from the app's Material `ColorScheme` so the grid follows the host theme and its brightness. Opt-in: the existing light and dark palettes are unchanged (#336). @doonfrs @stan-at-work
+* Fix: `TrinaGridStyleConfig.copyWith` no longer drops `rowCheckedColor`, `rowHoveredColor`, `enableRowHoverColor` and `cellDefaultColor`. It rebuilt the style through the public light/dark constructors, which do not accept those fields, so any customized value silently reverted to the default. These are now also settable through `copyWith`, along with `cellDirtyColor`, `frozenRowColor` and `frozenRowBorderColor`. @doonfrs
+* Fix: The hidden-columns popup now inherits the grid's own configuration instead of rebuilding from a fresh default light or dark one, so custom and theme-derived styles reach it. @doonfrs
 * Feature: Added `checkReadOnly` to `TrinaRow` and `TrinaCell`, so read-only conditions can be declared per row or per cell instead of only per column. The first callback that is set wins: cell, then row, then column, then the static `TrinaColumn.readOnly` (#404). @doonfrs
 * Feature: Added `stateManager.refreshReadOnly()` to re-evaluate the read-only styling of the cells on screen. Read-only enforcement was already live, but the styling is memoized per cell and could go stale when a `checkReadOnly` callback depended on state outside its row (#404). @doonfrs
 * Fix: The record sidebar now honors `checkReadOnly`. It only read the static `TrinaColumn.readOnly`, so it let users edit fields the grid itself blocked (#404). @doonfrs

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -32,6 +32,7 @@ import 'screen/feature/column_sorting_screen.dart';
 import 'screen/feature/copy_and_paste_screen.dart';
 import 'screen/feature/currency_type_column_screen.dart';
 import 'screen/feature/dark_mode_screen.dart';
+import 'screen/feature/theme_integration_screen.dart';
 import 'screen/feature/date_type_column_screen.dart';
 import 'screen/feature/dual_mode_screen.dart';
 import 'screen/feature/edit_cell_renderer_screen.dart';
@@ -130,6 +131,8 @@ class MyApp extends StatelessWidget {
         CustomTypeColumnScreen.routeName: (context) =>
             const CustomTypeColumnScreen(),
         DarkModeScreen.routeName: (context) => const DarkModeScreen(),
+        ThemeIntegrationScreen.routeName: (context) =>
+            const ThemeIntegrationScreen(),
         DateTypeColumnScreen.routeName: (context) =>
             const DateTypeColumnScreen(),
         DualModeScreen.routeName: (context) => const DualModeScreen(),

--- a/demo/lib/screen/feature/theme_integration_screen.dart
+++ b/demo/lib/screen/feature/theme_integration_screen.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+import '../../widget/trina_example_button.dart';
+import '../../widget/trina_example_screen.dart';
+
+class ThemeIntegrationScreen extends StatefulWidget {
+  static const routeName = 'feature/theme-integration';
+
+  const ThemeIntegrationScreen({super.key});
+
+  @override
+  State<ThemeIntegrationScreen> createState() => _ThemeIntegrationScreenState();
+}
+
+class _ThemeIntegrationScreenState extends State<ThemeIntegrationScreen> {
+  final List<TrinaColumn> columns = [];
+
+  final List<TrinaRow> rows = [];
+
+  static const Map<String, Color> _seeds = {
+    'Indigo': Colors.indigo,
+    'Deep purple': Colors.deepPurple,
+    'Teal': Colors.teal,
+    'Orange': Colors.orange,
+    'Pink': Colors.pink,
+  };
+
+  String _seedName = 'Indigo';
+
+  Brightness _brightness = Brightness.light;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      TrinaColumn(
+        title: 'ID',
+        field: 'id',
+        type: TrinaColumnType.number(),
+        width: 80,
+        frozen: TrinaColumnFrozen.start,
+      ),
+      TrinaColumn(
+        title: 'Name',
+        field: 'name',
+        type: TrinaColumnType.text(),
+        width: 150,
+        enableRowChecked: true,
+      ),
+      TrinaColumn(
+        title: 'Status',
+        field: 'status',
+        type: TrinaColumnType.select(<String>[
+          'Active',
+          'Inactive',
+          'Pending',
+          'Completed',
+        ]),
+        width: 130,
+      ),
+      TrinaColumn(
+        title: 'Date',
+        field: 'date',
+        type: TrinaColumnType.date(),
+        width: 130,
+      ),
+      TrinaColumn(
+        title: 'Amount',
+        field: 'amount',
+        type: TrinaColumnType.currency(),
+        width: 140,
+        readOnly: true,
+      ),
+    ]);
+
+    const statuses = ['Active', 'Inactive', 'Pending', 'Completed'];
+
+    for (int i = 1; i <= 40; i += 1) {
+      rows.add(
+        TrinaRow(
+          cells: {
+            'id': TrinaCell(value: i),
+            'name': TrinaCell(value: 'Item $i'),
+            'status': TrinaCell(value: statuses[i % statuses.length]),
+            'date': TrinaCell(
+              value: DateTime.now().add(Duration(days: i % 30 - 15)),
+            ),
+            'amount': TrinaCell(value: (5000 + (i * 123.45)) % 50000),
+          },
+        ),
+      );
+    }
+  }
+
+  ThemeData get _theme => ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: _seeds[_seedName]!,
+      brightness: _brightness,
+    ),
+  );
+
+  Widget _buildControls() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Wrap(
+        spacing: 16,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          const Text('Seed color:'),
+          DropdownButton<String>(
+            value: _seedName,
+            items: _seeds.keys
+                .map(
+                  (name) => DropdownMenuItem<String>(
+                    value: name,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 14,
+                          height: 14,
+                          decoration: BoxDecoration(
+                            color: _seeds[name],
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(name),
+                      ],
+                    ),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              if (value == null) return;
+              setState(() => _seedName = value);
+            },
+          ),
+          const Text('Brightness:'),
+          SegmentedButton<Brightness>(
+            segments: const [
+              ButtonSegment(value: Brightness.light, label: Text('Light')),
+              ButtonSegment(value: Brightness.dark, label: Text('Dark')),
+            ],
+            selected: {_brightness},
+            onSelectionChanged: (selection) {
+              setState(() => _brightness = selection.first);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TrinaExampleScreen(
+      title: 'Material theme integration',
+      topTitle: 'Material theme integration',
+      topContents: const [
+        Text(
+          'TrinaGridConfiguration.fromTheme(context) derives the grid colors from the ambient Material ColorScheme.',
+        ),
+        SizedBox(height: 8),
+        Text(
+          'Change the seed color or the brightness below and the whole grid follows, including the column menu, the filter popup and the select and date editors.',
+        ),
+        SizedBox(height: 8),
+        Text(
+          'This is opt-in. TrinaGridConfiguration() and TrinaGridConfiguration.dark() keep their fixed palettes.',
+        ),
+      ],
+      topButtons: [
+        TrinaExampleButton(
+          url:
+              'https://github.com/doonfrs/trina_grid/blob/master/demo/lib/screen/feature/theme_integration_screen.dart',
+        ),
+      ],
+      body: Theme(
+        data: _theme,
+        child: Builder(
+          builder: (themedContext) {
+            return ColoredBox(
+              color: Theme.of(themedContext).colorScheme.surfaceContainerLowest,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildControls(),
+                    Expanded(
+                      child: TrinaGrid(
+                        key: ValueKey('$_seedName-$_brightness'),
+                        columns: columns,
+                        rows: rows,
+                        configuration:
+                            TrinaGridConfiguration.fromTheme(
+                              themedContext,
+                            ).copyWith(
+                              columnFilter: const TrinaGridColumnFilterConfig(
+                                filters: [...FilterHelper.defaultFilters],
+                              ),
+                            ),
+                        onLoaded: (event) {
+                          event.stateManager.setShowColumnFilter(true);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -44,6 +44,7 @@ import 'feature/copy_and_paste_screen.dart';
 import 'feature/currency_type_column_screen.dart';
 import 'feature/custom_pagination_screen.dart';
 import 'feature/dark_mode_screen.dart';
+import 'feature/theme_integration_screen.dart';
 import 'feature/date_type_column_screen.dart';
 import 'feature/dual_mode_screen.dart';
 import 'feature/editing_state_screen.dart';
@@ -668,6 +669,15 @@ class _TrinaFeaturesState extends State<TrinaFeatures> {
         onTapLiveDemo: () {
           Navigator.pushNamed(context, DarkModeScreen.routeName);
         },
+      ),
+      TrinaListTile(
+        title: 'Material theme integration',
+        description:
+            'Derive the grid colors from the app ColorScheme with fromTheme.',
+        onTapLiveDemo: () {
+          Navigator.pushNamed(context, ThemeIntegrationScreen.routeName);
+        },
+        trailing: newIcon,
       ),
       TrinaListTile(
         title: 'Dark mode Switching',

--- a/doc/features/themes.md
+++ b/doc/features/themes.md
@@ -1,0 +1,129 @@
+# Themes
+
+TrinaGrid gives you three ways to style a grid:
+
+1. **The built-in palettes** - `TrinaGridConfiguration()` (light) and `TrinaGridConfiguration.dark()`. Fixed colors, unchanged since the earliest versions.
+2. **Material theme integration** - `TrinaGridConfiguration.fromTheme(context)` derives the grid colors from your app's `ColorScheme`.
+3. **Manual styling** - spell out the fields of `TrinaGridStyleConfig` yourself.
+
+All three can be combined with `copyWith`.
+
+## Material theme integration
+
+By default the grid does **not** follow your app theme. A grid dropped into a `deepPurple`-seeded `MaterialApp` still renders white with light-blue selection, because the defaults are compile-time constants and a `const` constructor cannot read `Theme.of(context)`.
+
+`fromTheme` closes that gap:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration.fromTheme(context),
+)
+```
+
+The grid now uses your seed color, and follows light/dark automatically because `ColorScheme.brightness` decides `isDarkStyle`.
+
+> Call it inside `build`. It reads the ambient theme, so it cannot be `const`, and calling it from `initState` would freeze the grid on whatever theme was active at the time.
+
+### Setting other options
+
+`fromTheme` only sets `style`. Chain `copyWith` for everything else:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration.fromTheme(context).copyWith(
+    selectingMode: TrinaGridSelectingMode.row,
+    enableMoveDownAfterSelecting: true,
+  ),
+)
+```
+
+### Overriding individual colors
+
+Use `TrinaGridStyleConfig.copyWith` to keep the theme mapping but change a few values:
+
+```dart
+final theme = Theme.of(context);
+
+TrinaGridConfiguration(
+  style: TrinaGridStyleConfig.fromTheme(theme).copyWith(
+    rowHeight: 56,
+    oddRowColor: TrinaOptional(theme.colorScheme.surfaceContainerLowest),
+  ),
+)
+```
+
+### Starting from a ColorScheme
+
+When you have a scheme but no full `ThemeData`:
+
+```dart
+TrinaGridStyleConfig.fromColorScheme(
+  ColorScheme.fromSeed(seedColor: Colors.indigo),
+)
+```
+
+`fromTheme` delegates to this, passing `theme.textTheme` so `columnTextStyle` and `cellTextStyle` inherit your font.
+
+## What gets mapped
+
+| Style field | ColorScheme role |
+|---|---|
+| `gridBackgroundColor`, `rowColor`, `cellColorInEditState` | `surface` |
+| `frozenRowColor` | `surfaceContainerLow` |
+| `menuBackgroundColor` | `surfaceContainer` |
+| `cellColorInReadOnlyState`, `unfocusedSelectionColor` | `surfaceContainerHighest` |
+| `activatedColor`, `columnCheckedColor`, `cellCheckedColor` | `primaryContainer` |
+| `dragTargetColumnColor` | `primaryContainer` at 50% alpha |
+| `activatedBorderColor`, `columnActiveColor`, `cellActiveColor` | `primary` |
+| `rowCheckedColor` | `primary` at 8% alpha |
+| `rowHoveredColor` | `onSurface` at 8% alpha |
+| `borderColor`, `inactivatedBorderColor`, `frozenRowBorderColor` | `outlineVariant` |
+| `gridBorderColor` | `outline` |
+| `iconColor`, `columnUnselectedColor`, `cellUnselectedColor` | `onSurfaceVariant` |
+| `disabledIconColor` | `onSurface` at 38% alpha |
+| `cellDirtyColor` | `tertiaryContainer` |
+| `columnTextStyle` | `textTheme.titleSmall` recolored to `onSurface` |
+| `cellTextStyle` | `textTheme.bodyMedium` recolored to `onSurface` |
+| `isDarkStyle` | `scheme.brightness == Brightness.dark` |
+
+Everything that is not a color keeps the default value: `rowHeight`, `columnHeight`, paddings, icon sizes, border widths, and the sort/group/context icons.
+
+The opt-in nullable colors stay `null` so their existing fallbacks still apply: `oddRowColor`, `evenRowColor`, `cellReadonlyColor`, `cellDefaultColor`, `cellColorGroupedRow`, `filterHeaderColor`, `filterPopupHeaderColor`, `filterHeaderIconColor`.
+
+## Backward compatibility
+
+`fromTheme` is entirely opt-in. `TrinaGridConfiguration()` and `TrinaGridConfiguration.dark()` keep the exact colors they have always had, so upgrading changes nothing until you call `fromTheme` yourself.
+
+## Known gaps
+
+A few colors are not reachable through `TrinaGridStyleConfig` yet, so they stay fixed even under `fromTheme`:
+
+- the green and red default sort icons in column titles
+- the blue column-drag indicator
+- the column resize divider
+- some popup chrome (background, arrow, barrier)
+- the default checkbox colors
+
+These need their own configuration fields before they can follow a theme. Track this with [issue #336](https://github.com/doonfrs/trina_grid/issues/336).
+
+## Dark mode without theme integration
+
+If you only want the built-in dark palette:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: const TrinaGridConfiguration.dark(),
+)
+```
+
+## Related
+
+- [Configuration](../getting-started/configuration.md) - the full list of style fields
+- [Cell Color](cell-color.md) - per-cell coloring
+- [Row Color](row-color.md) - per-row coloring

--- a/doc/getting-started/configuration.md
+++ b/doc/getting-started/configuration.md
@@ -29,7 +29,7 @@ TrinaGridConfiguration(
     gridBackgroundColor: Colors.white,
     borderColor: Colors.grey[300]!,
     activatedBorderColor: Colors.blue,
-    activatedColor: Colors.blue.withOpacity(0.2),
+    activatedColor: Colors.blue.withValues(alpha: 0.2),
     inactivatedBorderColor: Colors.grey[300]!,
     
     // Cell styles
@@ -118,10 +118,10 @@ TrinaGridConfiguration(
     // Appearance settings
     thickness: 8.0,
     minThumbLength: 40.0,
-    thumbColor: Colors.blue.withOpacity(0.6),
-    trackColor: Colors.grey.withOpacity(0.2),
-    thumbHoverColor: Colors.blue.withOpacity(0.8),
-    trackHoverColor: Colors.grey.withOpacity(0.3),
+    thumbColor: Colors.blue.withValues(alpha: 0.6),
+    trackColor: Colors.grey.withValues(alpha: 0.2),
+    thumbHoverColor: Colors.blue.withValues(alpha: 0.8),
+    trackHoverColor: Colors.grey.withValues(alpha: 0.3),
     isDraggable: true,
   ),
 )
@@ -270,6 +270,38 @@ TrinaGrid(
 )
 ```
 
+### Material Theme Integration
+
+By default the grid does not follow your app theme: the defaults are compile-time
+constants, so a `const` constructor cannot read `Theme.of(context)`. Use
+`fromTheme` to derive the grid colors from your app's `ColorScheme` instead:
+
+```dart
+TrinaGrid(
+  columns: columns,
+  rows: rows,
+  configuration: TrinaGridConfiguration.fromTheme(context),
+)
+```
+
+This also follows light/dark automatically, because `ColorScheme.brightness`
+decides the grid's dark styling. Call it inside `build` so the grid tracks
+theme changes.
+
+`fromTheme` only sets `style`; chain `copyWith` for the other options, and
+`TrinaGridStyleConfig.copyWith` to override individual colors:
+
+```dart
+TrinaGridConfiguration.fromTheme(context).copyWith(
+  selectingMode: TrinaGridSelectingMode.row,
+)
+```
+
+It is entirely opt-in - `TrinaGridConfiguration()` and
+`TrinaGridConfiguration.dark()` keep the colors they have always had.
+
+See [Themes](../features/themes.md) for the full role mapping.
+
 ### Custom Theme
 
 You can create your own theme by extending the default configuration:
@@ -280,7 +312,7 @@ final myTheme = TrinaGridConfiguration(
     gridBackgroundColor: Colors.indigo[50]!,
     borderColor: Colors.indigo[300]!,
     activatedBorderColor: Colors.indigo,
-    activatedColor: Colors.indigo.withOpacity(0.2),
+    activatedColor: Colors.indigo.withValues(alpha: 0.2),
     columnTextStyle: const TextStyle(
       color: Colors.indigo[900]!,
       fontWeight: FontWeight.bold,
@@ -401,7 +433,7 @@ TrinaGrid(
       gridBackgroundColor: Colors.white,
       borderColor: Colors.grey[300]!,
       activatedBorderColor: Colors.blue,
-      activatedColor: Colors.blue.withOpacity(0.2),
+      activatedColor: Colors.blue.withValues(alpha: 0.2),
       cellTextStyle: const TextStyle(fontSize: 14),
       columnTextStyle: const TextStyle(
         fontSize: 14,
@@ -429,10 +461,10 @@ TrinaGrid(
       showTrack: true,             // Show scrollbar tracks
       thickness: 8.0,              // Scrollbar thickness
       minThumbLength: 40.0,        // Minimum thumb length
-      thumbColor: Colors.blue.withOpacity(0.6),  // Thumb color
-      trackColor: Colors.grey.withOpacity(0.2),  // Track color
-      thumbHoverColor: Colors.blue.withOpacity(0.8),
-      trackHoverColor: Colors.grey.withOpacity(0.3),
+      thumbColor: Colors.blue.withValues(alpha: 0.6),  // Thumb color
+      trackColor: Colors.grey.withValues(alpha: 0.2),  // Track color
+      thumbHoverColor: Colors.blue.withValues(alpha: 0.8),
+      trackHoverColor: Colors.grey.withValues(alpha: 0.3),
       isDraggable: true,
     ),
     

--- a/lib/src/manager/state/column_state.dart
+++ b/lib/src/manager/state/column_state.dart
@@ -775,10 +775,10 @@ mixin ColumnState implements ITrinaGridState {
       }
     }
 
-    // Use dark configuration if the current configuration is in dark mode
-    final baseConfiguration = configuration.style.isDarkStyle
-        ? const TrinaGridConfiguration.dark()
-        : const TrinaGridConfiguration();
+    // Inherit the grid's own configuration so the popup matches it, including
+    // custom and theme-derived styles. Rebuilding from a fresh const light or
+    // dark configuration here used to discard them.
+    final baseConfiguration = configuration;
 
     TrinaGridPopup(
       context: context,

--- a/lib/src/trina_grid_configuration.dart
+++ b/lib/src/trina_grid_configuration.dart
@@ -237,6 +237,37 @@ class TrinaGridConfiguration {
     this.rowWrapperIsConstantHeight = false,
   });
 
+  /// Builds a configuration whose [style] is derived from the Material theme
+  /// of [context].
+  ///
+  /// This is opt-in: [TrinaGridConfiguration] and [TrinaGridConfiguration.dark]
+  /// keep their fixed palettes, so existing grids look exactly the same.
+  ///
+  /// ```dart
+  /// TrinaGrid(
+  ///   columns: columns,
+  ///   rows: rows,
+  ///   configuration: TrinaGridConfiguration.fromTheme(context),
+  /// )
+  /// ```
+  ///
+  /// Chain [copyWith] to set the non-style options, and
+  /// [TrinaGridStyleConfig.copyWith] to override individual colors:
+  ///
+  /// ```dart
+  /// TrinaGridConfiguration.fromTheme(context).copyWith(
+  ///   selectingMode: TrinaGridSelectingMode.row,
+  /// )
+  /// ```
+  ///
+  /// Because it reads the theme, this cannot be `const` and must be called
+  /// from `build` so the grid follows theme and brightness changes.
+  factory TrinaGridConfiguration.fromTheme(BuildContext context) {
+    return TrinaGridConfiguration(
+      style: TrinaGridStyleConfig.fromTheme(Theme.of(context)),
+    );
+  }
+
   void updateLocale() {
     TrinaFilterTypeContains.name = localeText.filterContains;
     TrinaFilterTypeEquals.name = localeText.filterEquals;
@@ -565,6 +596,183 @@ class TrinaGridStyleConfig {
        cellActiveColor = (cellActiveColor ?? const Color(0xFFFFFFFF)),
        isDarkStyle = true;
 
+  /// Full constructor used by the theme factories.
+  ///
+  /// The public constructors fix [isDarkStyle] in their initializer lists, so
+  /// they cannot express a style whose brightness is decided at runtime. This
+  /// one takes every field, [isDarkStyle] included. Its defaults mirror the
+  /// light constructor so a factory only has to pass what it actually derives.
+  const TrinaGridStyleConfig._({
+    required this.isDarkStyle,
+    this.enableGridBorderShadow = false,
+    this.enableColumnBorderVertical = true,
+    this.enableColumnBorderHorizontal = true,
+    this.enableCellBorderVertical = true,
+    this.enableCellBorderHorizontal = true,
+    this.enableRowColorAnimation = false,
+    this.enableRowHoverColor = false,
+    this.filterIcon = const Icon(Icons.filter_alt_outlined),
+    this.filterIconWidget,
+    this.gridBackgroundColor = Colors.white,
+    this.unfocusedSelectionColor,
+    this.rowColor = Colors.white,
+    this.oddRowColor,
+    this.evenRowColor,
+    this.activatedColor = const Color(0xFFDCF5FF),
+    this.columnCheckedColor = const Color(0xFFDCF5FF),
+    this.columnCheckedSide,
+    this.cellCheckedColor = const Color(0xFFDCF5FF),
+    this.cellCheckedSide,
+    this.rowCheckedColor = const Color(0x11757575),
+    this.rowHoveredColor = const Color(0xFFB1B3B7),
+    this.cellColorInEditState = Colors.white,
+    this.cellColorInReadOnlyState = const Color(0xFFDBDBDC),
+    this.cellReadonlyColor,
+    this.cellDefaultColor,
+    this.cellColorGroupedRow,
+    this.cellDirtyColor = const Color(0xFFFFF9C4),
+    this.frozenRowColor = const Color(0xFFF8F8F8),
+    this.frozenRowBorderColor = const Color(0xFFE0E0E0),
+    this.dragTargetColumnColor = const Color.fromARGB(129, 220, 245, 255),
+    this.iconColor = Colors.black38,
+    this.disabledIconColor = Colors.black12,
+    this.menuBackgroundColor = Colors.white,
+    this.gridBorderColor = const Color(0xFFA1A5AE),
+    this.borderColor = const Color(0xFFDDE2EB),
+    this.activatedBorderColor = Colors.lightBlue,
+    this.inactivatedBorderColor = const Color(0xFFC4C7CC),
+    this.iconSize = 18,
+    this.rowHeight = TrinaGridSettings.rowHeight,
+    this.columnHeight = TrinaGridSettings.rowHeight,
+    this.columnFilterHeight = TrinaGridSettings.rowHeight,
+    this.defaultColumnTitlePadding = TrinaGridSettings.columnTitlePadding,
+    this.defaultColumnFilterPadding = TrinaGridSettings.columnFilterPadding,
+    this.defaultCellPadding = TrinaGridSettings.cellPadding,
+    this.columnTextStyle = const TextStyle(
+      color: Colors.black,
+      decoration: TextDecoration.none,
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+    ),
+    this.columnUnselectedColor = Colors.black38,
+    this.columnActiveColor = Colors.lightBlue,
+    this.cellUnselectedColor = Colors.black38,
+    this.cellActiveColor = Colors.lightBlue,
+    this.cellTextStyle = defaultLightCellTextStyle,
+    this.columnContextIcon = Icons.dehaze,
+    this.columnResizeIcon = Icons.code_sharp,
+    this.columnResizeWidget,
+    this.columnAscendingIcon,
+    this.columnDescendingIcon,
+    this.rowGroupExpandedIcon = Icons.keyboard_arrow_down,
+    this.rowGroupCollapsedIcon = const IconData(
+      0xe355,
+      matchTextDirection: true,
+      fontFamily: 'MaterialIcons',
+    ),
+    this.rowGroupEmptyIcon = Icons.noise_control_off,
+    this.gridBorderRadius = BorderRadius.zero,
+    this.gridPopupBorderRadius = BorderRadius.zero,
+    this.gridPadding = TrinaGridSettings.gridPadding,
+    this.gridBorderWidth = TrinaGridSettings.gridBorderWidth,
+    this.cellVerticalBorderWidth = TrinaGridSettings.cellVerticalBorderWidth,
+    this.cellHorizontalBorderWidth =
+        TrinaGridSettings.cellHorizontalBorderWidth,
+    this.filterHeaderColor,
+    this.filterPopupHeaderColor,
+    this.filterHeaderIconColor,
+  });
+
+  /// Derives the grid style from a Material [ThemeData].
+  ///
+  /// This is opt-in. The default [TrinaGridStyleConfig] and
+  /// [TrinaGridStyleConfig.dark] keep their fixed palettes, so existing grids
+  /// are unaffected.
+  ///
+  /// ```dart
+  /// TrinaGrid(
+  ///   columns: columns,
+  ///   rows: rows,
+  ///   configuration: TrinaGridConfiguration(
+  ///     style: TrinaGridStyleConfig.fromTheme(Theme.of(context)),
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// Override individual values with [copyWith] afterwards.
+  factory TrinaGridStyleConfig.fromTheme(ThemeData theme) {
+    return TrinaGridStyleConfig.fromColorScheme(
+      theme.colorScheme,
+      textTheme: theme.textTheme,
+    );
+  }
+
+  /// Derives the grid style from a Material [ColorScheme].
+  ///
+  /// [TrinaGridStyleConfig.fromTheme] delegates here. Use this directly when
+  /// you have a scheme but no full [ThemeData].
+  ///
+  /// Only colors and text styles are derived. Sizes, paddings, icons and
+  /// border widths keep the values of the default constructor, and the
+  /// nullable opt-in colors ([oddRowColor], [evenRowColor], the `filter*`
+  /// colors) stay null so their existing fallbacks apply.
+  factory TrinaGridStyleConfig.fromColorScheme(
+    ColorScheme scheme, {
+    TextTheme? textTheme,
+  }) {
+    final onSurfaceVariant = scheme.onSurfaceVariant;
+
+    final columnTextStyle = (textTheme?.titleSmall ?? const TextStyle())
+        .copyWith(
+          color: scheme.onSurface,
+          decoration: TextDecoration.none,
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+        );
+
+    final cellTextStyle = (textTheme?.bodyMedium ?? const TextStyle()).copyWith(
+      color: scheme.onSurface,
+      decoration: TextDecoration.none,
+      fontSize: 14,
+    );
+
+    return TrinaGridStyleConfig._(
+      isDarkStyle: scheme.brightness == Brightness.dark,
+      // Surfaces
+      gridBackgroundColor: scheme.surface,
+      rowColor: scheme.surface,
+      cellColorInEditState: scheme.surface,
+      frozenRowColor: scheme.surfaceContainerLow,
+      menuBackgroundColor: scheme.surfaceContainer,
+      cellColorInReadOnlyState: scheme.surfaceContainerHighest,
+      unfocusedSelectionColor: scheme.surfaceContainerHighest,
+      // Selection / activation
+      activatedColor: scheme.primaryContainer,
+      columnCheckedColor: scheme.primaryContainer,
+      cellCheckedColor: scheme.primaryContainer,
+      dragTargetColumnColor: scheme.primaryContainer.withValues(alpha: 0.5),
+      activatedBorderColor: scheme.primary,
+      columnActiveColor: scheme.primary,
+      cellActiveColor: scheme.primary,
+      rowCheckedColor: scheme.primary.withValues(alpha: 0.08),
+      rowHoveredColor: scheme.onSurface.withValues(alpha: 0.08),
+      // Borders
+      borderColor: scheme.outlineVariant,
+      inactivatedBorderColor: scheme.outlineVariant,
+      frozenRowBorderColor: scheme.outlineVariant,
+      gridBorderColor: scheme.outline,
+      // Icons
+      iconColor: onSurfaceVariant,
+      columnUnselectedColor: onSurfaceVariant,
+      cellUnselectedColor: onSurfaceVariant,
+      disabledIconColor: scheme.onSurface.withValues(alpha: 0.38),
+      // Misc
+      cellDirtyColor: scheme.tertiaryContainer,
+      columnTextStyle: columnTextStyle,
+      cellTextStyle: cellTextStyle,
+    );
+  }
+
   /// Enable borderShadow in [TrinaGrid].
   final bool enableGridBorderShadow;
 
@@ -815,6 +1023,7 @@ class TrinaGridStyleConfig {
     bool? enableCellBorderVertical,
     bool? enableCellBorderHorizontal,
     bool? enableRowColorAnimation,
+    bool? enableRowHoverColor,
     Icon? filterIcon,
     TrinaOptional<Widget?>? filterIconWidget,
     Color? gridBackgroundColor,
@@ -827,9 +1036,15 @@ class TrinaGridStyleConfig {
     BorderSide? columnCheckedSide,
     Color? cellCheckedColor,
     BorderSide? cellCheckedSide,
+    Color? rowCheckedColor,
+    Color? rowHoveredColor,
     Color? cellColorInEditState,
     Color? cellColorInReadOnlyState,
     Color? cellReadonlyColor,
+    Color? cellDefaultColor,
+    Color? cellDirtyColor,
+    Color? frozenRowColor,
+    Color? frozenRowBorderColor,
     TrinaOptional<Color?>? cellColorGroupedRow,
     Color? dragTargetColumnColor,
     Color? iconColor,
@@ -870,192 +1085,110 @@ class TrinaGridStyleConfig {
     Color? filterHeaderColor,
     Color? filterHeaderIconColor,
   }) {
-    // Preserve the dark style flag by using the appropriate constructor
-    if (isDarkStyle) {
-      return TrinaGridStyleConfig.dark(
-        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
-        cellVerticalBorderWidth:
-            cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
-        cellHorizontalBorderWidth:
-            cellHorizontalBorderWidth ?? this.cellHorizontalBorderWidth,
-        enableGridBorderShadow:
-            enableGridBorderShadow ?? this.enableGridBorderShadow,
-        enableColumnBorderVertical:
-            enableColumnBorderVertical ?? this.enableColumnBorderVertical,
-        enableColumnBorderHorizontal:
-            enableColumnBorderHorizontal ?? this.enableColumnBorderHorizontal,
-        enableCellBorderVertical:
-            enableCellBorderVertical ?? this.enableCellBorderVertical,
-        enableCellBorderHorizontal:
-            enableCellBorderHorizontal ?? this.enableCellBorderHorizontal,
-        enableRowColorAnimation:
-            enableRowColorAnimation ?? this.enableRowColorAnimation,
-        filterIcon: filterIcon ?? this.filterIcon,
-        filterIconWidget: filterIconWidget == null
-            ? this.filterIconWidget
-            : filterIconWidget.value,
-        gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
-        unfocusedSelectionColor:
-            unfocusedSelectionColor ?? this.unfocusedSelectionColor,
-        rowColor: rowColor ?? this.rowColor,
-        oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
-        evenRowColor: evenRowColor == null
-            ? this.evenRowColor
-            : evenRowColor.value,
-        activatedColor: activatedColor ?? this.activatedColor,
-        columnCheckedColor: columnCheckedColor ?? this.columnCheckedColor,
-        columnCheckedSide: columnCheckedSide ?? this.columnCheckedSide,
-        cellCheckedColor: cellCheckedColor ?? this.cellCheckedColor,
-        cellCheckedSide: cellCheckedSide ?? this.cellCheckedSide,
-        cellColorInEditState: cellColorInEditState ?? this.cellColorInEditState,
-        cellColorInReadOnlyState:
-            cellColorInReadOnlyState ?? this.cellColorInReadOnlyState,
-        cellReadonlyColor: cellReadonlyColor ?? this.cellReadonlyColor,
-        cellColorGroupedRow: cellColorGroupedRow == null
-            ? this.cellColorGroupedRow
-            : cellColorGroupedRow.value,
-        dragTargetColumnColor:
-            dragTargetColumnColor ?? this.dragTargetColumnColor,
-        iconColor: iconColor ?? this.iconColor,
-        disabledIconColor: disabledIconColor ?? this.disabledIconColor,
-        menuBackgroundColor: menuBackgroundColor ?? this.menuBackgroundColor,
-        gridBorderColor: gridBorderColor ?? this.gridBorderColor,
-        borderColor: borderColor ?? this.borderColor,
-        activatedBorderColor: activatedBorderColor ?? this.activatedBorderColor,
-        inactivatedBorderColor:
-            inactivatedBorderColor ?? this.inactivatedBorderColor,
-        iconSize: iconSize ?? this.iconSize,
-        rowHeight: rowHeight ?? this.rowHeight,
-        columnHeight: columnHeight ?? this.columnHeight,
-        columnFilterHeight: columnFilterHeight ?? this.columnFilterHeight,
-        defaultColumnTitlePadding:
-            defaultColumnTitlePadding ?? this.defaultColumnTitlePadding,
-        defaultColumnFilterPadding:
-            defaultColumnFilterPadding ?? this.defaultColumnFilterPadding,
-        defaultCellPadding: defaultCellPadding ?? this.defaultCellPadding,
-        columnTextStyle: columnTextStyle ?? this.columnTextStyle,
-        columnUnselectedColor:
-            columnUnselectedColor ?? this.columnUnselectedColor,
-        columnActiveColor: columnActiveColor ?? this.columnActiveColor,
-        cellUnselectedColor: cellUnselectedColor ?? this.cellUnselectedColor,
-        cellActiveColor: cellActiveColor ?? this.cellActiveColor,
-        cellTextStyle: cellTextStyle ?? this.cellTextStyle,
-        columnContextIcon: columnContextIcon ?? this.columnContextIcon,
-        columnResizeIcon: columnResizeIcon ?? this.columnResizeIcon,
-        columnAscendingIcon: columnAscendingIcon == null
-            ? this.columnAscendingIcon
-            : columnAscendingIcon.value,
-        columnDescendingIcon: columnDescendingIcon == null
-            ? this.columnDescendingIcon
-            : columnDescendingIcon.value,
-        rowGroupExpandedIcon: rowGroupExpandedIcon ?? this.rowGroupExpandedIcon,
-        rowGroupCollapsedIcon:
-            rowGroupCollapsedIcon ?? this.rowGroupCollapsedIcon,
-        rowGroupEmptyIcon: rowGroupEmptyIcon ?? this.rowGroupEmptyIcon,
-        gridBorderRadius: gridBorderRadius ?? this.gridBorderRadius,
-        gridPopupBorderRadius:
-            gridPopupBorderRadius ?? this.gridPopupBorderRadius,
-        gridPadding: gridPadding ?? this.gridPadding,
-        gridBorderWidth: gridBorderWidth ?? this.gridBorderWidth,
-        filterHeaderColor: filterHeaderColor ?? this.filterHeaderColor,
-        filterPopupHeaderColor:
-            filterPopupHeaderColor ?? this.filterPopupHeaderColor,
-        filterHeaderIconColor:
-            filterHeaderIconColor ?? this.filterHeaderIconColor,
-      );
-    } else {
-      return TrinaGridStyleConfig(
-        columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
-        cellVerticalBorderWidth:
-            cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
-        cellHorizontalBorderWidth:
-            cellHorizontalBorderWidth ?? this.cellHorizontalBorderWidth,
-        enableGridBorderShadow:
-            enableGridBorderShadow ?? this.enableGridBorderShadow,
-        enableColumnBorderVertical:
-            enableColumnBorderVertical ?? this.enableColumnBorderVertical,
-        enableColumnBorderHorizontal:
-            enableColumnBorderHorizontal ?? this.enableColumnBorderHorizontal,
-        enableCellBorderVertical:
-            enableCellBorderVertical ?? this.enableCellBorderVertical,
-        enableCellBorderHorizontal:
-            enableCellBorderHorizontal ?? this.enableCellBorderHorizontal,
-        enableRowColorAnimation:
-            enableRowColorAnimation ?? this.enableRowColorAnimation,
-        filterIcon: filterIcon ?? this.filterIcon,
-        filterIconWidget: filterIconWidget == null
-            ? this.filterIconWidget
-            : filterIconWidget.value,
-        gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
-        unfocusedSelectionColor:
-            unfocusedSelectionColor ?? this.unfocusedSelectionColor,
-        rowColor: rowColor ?? this.rowColor,
-        oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
-        evenRowColor: evenRowColor == null
-            ? this.evenRowColor
-            : evenRowColor.value,
-        activatedColor: activatedColor ?? this.activatedColor,
-        columnCheckedColor: columnCheckedColor ?? this.columnCheckedColor,
-        columnCheckedSide: columnCheckedSide ?? this.columnCheckedSide,
-        cellCheckedColor: cellCheckedColor ?? this.cellCheckedColor,
-        cellCheckedSide: cellCheckedSide ?? this.cellCheckedSide,
-        cellColorInEditState: cellColorInEditState ?? this.cellColorInEditState,
-        cellColorInReadOnlyState:
-            cellColorInReadOnlyState ?? this.cellColorInReadOnlyState,
-        cellReadonlyColor: cellReadonlyColor ?? this.cellReadonlyColor,
-        cellColorGroupedRow: cellColorGroupedRow == null
-            ? this.cellColorGroupedRow
-            : cellColorGroupedRow.value,
-        dragTargetColumnColor:
-            dragTargetColumnColor ?? this.dragTargetColumnColor,
-        iconColor: iconColor ?? this.iconColor,
-        disabledIconColor: disabledIconColor ?? this.disabledIconColor,
-        menuBackgroundColor: menuBackgroundColor ?? this.menuBackgroundColor,
-        gridBorderColor: gridBorderColor ?? this.gridBorderColor,
-        borderColor: borderColor ?? this.borderColor,
-        activatedBorderColor: activatedBorderColor ?? this.activatedBorderColor,
-        inactivatedBorderColor:
-            inactivatedBorderColor ?? this.inactivatedBorderColor,
-        iconSize: iconSize ?? this.iconSize,
-        rowHeight: rowHeight ?? this.rowHeight,
-        columnHeight: columnHeight ?? this.columnHeight,
-        columnFilterHeight: columnFilterHeight ?? this.columnFilterHeight,
-        defaultColumnTitlePadding:
-            defaultColumnTitlePadding ?? this.defaultColumnTitlePadding,
-        defaultColumnFilterPadding:
-            defaultColumnFilterPadding ?? this.defaultColumnFilterPadding,
-        defaultCellPadding: defaultCellPadding ?? this.defaultCellPadding,
-        columnTextStyle: columnTextStyle ?? this.columnTextStyle,
-        columnUnselectedColor:
-            columnUnselectedColor ?? this.columnUnselectedColor,
-        columnActiveColor: columnActiveColor ?? this.columnActiveColor,
-        cellUnselectedColor: cellUnselectedColor ?? this.cellUnselectedColor,
-        cellActiveColor: cellActiveColor ?? this.cellActiveColor,
-        cellTextStyle: cellTextStyle ?? this.cellTextStyle,
-        columnContextIcon: columnContextIcon ?? this.columnContextIcon,
-        columnResizeIcon: columnResizeIcon ?? this.columnResizeIcon,
-        columnAscendingIcon: columnAscendingIcon == null
-            ? this.columnAscendingIcon
-            : columnAscendingIcon.value,
-        columnDescendingIcon: columnDescendingIcon == null
-            ? this.columnDescendingIcon
-            : columnDescendingIcon.value,
-        rowGroupExpandedIcon: rowGroupExpandedIcon ?? this.rowGroupExpandedIcon,
-        rowGroupCollapsedIcon:
-            rowGroupCollapsedIcon ?? this.rowGroupCollapsedIcon,
-        rowGroupEmptyIcon: rowGroupEmptyIcon ?? this.rowGroupEmptyIcon,
-        gridBorderRadius: gridBorderRadius ?? this.gridBorderRadius,
-        gridPopupBorderRadius:
-            gridPopupBorderRadius ?? this.gridPopupBorderRadius,
-        gridPadding: gridPadding ?? this.gridPadding,
-        gridBorderWidth: gridBorderWidth ?? this.gridBorderWidth,
-        filterHeaderColor: filterHeaderColor ?? this.filterHeaderColor,
-        filterPopupHeaderColor:
-            filterPopupHeaderColor ?? this.filterPopupHeaderColor,
-        filterHeaderIconColor:
-            filterHeaderIconColor ?? this.filterHeaderIconColor,
-      );
-    }
+    // Delegates to the private constructor so every field is carried over and
+    // [isDarkStyle] is preserved as a plain value. Going through the public
+    // light/dark constructors instead used to drop the fields they do not
+    // accept, and would also collapse a theme-derived style back onto the
+    // fixed palettes.
+    return TrinaGridStyleConfig._(
+      isDarkStyle: isDarkStyle,
+      columnResizeWidget: columnResizeWidget ?? this.columnResizeWidget,
+      cellVerticalBorderWidth:
+          cellVerticalBorderWidth ?? this.cellVerticalBorderWidth,
+      cellHorizontalBorderWidth:
+          cellHorizontalBorderWidth ?? this.cellHorizontalBorderWidth,
+      enableGridBorderShadow:
+          enableGridBorderShadow ?? this.enableGridBorderShadow,
+      enableColumnBorderVertical:
+          enableColumnBorderVertical ?? this.enableColumnBorderVertical,
+      enableColumnBorderHorizontal:
+          enableColumnBorderHorizontal ?? this.enableColumnBorderHorizontal,
+      enableCellBorderVertical:
+          enableCellBorderVertical ?? this.enableCellBorderVertical,
+      enableCellBorderHorizontal:
+          enableCellBorderHorizontal ?? this.enableCellBorderHorizontal,
+      enableRowColorAnimation:
+          enableRowColorAnimation ?? this.enableRowColorAnimation,
+      enableRowHoverColor: enableRowHoverColor ?? this.enableRowHoverColor,
+      filterIcon: filterIcon ?? this.filterIcon,
+      filterIconWidget: filterIconWidget == null
+          ? this.filterIconWidget
+          : filterIconWidget.value,
+      gridBackgroundColor: gridBackgroundColor ?? this.gridBackgroundColor,
+      unfocusedSelectionColor:
+          unfocusedSelectionColor ?? this.unfocusedSelectionColor,
+      rowColor: rowColor ?? this.rowColor,
+      oddRowColor: oddRowColor == null ? this.oddRowColor : oddRowColor.value,
+      evenRowColor: evenRowColor == null
+          ? this.evenRowColor
+          : evenRowColor.value,
+      activatedColor: activatedColor ?? this.activatedColor,
+      columnCheckedColor: columnCheckedColor ?? this.columnCheckedColor,
+      columnCheckedSide: columnCheckedSide ?? this.columnCheckedSide,
+      cellCheckedColor: cellCheckedColor ?? this.cellCheckedColor,
+      cellCheckedSide: cellCheckedSide ?? this.cellCheckedSide,
+      rowCheckedColor: rowCheckedColor ?? this.rowCheckedColor,
+      rowHoveredColor: rowHoveredColor ?? this.rowHoveredColor,
+      cellColorInEditState: cellColorInEditState ?? this.cellColorInEditState,
+      cellColorInReadOnlyState:
+          cellColorInReadOnlyState ?? this.cellColorInReadOnlyState,
+      cellReadonlyColor: cellReadonlyColor ?? this.cellReadonlyColor,
+      cellDefaultColor: cellDefaultColor ?? this.cellDefaultColor,
+      cellDirtyColor: cellDirtyColor ?? this.cellDirtyColor,
+      frozenRowColor: frozenRowColor ?? this.frozenRowColor,
+      frozenRowBorderColor: frozenRowBorderColor ?? this.frozenRowBorderColor,
+      cellColorGroupedRow: cellColorGroupedRow == null
+          ? this.cellColorGroupedRow
+          : cellColorGroupedRow.value,
+      dragTargetColumnColor:
+          dragTargetColumnColor ?? this.dragTargetColumnColor,
+      iconColor: iconColor ?? this.iconColor,
+      disabledIconColor: disabledIconColor ?? this.disabledIconColor,
+      menuBackgroundColor: menuBackgroundColor ?? this.menuBackgroundColor,
+      gridBorderColor: gridBorderColor ?? this.gridBorderColor,
+      borderColor: borderColor ?? this.borderColor,
+      activatedBorderColor: activatedBorderColor ?? this.activatedBorderColor,
+      inactivatedBorderColor:
+          inactivatedBorderColor ?? this.inactivatedBorderColor,
+      iconSize: iconSize ?? this.iconSize,
+      rowHeight: rowHeight ?? this.rowHeight,
+      columnHeight: columnHeight ?? this.columnHeight,
+      columnFilterHeight: columnFilterHeight ?? this.columnFilterHeight,
+      defaultColumnTitlePadding:
+          defaultColumnTitlePadding ?? this.defaultColumnTitlePadding,
+      defaultColumnFilterPadding:
+          defaultColumnFilterPadding ?? this.defaultColumnFilterPadding,
+      defaultCellPadding: defaultCellPadding ?? this.defaultCellPadding,
+      columnTextStyle: columnTextStyle ?? this.columnTextStyle,
+      columnUnselectedColor:
+          columnUnselectedColor ?? this.columnUnselectedColor,
+      columnActiveColor: columnActiveColor ?? this.columnActiveColor,
+      cellUnselectedColor: cellUnselectedColor ?? this.cellUnselectedColor,
+      cellActiveColor: cellActiveColor ?? this.cellActiveColor,
+      cellTextStyle: cellTextStyle ?? this.cellTextStyle,
+      columnContextIcon: columnContextIcon ?? this.columnContextIcon,
+      columnResizeIcon: columnResizeIcon ?? this.columnResizeIcon,
+      columnAscendingIcon: columnAscendingIcon == null
+          ? this.columnAscendingIcon
+          : columnAscendingIcon.value,
+      columnDescendingIcon: columnDescendingIcon == null
+          ? this.columnDescendingIcon
+          : columnDescendingIcon.value,
+      rowGroupExpandedIcon: rowGroupExpandedIcon ?? this.rowGroupExpandedIcon,
+      rowGroupCollapsedIcon:
+          rowGroupCollapsedIcon ?? this.rowGroupCollapsedIcon,
+      rowGroupEmptyIcon: rowGroupEmptyIcon ?? this.rowGroupEmptyIcon,
+      gridBorderRadius: gridBorderRadius ?? this.gridBorderRadius,
+      gridPopupBorderRadius:
+          gridPopupBorderRadius ?? this.gridPopupBorderRadius,
+      gridPadding: gridPadding ?? this.gridPadding,
+      gridBorderWidth: gridBorderWidth ?? this.gridBorderWidth,
+      filterHeaderColor: filterHeaderColor ?? this.filterHeaderColor,
+      filterPopupHeaderColor:
+          filterPopupHeaderColor ?? this.filterPopupHeaderColor,
+      filterHeaderIconColor:
+          filterHeaderIconColor ?? this.filterHeaderIconColor,
+    );
   }
 
   @override

--- a/test/src/theme_integration_test.dart
+++ b/test/src/theme_integration_test.dart
@@ -1,0 +1,353 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trina_grid/trina_grid.dart';
+
+void main() {
+  group('TrinaGridStyleConfig.fromColorScheme', () {
+    test('maps ColorScheme roles onto the grid style', () {
+      final scheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
+      final style = TrinaGridStyleConfig.fromColorScheme(scheme);
+
+      // Surfaces
+      expect(style.gridBackgroundColor, scheme.surface);
+      expect(style.rowColor, scheme.surface);
+      expect(style.cellColorInEditState, scheme.surface);
+      expect(style.frozenRowColor, scheme.surfaceContainerLow);
+      expect(style.menuBackgroundColor, scheme.surfaceContainer);
+      expect(style.cellColorInReadOnlyState, scheme.surfaceContainerHighest);
+      expect(style.unfocusedSelectionColor, scheme.surfaceContainerHighest);
+
+      // Selection / activation
+      expect(style.activatedColor, scheme.primaryContainer);
+      expect(style.columnCheckedColor, scheme.primaryContainer);
+      expect(style.cellCheckedColor, scheme.primaryContainer);
+      expect(style.activatedBorderColor, scheme.primary);
+      expect(style.columnActiveColor, scheme.primary);
+      expect(style.cellActiveColor, scheme.primary);
+
+      // Borders
+      expect(style.borderColor, scheme.outlineVariant);
+      expect(style.inactivatedBorderColor, scheme.outlineVariant);
+      expect(style.frozenRowBorderColor, scheme.outlineVariant);
+      expect(style.gridBorderColor, scheme.outline);
+
+      // Icons
+      expect(style.iconColor, scheme.onSurfaceVariant);
+      expect(style.columnUnselectedColor, scheme.onSurfaceVariant);
+      expect(style.cellUnselectedColor, scheme.onSurfaceVariant);
+
+      // Misc
+      expect(style.cellDirtyColor, scheme.tertiaryContainer);
+      expect(style.columnTextStyle.color, scheme.onSurface);
+      expect(style.cellTextStyle.color, scheme.onSurface);
+    });
+
+    test('derives isDarkStyle from the scheme brightness', () {
+      final light = TrinaGridStyleConfig.fromColorScheme(
+        ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+      );
+      final dark = TrinaGridStyleConfig.fromColorScheme(
+        ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+      );
+
+      expect(light.isDarkStyle, false);
+      expect(dark.isDarkStyle, true);
+    });
+
+    test('leaves opt-in nullable colors unset so fallbacks still apply', () {
+      final style = TrinaGridStyleConfig.fromColorScheme(
+        ColorScheme.fromSeed(seedColor: Colors.teal),
+      );
+
+      expect(style.oddRowColor, isNull);
+      expect(style.evenRowColor, isNull);
+      expect(style.filterHeaderColor, isNull);
+      expect(style.filterPopupHeaderColor, isNull);
+      expect(style.filterHeaderIconColor, isNull);
+      expect(style.cellReadonlyColor, isNull);
+      expect(style.cellDefaultColor, isNull);
+      expect(style.cellColorGroupedRow, isNull);
+    });
+
+    test('keeps the non-color defaults of the default constructor', () {
+      const defaults = TrinaGridStyleConfig();
+      final style = TrinaGridStyleConfig.fromColorScheme(
+        ColorScheme.fromSeed(seedColor: Colors.teal),
+      );
+
+      expect(style.rowHeight, defaults.rowHeight);
+      expect(style.columnHeight, defaults.columnHeight);
+      expect(style.columnFilterHeight, defaults.columnFilterHeight);
+      expect(style.iconSize, defaults.iconSize);
+      expect(style.defaultCellPadding, defaults.defaultCellPadding);
+      expect(
+        style.defaultColumnTitlePadding,
+        defaults.defaultColumnTitlePadding,
+      );
+      expect(style.gridBorderWidth, defaults.gridBorderWidth);
+      expect(style.cellVerticalBorderWidth, defaults.cellVerticalBorderWidth);
+      expect(
+        style.cellHorizontalBorderWidth,
+        defaults.cellHorizontalBorderWidth,
+      );
+      expect(style.columnContextIcon, defaults.columnContextIcon);
+      expect(style.rowGroupExpandedIcon, defaults.rowGroupExpandedIcon);
+    });
+
+    test('fromTheme matches fromColorScheme for the same scheme', () {
+      final theme = ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+      );
+      final viaTheme = TrinaGridStyleConfig.fromTheme(theme);
+      final viaScheme = TrinaGridStyleConfig.fromColorScheme(theme.colorScheme);
+
+      expect(viaTheme.gridBackgroundColor, viaScheme.gridBackgroundColor);
+      expect(viaTheme.activatedColor, viaScheme.activatedColor);
+      expect(viaTheme.borderColor, viaScheme.borderColor);
+      expect(viaTheme.isDarkStyle, viaScheme.isDarkStyle);
+    });
+  });
+
+  group('additive guarantee', () {
+    test('the const light defaults are unchanged', () {
+      const style = TrinaGridStyleConfig();
+
+      expect(style.gridBackgroundColor, Colors.white);
+      expect(style.rowColor, Colors.white);
+      expect(style.activatedColor, const Color(0xFFDCF5FF));
+      expect(style.columnCheckedColor, const Color(0xFFDCF5FF));
+      expect(style.cellCheckedColor, const Color(0xFFDCF5FF));
+      expect(style.rowCheckedColor, const Color(0x11757575));
+      expect(style.rowHoveredColor, const Color(0xFFB1B3B7));
+      expect(style.cellColorInEditState, Colors.white);
+      expect(style.cellColorInReadOnlyState, const Color(0xFFDBDBDC));
+      expect(style.cellDirtyColor, const Color(0xFFFFF9C4));
+      expect(style.frozenRowColor, const Color(0xFFF8F8F8));
+      expect(style.frozenRowBorderColor, const Color(0xFFE0E0E0));
+      expect(
+        style.dragTargetColumnColor,
+        const Color.fromARGB(129, 220, 245, 255),
+      );
+      expect(style.iconColor, Colors.black38);
+      expect(style.disabledIconColor, Colors.black12);
+      expect(style.menuBackgroundColor, Colors.white);
+      expect(style.gridBorderColor, const Color(0xFFA1A5AE));
+      expect(style.borderColor, const Color(0xFFDDE2EB));
+      expect(style.activatedBorderColor, Colors.lightBlue);
+      expect(style.inactivatedBorderColor, const Color(0xFFC4C7CC));
+      expect(style.columnUnselectedColor, Colors.black38);
+      expect(style.columnActiveColor, Colors.lightBlue);
+      expect(style.cellUnselectedColor, Colors.black38);
+      expect(style.cellActiveColor, Colors.lightBlue);
+      expect(style.isDarkStyle, false);
+    });
+
+    test('the const dark defaults are unchanged', () {
+      const style = TrinaGridStyleConfig.dark();
+
+      expect(style.gridBackgroundColor, const Color(0xFF111111));
+      expect(style.rowColor, const Color(0xFF111111));
+      expect(style.unfocusedSelectionColor, const Color(0xFF4A4A4A));
+      expect(style.activatedColor, const Color(0xFF313131));
+      expect(style.columnCheckedColor, const Color(0xFF313131));
+      expect(style.cellCheckedColor, const Color(0xFF313131));
+      expect(style.rowCheckedColor, const Color(0x11202020));
+      expect(style.rowHoveredColor, const Color(0xFF3D3D3D));
+      expect(style.cellColorInEditState, const Color(0xFF666666));
+      expect(style.cellColorInReadOnlyState, const Color(0xFF222222));
+      expect(style.cellDirtyColor, const Color(0xFF5D4037));
+      expect(style.frozenRowColor, const Color(0xFF222222));
+      expect(style.frozenRowBorderColor, const Color(0xFF666666));
+      expect(style.dragTargetColumnColor, const Color(0xFF313131));
+      expect(style.iconColor, Colors.white38);
+      expect(style.disabledIconColor, Colors.white12);
+      expect(style.menuBackgroundColor, const Color(0xFF414141));
+      expect(style.gridBorderColor, const Color(0xFF666666));
+      expect(style.borderColor, const Color(0xFF222222));
+      expect(style.activatedBorderColor, const Color(0xFFFFFFFF));
+      expect(style.inactivatedBorderColor, const Color(0xFF666666));
+      expect(style.isDarkStyle, true);
+    });
+
+    test('default configurations still compare equal', () {
+      expect(const TrinaGridStyleConfig(), const TrinaGridStyleConfig());
+      expect(
+        const TrinaGridStyleConfig.dark(),
+        const TrinaGridStyleConfig.dark(),
+      );
+      expect(
+        const TrinaGridConfiguration(),
+        isNot(const TrinaGridConfiguration.dark()),
+      );
+    });
+  });
+
+  group('copyWith', () {
+    test('preserves theme-derived values when overriding one field', () {
+      final scheme = ColorScheme.fromSeed(
+        seedColor: Colors.deepPurple,
+        brightness: Brightness.dark,
+      );
+      final themed = TrinaGridStyleConfig.fromColorScheme(scheme);
+      final copied = themed.copyWith(gridBackgroundColor: Colors.black);
+
+      expect(copied.gridBackgroundColor, Colors.black);
+      // Everything else must survive rather than fall back to the fixed
+      // dark palette.
+      expect(copied.isDarkStyle, true);
+      expect(copied.rowColor, scheme.surface);
+      expect(copied.activatedColor, scheme.primaryContainer);
+      expect(copied.borderColor, scheme.outlineVariant);
+      expect(copied.gridBorderColor, scheme.outline);
+      expect(copied.iconColor, scheme.onSurfaceVariant);
+      expect(copied.cellDirtyColor, scheme.tertiaryContainer);
+      expect(copied.menuBackgroundColor, scheme.surfaceContainer);
+      expect(copied.cellTextStyle.color, scheme.onSurface);
+    });
+
+    test('carries over fields the old implementation dropped', () {
+      const style = TrinaGridStyleConfig(
+        enableRowHoverColor: true,
+        rowCheckedColor: Color(0xFF123456),
+        rowHoveredColor: Color(0xFF654321),
+        cellDefaultColor: Color(0xFF111222),
+        cellDirtyColor: Color(0xFF333444),
+        frozenRowColor: Color(0xFF555666),
+        frozenRowBorderColor: Color(0xFF777888),
+      );
+
+      final copied = style.copyWith(rowHeight: 60);
+
+      expect(copied.rowHeight, 60);
+      expect(copied.enableRowHoverColor, true);
+      expect(copied.rowCheckedColor, const Color(0xFF123456));
+      expect(copied.rowHoveredColor, const Color(0xFF654321));
+      expect(copied.cellDefaultColor, const Color(0xFF111222));
+      expect(copied.cellDirtyColor, const Color(0xFF333444));
+      expect(copied.frozenRowColor, const Color(0xFF555666));
+      expect(copied.frozenRowBorderColor, const Color(0xFF777888));
+    });
+
+    test('preserves isDarkStyle for both fixed palettes', () {
+      expect(
+        const TrinaGridStyleConfig().copyWith(rowHeight: 50).isDarkStyle,
+        false,
+      );
+      expect(
+        const TrinaGridStyleConfig.dark().copyWith(rowHeight: 50).isDarkStyle,
+        true,
+      );
+    });
+  });
+
+  group('TrinaGridConfiguration.fromTheme', () {
+    testWidgets('derives the style from the ambient Material theme', (
+      tester,
+    ) async {
+      final theme = ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+      );
+      late TrinaGridConfiguration configuration;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Builder(
+            builder: (context) {
+              configuration = TrinaGridConfiguration.fromTheme(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        configuration.style.gridBackgroundColor,
+        theme.colorScheme.surface,
+      );
+      expect(
+        configuration.style.activatedColor,
+        theme.colorScheme.primaryContainer,
+      );
+      expect(configuration.style.isDarkStyle, false);
+    });
+
+    testWidgets('follows a dark ambient theme', (tester) async {
+      final theme = ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.green,
+          brightness: Brightness.dark,
+        ),
+      );
+      late TrinaGridConfiguration configuration;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Builder(
+            builder: (context) {
+              configuration = TrinaGridConfiguration.fromTheme(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(configuration.style.isDarkStyle, true);
+      expect(
+        configuration.style.gridBackgroundColor,
+        theme.colorScheme.surface,
+      );
+    });
+
+    testWidgets('renders a grid using the themed surface color', (
+      tester,
+    ) async {
+      final theme = ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+      );
+
+      final columns = [
+        TrinaColumn(title: 'name', field: 'name', type: TrinaColumnType.text()),
+      ];
+      final rows = [
+        TrinaRow(cells: {'name': TrinaCell(value: 'a')}),
+        TrinaRow(cells: {'name': TrinaCell(value: 'b')}),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TrinaGrid(
+                columns: columns,
+                rows: rows,
+                configuration: TrinaGridConfiguration.fromTheme(context),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TrinaGrid), findsOneWidget);
+      expect(find.text('a'), findsOneWidget);
+
+      final decorations = tester
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .map((e) => e.decoration)
+          .whereType<BoxDecoration>()
+          .toList();
+
+      expect(
+        decorations.any((d) => d.color == theme.colorScheme.surface),
+        isTrue,
+        reason: 'expected at least one surface-colored box from the theme',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #336

## Problem

`TrinaGridStyleConfig` bakes in about 30 color literals in its light constructor and a fully duplicated set in `.dark()`. The root cause is structural rather than an oversight: **both constructors are `const`, so a default can never be `Theme.of(context)`-derived.**

The result is that the grid is inconsistent with itself. The leaf widgets already follow the app theme (`trina_dropdown_menu.dart`, `trina_time_picker.dart`, `trina_date_picker.dart` all read `Theme.of(context).colorScheme`), while the rows, headers, borders and selection around them do not. Drop a grid into a `deepPurple`-seeded dark app and you get a white grid with light-blue selection and purple dropdowns.

## Approach

The issue asks to "remove hardcoded colors". Doing that literally would repaint every existing user's grid, which is a breaking visual change for a cosmetic gain. This PR is **purely additive** instead: the const palettes stay byte-identical and callers opt in.

```dart
TrinaGrid(
  columns: columns,
  rows: rows,
  configuration: TrinaGridConfiguration.fromTheme(context),
)
```

Brightness comes along for free, since `ColorScheme.brightness` decides `isDarkStyle`.

There was already precedent for this shape in the repo: `EnsureShadTheme` reads `Theme.of(context).brightness` at build time as a fallback that never overrides an explicit value.

## New API

- `TrinaGridStyleConfig.fromColorScheme(scheme, {textTheme})` - the real mapping, testable without a `ThemeData`
- `TrinaGridStyleConfig.fromTheme(theme)` - delegates, passing `theme.textTheme` so text styles inherit the app font
- `TrinaGridConfiguration.fromTheme(context)` - one-liner; chain `copyWith` for the non-style options
- A private full constructor, so a factory can set `isDarkStyle` at runtime

Only colors and text styles are derived. Sizes, paddings, icons and border widths keep their current defaults, and the opt-in nullable colors (`oddRowColor`, `evenRowColor`, the `filter*` colors) stay null so their existing fallbacks still apply. The full role mapping table is in `doc/features/themes.md`.

## Two pre-existing bugs found along the way

**1. `copyWith` silently reset four fields.** Neither branch passed `rowCheckedColor`, `rowHoveredColor`, `enableRowHoverColor` or `cellDefaultColor`, because it rebuilt the style through the public light/dark constructors, which do not accept them. So this quietly reverted the hover color:

```dart
style.copyWith(rowHeight: 50) // rowHoveredColor silently back to default
```

This also would have wiped theme-derived values, so it had to be fixed for the feature to work at all. Both duplicated 60-field branches now delegate to the single private constructor, which removes about 120 lines of duplication. `cellDirtyColor`, `frozenRowColor` and `frozenRowBorderColor` became settable through `copyWith` in the process.

**2. The hidden-columns popup discarded the caller's style.** It rebuilt from a fresh `const TrinaGridConfiguration.dark()` / `()` rather than inheriting the live configuration, so any custom style was dropped, not just theme-derived ones.

## Docs and demo

- New `doc/features/themes.md`. `doc/index.md` already linked to this path and the file did not exist, so this fills a broken link.
- A Material Theme Integration section in `doc/getting-started/configuration.md`, plus 11 deprecated `withOpacity` calls updated to `withValues(alpha:)`.
- A demo screen with seed color and brightness pickers, so the whole grid recolors live.

## Known gap

Some colors are not reachable through `TrinaGridStyleConfig` at all and stay fixed even under `fromTheme`: the green and red sort icons, the blue column-drag indicator, the resize divider, some popup chrome, and the default checkbox colors. Each needs its own configuration field first, which is a separate change. This is documented honestly in the themes doc rather than left as a surprise.

## Verification

`dart analyze` clean across package and demo. Full suite green: **1657 passing**, including 14 new tests covering the role mapping, brightness derivation, that `copyWith` preserves theme-derived values, and regression guards asserting both const palettes are unchanged.
